### PR TITLE
remove history_drop_inactive option

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -58,9 +58,4 @@ type ChannelOptions struct {
 	// client. This option uses publications from history and must be used
 	// with reasonable HistorySize and HistoryLifetime configuration.
 	HistoryRecover bool `mapstructure:"history_recover" json:"history_recover"`
-
-	// HistoryDropInactive enables an optimization where history is
-	// only saved for channels that have at least one active subscriber.
-	// This can give a huge memory saving in suitable scenarios.
-	HistoryDropInactive bool `mapstructure:"history_drop_inactive" json:"history_drop_inactive"`
 }


### PR DESCRIPTION
This option makes Centrifugo be very non-deterministic in terms
of message log and blocks implementing custom engines. As we don't
know any production system that uses this feature I suppose we could
remove it for now and see what happens.