### PR TITLE
Options to disable presence and history for client protocol requests

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -42,6 +42,10 @@ type ChannelOptions struct {
 	// Presence is a structure with clients currently subscribed on channel.
 	Presence bool `json:"presence"`
 
+	// PresenceDisableForClient prevents presence to be asked by clients.
+	// In this case it's available only over server-side presence call.
+	PresenceDisableForClient bool `mapstructure:"presence_disable_for_client" json:"presence_disable_for_client"`
+
 	// HistorySize determines max amount of history messages for channel,
 	// 0 means no history for channel. Centrifugo history has auxiliary
 	// role – it can not replace your backend persistent storage.
@@ -58,4 +62,10 @@ type ChannelOptions struct {
 	// client. This option uses publications from history and must be used
 	// with reasonable HistorySize and HistoryLifetime configuration.
 	HistoryRecover bool `mapstructure:"history_recover" json:"history_recover"`
+
+	// HistoryDisableForClient prevents history to be asked by clients.
+	// In this case it's available only over server-side history call.
+	// History recover mechanism if enabled will continue to work for
+	// clients anyway.
+	HistoryDisableForClient bool `mapstructure:"history_disable_for_client" json:"history_disable_for_client"`
 }

--- a/client.go
+++ b/client.go
@@ -2067,7 +2067,7 @@ func (c *Client) presenceCmd(cmd *proto.PresenceRequest) (*proto.PresenceRespons
 		return resp, nil
 	}
 
-	if !chOpts.Presence {
+	if !chOpts.Presence || chOpts.PresenceDisableForClient {
 		resp.Error = ErrorNotAvailable
 		return resp, nil
 	}
@@ -2117,7 +2117,7 @@ func (c *Client) presenceStatsCmd(cmd *proto.PresenceStatsRequest) (*proto.Prese
 		return resp, nil
 	}
 
-	if !chOpts.Presence {
+	if !chOpts.Presence || chOpts.PresenceDisableForClient {
 		resp.Error = ErrorNotAvailable
 		return resp, nil
 	}
@@ -2167,7 +2167,7 @@ func (c *Client) historyCmd(cmd *proto.HistoryRequest) (*proto.HistoryResponse, 
 		return resp, nil
 	}
 
-	if chOpts.HistorySize <= 0 || chOpts.HistoryLifetime <= 0 {
+	if (chOpts.HistorySize <= 0 || chOpts.HistoryLifetime <= 0) || chOpts.HistoryDisableForClient {
 		resp.Error = ErrorNotAvailable
 		return resp, nil
 	}


### PR DESCRIPTION
Adds two new channel options: `PresenceDisableForClient` and `HistoryDisableForClient`. When on presence and history can only be asked on server side via corresponding `Node` methods. Clients will receive `ErrNotAvailable` error.