### PR TITLE
add support to configure tornado HTTPServer arguments via config file

### DIFF
--- a/centrifuge/node.py
+++ b/centrifuge/node.py
@@ -220,9 +220,17 @@ def main():
 
     handlers = create_application_handlers(sockjs_settings)
 
+    # custom settings to configure the tornado HTTPServer
+    tornado_settings = custom_settings.get("tornado_settings", {})
+    logger.debug("tornado_settings: %s", tornado_settings)
+    if 'io_loop' in tornado_settings:
+        stop_running(
+            "The io_loop in tornado_settings is not supported for now."
+            )
+
     try:
         app = Application(handlers=handlers, **settings)
-        server = tornado.httpserver.HTTPServer(app)
+        server = tornado.httpserver.HTTPServer(app, **tornado_settings)
         server.listen(options.port, address=options.address)
     except Exception as e:
         return stop_running(str(e))

--- a/deploy/centrifuge.nginx.conf
+++ b/deploy/centrifuge.nginx.conf
@@ -74,6 +74,8 @@ server {
 
     location /socket {
         proxy_buffering off;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Scheme $scheme;
         proxy_pass http://centrifuge;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
@@ -82,6 +84,8 @@ server {
 
     location /connection/websocket {
         proxy_buffering off;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Scheme $scheme;
         proxy_pass http://centrifuge;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
@@ -90,6 +94,8 @@ server {
 
     location /connection {
         proxy_buffering off;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Scheme $scheme;
         proxy_pass http://centrifuge;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/docs/content/configuration.rst
+++ b/docs/content/configuration.rst
@@ -45,6 +45,19 @@ configuration file. Example:
 
 Here I set custom ``sockjs_url`` option, list of all available options can be found in sockjs-tornado source code: `show on Github <https://github.com/mrjoes/sockjs-tornado/blob/master/sockjs/tornado/router.py#L14>`_
 
+Centrifuge runs a `tornado HTTPServer <http://www.tornadoweb.org/en/stable/httpserver.html#http-server>`_ under the hood. If you want to configure it you can do so via the ``tornado_settings``. Please note that the ``io_loop`` argument is not supported for now. Example:
+
+.. code-block:: javascript
+
+    {
+        "password": "admin",
+        "cookie_secret": "secret",
+        "api_secret": "secret",
+        "tornado_settings": {
+            "xheaders": true
+        }
+    }
+
 Centrifuge also allows to collect and export various metrics into Graphite.
 You can configure metric collecting and exporting behaviour using ``metrics``
 object in configuration JSON.

--- a/docs/content/deploy.rst
+++ b/docs/content/deploy.rst
@@ -77,6 +77,8 @@ Here is an example Nginx configuration to deploy Centrifuge.
             }
             location /socket {
                 proxy_buffering off;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Scheme $scheme;
                 proxy_pass http://centrifuge;
                 proxy_http_version 1.1;
                 proxy_set_header Upgrade $http_upgrade;
@@ -84,6 +86,8 @@ Here is an example Nginx configuration to deploy Centrifuge.
             }
             location /connection/websocket {
                 proxy_buffering off;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Scheme $scheme;
                 proxy_pass http://centrifuge;
                 proxy_http_version 1.1;
                 proxy_set_header Upgrade $http_upgrade;
@@ -91,6 +95,8 @@ Here is an example Nginx configuration to deploy Centrifuge.
             }
             location /connection {
                 proxy_buffering off;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Scheme $scheme;
                 proxy_pass http://centrifuge;
                 proxy_http_version 1.1;
                 proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
experimented a bit with the io_loop argument but it's just better to leave it unsupported for now :)