### PR TITLE
Add Node.Send() method

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -21,6 +21,8 @@ type BrokerEventHandler interface {
 	HandleLeave(ch string, leave *Leave) error
 	// Control must register callback func to handle Control data received.
 	HandleControl([]byte) error
+	// Send must register callback func to handle Send received.
+	HandleSend(uid string, data Raw) error
 }
 
 // HistoryFilter allows to filter history according to fields set.
@@ -84,6 +86,10 @@ type Broker interface {
 	// be used for admin needs to better understand state of system. So it's not
 	// a big problem if another Broker implementation won't support this method.
 	Channels() ([]string, error)
+	
+	// Send allows to send Raw to client by uid. Raw should
+	// be delivered to client on any of Centrifuge node.
+	Send(uid string, data Raw) error
 }
 
 // HistoryManager is responsible for dealing with channel history management.

--- a/engine_memory.go
+++ b/engine_memory.go
@@ -119,6 +119,12 @@ func (e *MemoryEngine) Channels() ([]string, error) {
 	return e.node.Hub().Channels(), nil
 }
 
+// Send calls node ClientMsg method to handle message.
+// We don't have any PUB/SUB here as Memory Engine is single node only.
+func (e *MemoryEngine) Send(uid string, data Raw) error {
+	return e.eventHandler.HandleSend(uid, data)
+}
+
 type presenceHub struct {
 	sync.RWMutex
 	presence map[string]map[string]*ClientInfo

--- a/hub.go
+++ b/hub.go
@@ -476,3 +476,8 @@ func (h *Hub) NumSubscribers(ch string) int {
 	}
 	return len(conns)
 }
+
+// GetClient returns Client by ID
+func (h *Hub) GetClient(uid string) (*Client, bool) {
+	return h.conns[uid]
+}

--- a/hub.go
+++ b/hub.go
@@ -428,6 +428,19 @@ func (h *Hub) broadcastLeave(channel string, leave *proto.Leave) error {
 	return nil
 }
 
+// send sends message to client by uid.
+func (h *Hub) send(uid string, data Raw) error {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	c, ok := h.conns[uid]
+	if !ok {
+		return nil
+	}
+
+	return c.Send(data)
+}
+
 // NumClients returns total number of client connections.
 func (h *Hub) NumClients() int {
 	h.mu.RLock()
@@ -475,9 +488,4 @@ func (h *Hub) NumSubscribers(ch string) int {
 		return 0
 	}
 	return len(conns)
-}
-
-// GetClient returns Client by ID
-func (h *Hub) GetClient(uid string) (*Client, bool) {
-	return h.conns[uid]
 }

--- a/node.go
+++ b/node.go
@@ -452,6 +452,13 @@ func (n *Node) handleLeave(ch string, leave *proto.Leave) error {
 	return n.hub.broadcastLeave(ch, leave)
 }
 
+// handleSend handles messages sent to client by uid and
+// coming from engine. The goal of method is to deliver this message
+// to client if it exist on this node.
+func (n *Node) handleSend(uid string, data Raw) error {
+	return n.hub.send(uid, data)
+}
+
 func (n *Node) publish(ch string, data []byte, info *ClientInfo, opts ...PublishOption) error {
 	chOpts, ok := n.ChannelOpts(ch)
 	if !ok {
@@ -494,6 +501,16 @@ func (n *Node) publish(ch string, data []byte, info *ClientInfo, opts ...Publish
 // will receive it and will send it to all clients on node subscribed on channel.
 func (n *Node) Publish(ch string, data []byte, opts ...PublishOption) error {
 	return n.publish(ch, data, nil, opts...)
+}
+
+func (n *Node) send(uid string, data []byte) error {
+	return n.broker.Send(uid, data)
+}
+
+// Send sends data to client by uid. All running nodes
+// will receive it and will try find client on node to send data.
+func (n *Node) Send(uid string, data []byte) error {
+	return n.send(uid, data)
 }
 
 var (
@@ -984,4 +1001,9 @@ func (h *brokerEventHandler) HandleLeave(ch string, leave *Leave) error {
 // HandleControl ...
 func (h *brokerEventHandler) HandleControl(data []byte) error {
 	return h.node.handleControl(data)
+}
+
+// HandleSend ...
+func (h *brokerEventHandler) HandleSend(uid string, data Raw) error {
+	return h.node.handleSend(uid, data)
 }


### PR DESCRIPTION
The method is required to send personalized messages to channel subscribers when certain channel events occur.
For example:
```go

	node, _ := centrifuge.New(cfg)
	node.On().ClientConnected(func(ctx context.Context, client *centrifuge.Client) {
		client.On().Message(func(e centrifuge.MessageEvent) centrifuge.MessageReply {

			ci, _ := node.Presence("channel")
			for uid := range ci {
				node.Send(uid, []byte(uid))
			}

			return centrifuge.MessageReply{}
		})
	})

```