### PR TITLE
Introduce distinction between protocol type and payload encoding used

### DIFF
--- a/_examples/chat_json/main.go
+++ b/_examples/chat_json/main.go
@@ -140,7 +140,7 @@ func main() {
 		})
 
 		transport := client.Transport()
-		log.Printf("user %s connected via %s with encoding: %s", client.UserID(), transport.Name(), transport.Encoding())
+		log.Printf("user %s connected via %s with protocol: %s", client.UserID(), transport.Name(), transport.Protocol())
 
 		// Connect handler should not block, so start separate goroutine to
 		// periodically send messages to client.

--- a/_examples/chat_protobuf/main.go
+++ b/_examples/chat_protobuf/main.go
@@ -102,7 +102,7 @@ func main() {
 		})
 
 		transport := client.Transport()
-		log.Printf("user %s connected via %s with encoding: %s", client.UserID(), transport.Name(), transport.Encoding())
+		log.Printf("user %s connected via %s with protocol: %s", client.UserID(), transport.Name(), transport.Protocol())
 
 		go func() {
 			err := client.Send([]byte("hello"))

--- a/_examples/custom_broker/main.go
+++ b/_examples/custom_broker/main.go
@@ -95,7 +95,7 @@ func main() {
 		})
 
 		transport := client.Transport()
-		log.Printf("user %s connected via %s with encoding: %s", client.UserID(), transport.Name(), transport.Encoding())
+		log.Printf("user %s connected via %s with protocol: %s", client.UserID(), transport.Name(), transport.Protocol())
 	})
 
 	broker, err := natsbroker.New(node, natsbroker.Config{

--- a/_examples/redis_engine/main.go
+++ b/_examples/redis_engine/main.go
@@ -93,7 +93,7 @@ func main() {
 		})
 
 		transport := client.Transport()
-		log.Printf("user %s connected via %s with encoding: %s", client.UserID(), transport.Name(), transport.Encoding())
+		log.Printf("user %s connected via %s with protocol: %s", client.UserID(), transport.Name(), transport.Protocol())
 	})
 
 	engine, err := centrifuge.NewRedisEngine(node, centrifuge.RedisEngineConfig{

--- a/client.go
+++ b/client.go
@@ -371,7 +371,7 @@ func (c *Client) Send(data Raw) error {
 		Data: data,
 	}
 
-	pushEncoder := proto.GetPushEncoder(c.transport.Encoding())
+	pushEncoder := proto.GetPushEncoder(c.transport.Protocol())
 	data, err := pushEncoder.EncodeMessage(p)
 	if err != nil {
 		return err
@@ -383,7 +383,7 @@ func (c *Client) Send(data Raw) error {
 
 	reply := newPreparedReply(&proto.Reply{
 		Result: result,
-	}, c.transport.Encoding())
+	}, c.transport.Protocol())
 
 	return c.transportSend(reply)
 }
@@ -405,7 +405,7 @@ func (c *Client) Unsubscribe(ch string, resubscribe bool) error {
 }
 
 func (c *Client) sendUnsub(ch string, resubscribe bool) error {
-	pushEncoder := proto.GetPushEncoder(c.transport.Encoding())
+	pushEncoder := proto.GetPushEncoder(c.transport.Protocol())
 
 	data, err := pushEncoder.EncodeUnsub(&proto.Unsub{Resubscribe: resubscribe})
 	if err != nil {
@@ -418,7 +418,7 @@ func (c *Client) sendUnsub(ch string, resubscribe bool) error {
 
 	reply := newPreparedReply(&proto.Reply{
 		Result: result,
-	}, c.transport.Encoding())
+	}, c.transport.Protocol())
 
 	c.transportSend(reply)
 
@@ -541,7 +541,7 @@ func (c *Client) handleRawData(data []byte) bool {
 		return false
 	}
 
-	enc := c.transport.Encoding()
+	enc := c.transport.Protocol()
 
 	encoder := proto.GetReplyEncoder(enc)
 	decoder := proto.GetCommandDecoder(enc, data)
@@ -750,7 +750,7 @@ func (c *Client) expire() {
 }
 
 func (c *Client) handleConnect(params proto.Raw, rw *replyWriter) *Disconnect {
-	cmd, err := proto.GetParamsDecoder(c.transport.Encoding()).DecodeConnect(params)
+	cmd, err := proto.GetParamsDecoder(c.transport.Protocol()).DecodeConnect(params)
 	if err != nil {
 		c.node.logger.log(newLogEntry(LogLevelInfo, "error decoding connect", map[string]interface{}{"error": err.Error()}))
 		return DisconnectBadRequest
@@ -765,7 +765,7 @@ func (c *Client) handleConnect(params proto.Raw, rw *replyWriter) *Disconnect {
 	}
 	var replyRes []byte
 	if resp.Result != nil {
-		replyRes, err = proto.GetResultEncoder(c.transport.Encoding()).EncodeConnectResult(resp.Result)
+		replyRes, err = proto.GetResultEncoder(c.transport.Protocol()).EncodeConnectResult(resp.Result)
 		if err != nil {
 			c.node.logger.log(newLogEntry(LogLevelError, "error encoding connect", map[string]interface{}{"error": err.Error()}))
 			return DisconnectServerError
@@ -782,7 +782,7 @@ func (c *Client) handleConnect(params proto.Raw, rw *replyWriter) *Disconnect {
 }
 
 func (c *Client) handleRefresh(params proto.Raw, rw *replyWriter) *Disconnect {
-	cmd, err := proto.GetParamsDecoder(c.transport.Encoding()).DecodeRefresh(params)
+	cmd, err := proto.GetParamsDecoder(c.transport.Protocol()).DecodeRefresh(params)
 	if err != nil {
 		c.node.logger.log(newLogEntry(LogLevelInfo, "error decoding refresh", map[string]interface{}{"error": err.Error()}))
 		return DisconnectBadRequest
@@ -797,7 +797,7 @@ func (c *Client) handleRefresh(params proto.Raw, rw *replyWriter) *Disconnect {
 	}
 	var replyRes []byte
 	if resp.Result != nil {
-		replyRes, err = proto.GetResultEncoder(c.transport.Encoding()).EncodeRefreshResult(resp.Result)
+		replyRes, err = proto.GetResultEncoder(c.transport.Protocol()).EncodeRefreshResult(resp.Result)
 		if err != nil {
 			c.node.logger.log(newLogEntry(LogLevelError, "error encoding refresh", map[string]interface{}{"error": err.Error()}))
 			return DisconnectServerError
@@ -808,7 +808,7 @@ func (c *Client) handleRefresh(params proto.Raw, rw *replyWriter) *Disconnect {
 }
 
 func (c *Client) handleSubscribe(params proto.Raw, rw *replyWriter) *Disconnect {
-	cmd, err := proto.GetParamsDecoder(c.transport.Encoding()).DecodeSubscribe(params)
+	cmd, err := proto.GetParamsDecoder(c.transport.Protocol()).DecodeSubscribe(params)
 	if err != nil {
 		c.node.logger.log(newLogEntry(LogLevelInfo, "error decoding subscribe", map[string]interface{}{"error": err.Error()}))
 		return DisconnectBadRequest
@@ -817,7 +817,7 @@ func (c *Client) handleSubscribe(params proto.Raw, rw *replyWriter) *Disconnect 
 }
 
 func (c *Client) handleSubRefresh(params proto.Raw, rw *replyWriter) *Disconnect {
-	cmd, err := proto.GetParamsDecoder(c.transport.Encoding()).DecodeSubRefresh(params)
+	cmd, err := proto.GetParamsDecoder(c.transport.Protocol()).DecodeSubRefresh(params)
 	if err != nil {
 		c.node.logger.log(newLogEntry(LogLevelInfo, "error decoding sub refresh", map[string]interface{}{"error": err.Error()}))
 		return DisconnectBadRequest
@@ -832,7 +832,7 @@ func (c *Client) handleSubRefresh(params proto.Raw, rw *replyWriter) *Disconnect
 	}
 	var replyRes []byte
 	if resp.Result != nil {
-		replyRes, err = proto.GetResultEncoder(c.transport.Encoding()).EncodeSubRefreshResult(resp.Result)
+		replyRes, err = proto.GetResultEncoder(c.transport.Protocol()).EncodeSubRefreshResult(resp.Result)
 		if err != nil {
 			c.node.logger.log(newLogEntry(LogLevelError, "error encoding sub refresh", map[string]interface{}{"error": err.Error()}))
 			return DisconnectServerError
@@ -843,7 +843,7 @@ func (c *Client) handleSubRefresh(params proto.Raw, rw *replyWriter) *Disconnect
 }
 
 func (c *Client) handleUnsubscribe(params proto.Raw, rw *replyWriter) *Disconnect {
-	cmd, err := proto.GetParamsDecoder(c.transport.Encoding()).DecodeUnsubscribe(params)
+	cmd, err := proto.GetParamsDecoder(c.transport.Protocol()).DecodeUnsubscribe(params)
 	if err != nil {
 		c.node.logger.log(newLogEntry(LogLevelInfo, "error decoding unsubscribe", map[string]interface{}{"error": err.Error()}))
 		return DisconnectBadRequest
@@ -858,7 +858,7 @@ func (c *Client) handleUnsubscribe(params proto.Raw, rw *replyWriter) *Disconnec
 	}
 	var replyRes []byte
 	if resp.Result != nil {
-		replyRes, err = proto.GetResultEncoder(c.transport.Encoding()).EncodeUnsubscribeResult(resp.Result)
+		replyRes, err = proto.GetResultEncoder(c.transport.Protocol()).EncodeUnsubscribeResult(resp.Result)
 		if err != nil {
 			c.node.logger.log(newLogEntry(LogLevelError, "error encoding unsubscribe", map[string]interface{}{"error": err.Error()}))
 			return DisconnectServerError
@@ -869,7 +869,7 @@ func (c *Client) handleUnsubscribe(params proto.Raw, rw *replyWriter) *Disconnec
 }
 
 func (c *Client) handlePublish(params proto.Raw, rw *replyWriter) *Disconnect {
-	cmd, err := proto.GetParamsDecoder(c.transport.Encoding()).DecodePublish(params)
+	cmd, err := proto.GetParamsDecoder(c.transport.Protocol()).DecodePublish(params)
 	if err != nil {
 		c.node.logger.log(newLogEntry(LogLevelInfo, "error decoding publish", map[string]interface{}{"error": err.Error()}))
 		return DisconnectBadRequest
@@ -884,7 +884,7 @@ func (c *Client) handlePublish(params proto.Raw, rw *replyWriter) *Disconnect {
 	}
 	var replyRes []byte
 	if resp.Result != nil {
-		replyRes, err = proto.GetResultEncoder(c.transport.Encoding()).EncodePublishResult(resp.Result)
+		replyRes, err = proto.GetResultEncoder(c.transport.Protocol()).EncodePublishResult(resp.Result)
 		if err != nil {
 			c.node.logger.log(newLogEntry(LogLevelError, "error encoding publish", map[string]interface{}{"error": err.Error()}))
 			return DisconnectServerError
@@ -895,7 +895,7 @@ func (c *Client) handlePublish(params proto.Raw, rw *replyWriter) *Disconnect {
 }
 
 func (c *Client) handlePresence(params proto.Raw, rw *replyWriter) *Disconnect {
-	cmd, err := proto.GetParamsDecoder(c.transport.Encoding()).DecodePresence(params)
+	cmd, err := proto.GetParamsDecoder(c.transport.Protocol()).DecodePresence(params)
 	if err != nil {
 		c.node.logger.log(newLogEntry(LogLevelInfo, "error decoding presence", map[string]interface{}{"error": err.Error()}))
 		return DisconnectBadRequest
@@ -910,7 +910,7 @@ func (c *Client) handlePresence(params proto.Raw, rw *replyWriter) *Disconnect {
 	}
 	var replyRes []byte
 	if resp.Result != nil {
-		replyRes, err = proto.GetResultEncoder(c.transport.Encoding()).EncodePresenceResult(resp.Result)
+		replyRes, err = proto.GetResultEncoder(c.transport.Protocol()).EncodePresenceResult(resp.Result)
 		if err != nil {
 			c.node.logger.log(newLogEntry(LogLevelError, "error encoding presence", map[string]interface{}{"error": err.Error()}))
 			return DisconnectServerError
@@ -921,7 +921,7 @@ func (c *Client) handlePresence(params proto.Raw, rw *replyWriter) *Disconnect {
 }
 
 func (c *Client) handlePresenceStats(params proto.Raw, rw *replyWriter) *Disconnect {
-	cmd, err := proto.GetParamsDecoder(c.transport.Encoding()).DecodePresenceStats(params)
+	cmd, err := proto.GetParamsDecoder(c.transport.Protocol()).DecodePresenceStats(params)
 	if err != nil {
 		c.node.logger.log(newLogEntry(LogLevelInfo, "error decoding presence stats", map[string]interface{}{"error": err.Error()}))
 		return DisconnectBadRequest
@@ -936,7 +936,7 @@ func (c *Client) handlePresenceStats(params proto.Raw, rw *replyWriter) *Disconn
 	}
 	var replyRes []byte
 	if resp.Result != nil {
-		replyRes, err = proto.GetResultEncoder(c.transport.Encoding()).EncodePresenceStatsResult(resp.Result)
+		replyRes, err = proto.GetResultEncoder(c.transport.Protocol()).EncodePresenceStatsResult(resp.Result)
 		if err != nil {
 			c.node.logger.log(newLogEntry(LogLevelError, "error encoding presence stats", map[string]interface{}{"error": err.Error()}))
 			return DisconnectServerError
@@ -947,7 +947,7 @@ func (c *Client) handlePresenceStats(params proto.Raw, rw *replyWriter) *Disconn
 }
 
 func (c *Client) handleHistory(params proto.Raw, rw *replyWriter) *Disconnect {
-	cmd, err := proto.GetParamsDecoder(c.transport.Encoding()).DecodeHistory(params)
+	cmd, err := proto.GetParamsDecoder(c.transport.Protocol()).DecodeHistory(params)
 	if err != nil {
 		c.node.logger.log(newLogEntry(LogLevelInfo, "error decoding history", map[string]interface{}{"error": err.Error()}))
 		return DisconnectBadRequest
@@ -962,7 +962,7 @@ func (c *Client) handleHistory(params proto.Raw, rw *replyWriter) *Disconnect {
 	}
 	var replyRes []byte
 	if resp.Result != nil {
-		replyRes, err = proto.GetResultEncoder(c.transport.Encoding()).EncodeHistoryResult(resp.Result)
+		replyRes, err = proto.GetResultEncoder(c.transport.Protocol()).EncodeHistoryResult(resp.Result)
 		if err != nil {
 			c.node.logger.log(newLogEntry(LogLevelError, "error encoding history", map[string]interface{}{"error": err.Error()}))
 			return DisconnectServerError
@@ -973,7 +973,7 @@ func (c *Client) handleHistory(params proto.Raw, rw *replyWriter) *Disconnect {
 }
 
 func (c *Client) handlePing(params proto.Raw, rw *replyWriter) *Disconnect {
-	cmd, err := proto.GetParamsDecoder(c.transport.Encoding()).DecodePing(params)
+	cmd, err := proto.GetParamsDecoder(c.transport.Protocol()).DecodePing(params)
 	if err != nil {
 		c.node.logger.log(newLogEntry(LogLevelInfo, "error decoding ping", map[string]interface{}{"error": err.Error()}))
 		return DisconnectBadRequest
@@ -988,7 +988,7 @@ func (c *Client) handlePing(params proto.Raw, rw *replyWriter) *Disconnect {
 	}
 	var replyRes []byte
 	if resp.Result != nil {
-		replyRes, err = proto.GetResultEncoder(c.transport.Encoding()).EncodePingResult(resp.Result)
+		replyRes, err = proto.GetResultEncoder(c.transport.Protocol()).EncodePingResult(resp.Result)
 		if err != nil {
 			c.node.logger.log(newLogEntry(LogLevelError, "error encoding ping", map[string]interface{}{"error": err.Error()}))
 			return DisconnectServerError
@@ -1000,7 +1000,7 @@ func (c *Client) handlePing(params proto.Raw, rw *replyWriter) *Disconnect {
 
 func (c *Client) handleRPC(params proto.Raw, rw *replyWriter) *Disconnect {
 	if c.eventHub.rpcHandler != nil {
-		cmd, err := proto.GetParamsDecoder(c.transport.Encoding()).DecodeRPC(params)
+		cmd, err := proto.GetParamsDecoder(c.transport.Protocol()).DecodeRPC(params)
 		if err != nil {
 			c.node.logger.log(newLogEntry(LogLevelInfo, "error decoding rpc", map[string]interface{}{"error": err.Error()}))
 			return DisconnectBadRequest
@@ -1021,7 +1021,7 @@ func (c *Client) handleRPC(params proto.Raw, rw *replyWriter) *Disconnect {
 		}
 
 		var replyRes []byte
-		replyRes, err = proto.GetResultEncoder(c.transport.Encoding()).EncodeRPCResult(result)
+		replyRes, err = proto.GetResultEncoder(c.transport.Protocol()).EncodeRPCResult(result)
 		if err != nil {
 			c.node.logger.log(newLogEntry(LogLevelError, "error encoding rpc", map[string]interface{}{"error": err.Error()}))
 			return DisconnectServerError
@@ -1035,7 +1035,7 @@ func (c *Client) handleRPC(params proto.Raw, rw *replyWriter) *Disconnect {
 
 func (c *Client) handleSend(params proto.Raw, rw *replyWriter) *Disconnect {
 	if c.eventHub.messageHandler != nil {
-		cmd, err := proto.GetParamsDecoder(c.transport.Encoding()).DecodeSend(params)
+		cmd, err := proto.GetParamsDecoder(c.transport.Protocol()).DecodeSend(params)
 		if err != nil {
 			c.node.logger.log(newLogEntry(LogLevelInfo, "error decoding message", map[string]interface{}{"error": err.Error()}))
 			return DisconnectBadRequest
@@ -1679,7 +1679,7 @@ func (c *Client) subscribeCmd(cmd *proto.SubscribeRequest, rw *replyWriter) *Dis
 		res.Publications = uniquePublications(res.Publications)
 	}
 
-	replyRes, err := proto.GetResultEncoder(c.transport.Encoding()).EncodeSubscribeResult(res)
+	replyRes, err := proto.GetResultEncoder(c.transport.Protocol()).EncodeSubscribeResult(res)
 	if err != nil {
 		c.node.logger.log(newLogEntry(LogLevelError, "error encoding subscribe", map[string]interface{}{"error": err.Error()}))
 		if chOpts.HistoryRecover {

--- a/client_test.go
+++ b/client_test.go
@@ -82,7 +82,7 @@ func TestClientInitialState(t *testing.T) {
 	assert.Equal(t, client.uid, client.ID())
 	assert.NotNil(t, "", client.user)
 	assert.Equal(t, 0, len(client.Channels()))
-	assert.Equal(t, proto.EncodingJSON, client.Transport().Encoding())
+	assert.Equal(t, proto.ProtocolTypeJSON, client.Transport().Protocol())
 	assert.Equal(t, "test_transport", client.Transport().Name())
 	assert.False(t, client.closed)
 	assert.False(t, client.authenticated)

--- a/handler_sockjs.go
+++ b/handler_sockjs.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/centrifugal/centrifuge/internal/proto"
-
 	"github.com/igm/sockjs-go/sockjs"
 )
 
@@ -34,8 +32,12 @@ func (t *sockjsTransport) Name() string {
 	return transportSockJS
 }
 
-func (t *sockjsTransport) Encoding() proto.Encoding {
-	return proto.EncodingJSON
+func (t *sockjsTransport) Protocol() ProtocolType {
+	return ProtocolTypeJSON
+}
+
+func (t *sockjsTransport) Encoding() EncodingType {
+	return EncodingTypeJSON
 }
 
 func (t *sockjsTransport) Info() TransportInfo {

--- a/hub.go
+++ b/hub.go
@@ -7,29 +7,29 @@ import (
 	"github.com/centrifugal/centrifuge/internal/proto"
 )
 
-// preparedReply is structure for encoding reply only once.
+// preparedReply is structure for protoTypeoding reply only once.
 type preparedReply struct {
-	Enc   proto.Encoding
-	Reply *proto.Reply
-	data  []byte
-	once  sync.Once
+	ProtoType proto.ProtocolType
+	Reply     *proto.Reply
+	data      []byte
+	once      sync.Once
 }
 
 // newPreparedReply initializes PreparedReply.
-func newPreparedReply(reply *proto.Reply, enc proto.Encoding) *preparedReply {
+func newPreparedReply(reply *proto.Reply, protoType proto.ProtocolType) *preparedReply {
 	return &preparedReply{
-		Reply: reply,
-		Enc:   enc,
+		Reply:     reply,
+		ProtoType: protoType,
 	}
 }
 
 // Data returns data associated with reply which is only calculated once.
 func (r *preparedReply) Data() []byte {
 	r.once.Do(func() {
-		encoder := proto.GetReplyEncoder(r.Enc)
+		encoder := proto.GetReplyEncoder(r.ProtoType)
 		encoder.Encode(r.Reply)
 		data := encoder.Finish()
-		proto.PutReplyEncoder(r.Enc, encoder)
+		proto.PutReplyEncoder(r.ProtoType, encoder)
 		r.data = data
 	})
 	return r.data
@@ -274,37 +274,37 @@ func (h *Hub) broadcastPublication(channel string, pub *Publication, chOpts *Cha
 		if !ok {
 			continue
 		}
-		enc := c.Transport().Encoding()
-		if enc == proto.EncodingJSON {
+		protoType := c.Transport().Protocol()
+		if protoType == proto.ProtocolTypeJSON {
 			if jsonReply == nil {
-				data, err := proto.GetPushEncoder(enc).EncodePublication(pub)
+				data, err := proto.GetPushEncoder(protoType).EncodePublication(pub)
 				if err != nil {
 					return err
 				}
-				messageBytes, err := proto.GetPushEncoder(enc).Encode(proto.NewPublicationPush(channel, data))
+				messageBytes, err := proto.GetPushEncoder(protoType).Encode(proto.NewPublicationPush(channel, data))
 				if err != nil {
 					return err
 				}
 				reply := &proto.Reply{
 					Result: messageBytes,
 				}
-				jsonReply = newPreparedReply(reply, proto.EncodingJSON)
+				jsonReply = newPreparedReply(reply, proto.ProtocolTypeJSON)
 			}
 			c.writePublication(channel, pub, jsonReply, chOpts)
-		} else if enc == proto.EncodingProtobuf {
+		} else if protoType == proto.ProtocolTypeProtobuf {
 			if protobufReply == nil {
-				data, err := proto.GetPushEncoder(enc).EncodePublication(pub)
+				data, err := proto.GetPushEncoder(protoType).EncodePublication(pub)
 				if err != nil {
 					return err
 				}
-				messageBytes, err := proto.GetPushEncoder(enc).Encode(proto.NewPublicationPush(channel, data))
+				messageBytes, err := proto.GetPushEncoder(protoType).Encode(proto.NewPublicationPush(channel, data))
 				if err != nil {
 					return err
 				}
 				reply := &proto.Reply{
 					Result: messageBytes,
 				}
-				protobufReply = newPreparedReply(reply, proto.EncodingProtobuf)
+				protobufReply = newPreparedReply(reply, proto.ProtocolTypeProtobuf)
 			}
 			c.writePublication(channel, pub, protobufReply, chOpts)
 		}
@@ -332,37 +332,37 @@ func (h *Hub) broadcastJoin(channel string, join *proto.Join) error {
 		if !ok {
 			continue
 		}
-		enc := c.Transport().Encoding()
-		if enc == proto.EncodingJSON {
+		protoType := c.Transport().Protocol()
+		if protoType == proto.ProtocolTypeJSON {
 			if jsonReply == nil {
-				data, err := proto.GetPushEncoder(enc).EncodeJoin(join)
+				data, err := proto.GetPushEncoder(protoType).EncodeJoin(join)
 				if err != nil {
 					return err
 				}
-				messageBytes, err := proto.GetPushEncoder(enc).Encode(proto.NewJoinPush(channel, data))
+				messageBytes, err := proto.GetPushEncoder(protoType).Encode(proto.NewJoinPush(channel, data))
 				if err != nil {
 					return err
 				}
 				reply := &proto.Reply{
 					Result: messageBytes,
 				}
-				jsonReply = newPreparedReply(reply, proto.EncodingJSON)
+				jsonReply = newPreparedReply(reply, proto.ProtocolTypeJSON)
 			}
 			c.writeJoin(channel, jsonReply)
-		} else if enc == proto.EncodingProtobuf {
+		} else if protoType == proto.ProtocolTypeProtobuf {
 			if protobufReply == nil {
-				data, err := proto.GetPushEncoder(enc).EncodeJoin(join)
+				data, err := proto.GetPushEncoder(protoType).EncodeJoin(join)
 				if err != nil {
 					return err
 				}
-				messageBytes, err := proto.GetPushEncoder(enc).Encode(proto.NewJoinPush(channel, data))
+				messageBytes, err := proto.GetPushEncoder(protoType).Encode(proto.NewJoinPush(channel, data))
 				if err != nil {
 					return err
 				}
 				reply := &proto.Reply{
 					Result: messageBytes,
 				}
-				protobufReply = newPreparedReply(reply, proto.EncodingProtobuf)
+				protobufReply = newPreparedReply(reply, proto.ProtocolTypeProtobuf)
 			}
 			c.writeJoin(channel, protobufReply)
 		}
@@ -390,37 +390,37 @@ func (h *Hub) broadcastLeave(channel string, leave *proto.Leave) error {
 		if !ok {
 			continue
 		}
-		enc := c.Transport().Encoding()
-		if enc == proto.EncodingJSON {
+		protoType := c.Transport().Protocol()
+		if protoType == proto.ProtocolTypeJSON {
 			if jsonReply == nil {
-				data, err := proto.GetPushEncoder(enc).EncodeLeave(leave)
+				data, err := proto.GetPushEncoder(protoType).EncodeLeave(leave)
 				if err != nil {
 					return err
 				}
-				messageBytes, err := proto.GetPushEncoder(enc).Encode(proto.NewLeavePush(channel, data))
+				messageBytes, err := proto.GetPushEncoder(protoType).Encode(proto.NewLeavePush(channel, data))
 				if err != nil {
 					return err
 				}
 				reply := &proto.Reply{
 					Result: messageBytes,
 				}
-				jsonReply = newPreparedReply(reply, proto.EncodingJSON)
+				jsonReply = newPreparedReply(reply, proto.ProtocolTypeJSON)
 			}
 			c.writeLeave(channel, jsonReply)
-		} else if enc == proto.EncodingProtobuf {
+		} else if protoType == proto.ProtocolTypeProtobuf {
 			if protobufReply == nil {
-				data, err := proto.GetPushEncoder(enc).EncodeLeave(leave)
+				data, err := proto.GetPushEncoder(protoType).EncodeLeave(leave)
 				if err != nil {
 					return err
 				}
-				messageBytes, err := proto.GetPushEncoder(enc).Encode(proto.NewLeavePush(channel, data))
+				messageBytes, err := proto.GetPushEncoder(protoType).Encode(proto.NewLeavePush(channel, data))
 				if err != nil {
 					return err
 				}
 				reply := &proto.Reply{
 					Result: messageBytes,
 				}
-				protobufReply = newPreparedReply(reply, proto.EncodingProtobuf)
+				protobufReply = newPreparedReply(reply, proto.ProtocolTypeProtobuf)
 			}
 			c.writeLeave(channel, protobufReply)
 		}

--- a/hub_test.go
+++ b/hub_test.go
@@ -38,8 +38,12 @@ func (t *testTransport) Name() string {
 	return "test_transport"
 }
 
-func (t *testTransport) Encoding() Encoding {
-	return proto.EncodingJSON
+func (t *testTransport) Protocol() ProtocolType {
+	return proto.ProtocolTypeJSON
+}
+
+func (t *testTransport) Encoding() EncodingType {
+	return proto.EncodingTypeJSON
 }
 
 func (t *testTransport) Info() TransportInfo {
@@ -106,7 +110,7 @@ func TestHubSubscriptions(t *testing.T) {
 
 func TestPreparedReply(t *testing.T) {
 	reply := proto.Reply{}
-	prepared := newPreparedReply(&reply, proto.EncodingJSON)
+	prepared := newPreparedReply(&reply, proto.ProtocolTypeJSON)
 	data := prepared.Data()
 	assert.NotNil(t, data)
 }

--- a/internal/proto/encoding.go
+++ b/internal/proto/encoding.go
@@ -1,94 +1,11 @@
 package proto
 
-import "sync"
-
-// Encoding determines connection protocol encoding in use.
-type Encoding string
+// EncodingType determines connection payload encoding type.
+type EncodingType string
 
 const (
-	// EncodingJSON means JSON protocol.
-	EncodingJSON Encoding = "json"
-	// EncodingProtobuf means protobuf protocol.
-	EncodingProtobuf Encoding = "protobuf"
+	// EncodingTypeJSON means JSON protocol.
+	EncodingTypeJSON EncodingType = "json"
+	// EncodingTypeBinary means binary payload.
+	EncodingTypeBinary EncodingType = "binary"
 )
-
-// GetPushEncoder ...
-func GetPushEncoder(enc Encoding) PushEncoder {
-	if enc == EncodingJSON {
-		return NewJSONPushEncoder()
-	}
-	return NewProtobufPushEncoder()
-}
-
-var (
-	jsonReplyEncoderPool     sync.Pool
-	protobufReplyEncoderPool sync.Pool
-)
-
-// GetReplyEncoder ...
-func GetReplyEncoder(enc Encoding) ReplyEncoder {
-	if enc == EncodingJSON {
-		e := jsonReplyEncoderPool.Get()
-		if e == nil {
-			return NewJSONReplyEncoder()
-		}
-		encoder := e.(ReplyEncoder)
-		encoder.Reset()
-		return encoder
-	}
-	e := protobufReplyEncoderPool.Get()
-	if e == nil {
-		return NewProtobufReplyEncoder()
-	}
-	encoder := e.(ReplyEncoder)
-	encoder.Reset()
-	return encoder
-}
-
-// PutReplyEncoder ...
-func PutReplyEncoder(enc Encoding, e ReplyEncoder) {
-	if enc == EncodingJSON {
-		jsonReplyEncoderPool.Put(e)
-		return
-	}
-	protobufReplyEncoderPool.Put(e)
-}
-
-// GetCommandDecoder ...
-func GetCommandDecoder(enc Encoding, data []byte) CommandDecoder {
-	if enc == EncodingJSON {
-		return NewJSONCommandDecoder(data)
-	}
-	return NewProtobufCommandDecoder(data)
-}
-
-// PutCommandDecoder ...
-func PutCommandDecoder(enc Encoding, e CommandDecoder) {
-	return
-}
-
-// GetResultEncoder ...
-func GetResultEncoder(enc Encoding) ResultEncoder {
-	if enc == EncodingJSON {
-		return NewJSONResultEncoder()
-	}
-	return NewProtobufResultEncoder()
-}
-
-// PutResultEncoder ...
-func PutResultEncoder(enc Encoding, e ReplyEncoder) {
-	return
-}
-
-// GetParamsDecoder ...
-func GetParamsDecoder(enc Encoding) ParamsDecoder {
-	if enc == EncodingJSON {
-		return NewJSONParamsDecoder()
-	}
-	return NewProtobufParamsDecoder()
-}
-
-// PutParamsDecoder ...
-func PutParamsDecoder(enc Encoding, e ParamsDecoder) {
-	return
-}

--- a/internal/proto/protocol.go
+++ b/internal/proto/protocol.go
@@ -1,0 +1,94 @@
+package proto
+
+import "sync"
+
+// ProtocolType determines connection protocol protoTypeoding type.
+type ProtocolType string
+
+const (
+	// ProtocolTypeJSON means JSON protocol.
+	ProtocolTypeJSON ProtocolType = "json"
+	// ProtocolTypeProtobuf means protobuf protocol.
+	ProtocolTypeProtobuf ProtocolType = "protobuf"
+)
+
+// GetPushEncoder ...
+func GetPushEncoder(protoType ProtocolType) PushEncoder {
+	if protoType == ProtocolTypeJSON {
+		return NewJSONPushEncoder()
+	}
+	return NewProtobufPushEncoder()
+}
+
+var (
+	jsonReplyEncoderPool     sync.Pool
+	protobufReplyEncoderPool sync.Pool
+)
+
+// GetReplyEncoder ...
+func GetReplyEncoder(protoType ProtocolType) ReplyEncoder {
+	if protoType == ProtocolTypeJSON {
+		e := jsonReplyEncoderPool.Get()
+		if e == nil {
+			return NewJSONReplyEncoder()
+		}
+		protoTypeoder := e.(ReplyEncoder)
+		protoTypeoder.Reset()
+		return protoTypeoder
+	}
+	e := protobufReplyEncoderPool.Get()
+	if e == nil {
+		return NewProtobufReplyEncoder()
+	}
+	protoTypeoder := e.(ReplyEncoder)
+	protoTypeoder.Reset()
+	return protoTypeoder
+}
+
+// PutReplyEncoder ...
+func PutReplyEncoder(protoType ProtocolType, e ReplyEncoder) {
+	if protoType == ProtocolTypeJSON {
+		jsonReplyEncoderPool.Put(e)
+		return
+	}
+	protobufReplyEncoderPool.Put(e)
+}
+
+// GetCommandDecoder ...
+func GetCommandDecoder(protoType ProtocolType, data []byte) CommandDecoder {
+	if protoType == ProtocolTypeJSON {
+		return NewJSONCommandDecoder(data)
+	}
+	return NewProtobufCommandDecoder(data)
+}
+
+// PutCommandDecoder ...
+func PutCommandDecoder(protoType ProtocolType, e CommandDecoder) {
+	return
+}
+
+// GetResultEncoder ...
+func GetResultEncoder(protoType ProtocolType) ResultEncoder {
+	if protoType == ProtocolTypeJSON {
+		return NewJSONResultEncoder()
+	}
+	return NewProtobufResultEncoder()
+}
+
+// PutResultEncoder ...
+func PutResultEncoder(protoType ProtocolType, e ReplyEncoder) {
+	return
+}
+
+// GetParamsDecoder ...
+func GetParamsDecoder(protoType ProtocolType) ParamsDecoder {
+	if protoType == ProtocolTypeJSON {
+		return NewJSONParamsDecoder()
+	}
+	return NewProtobufParamsDecoder()
+}
+
+// PutParamsDecoder ...
+func PutParamsDecoder(protoType ProtocolType, e ParamsDecoder) {
+	return
+}

--- a/protocol.go
+++ b/protocol.go
@@ -21,8 +21,10 @@ type (
 	Leave = proto.Leave
 	// ClientInfo is short information about client connection.
 	ClientInfo = proto.ClientInfo
-	// Encoding represents client connection transport encoding format.
-	Encoding = proto.Encoding
+	// ProtocolType represents client connection transport encoding format.
+	ProtocolType = proto.ProtocolType
+	// EncodingType represents client payload encoding format.
+	EncodingType = proto.EncodingType
 	// Push wraps Publication, Join or Leave.
 	Push = proto.Push
 )
@@ -34,10 +36,14 @@ const (
 	PushTypeLeave       = proto.PushTypeLeave
 )
 
+// Protocol types.
+const (
+	ProtocolTypeJSON     = proto.ProtocolTypeJSON
+	ProtocolTypeProtobuf = proto.ProtocolTypeProtobuf
+)
+
 // Encoding types.
 const (
-	// EncodingJSON ...
-	EncodingJSON = proto.EncodingJSON
-	// EncodingProtobuf ...
-	EncodingProtobuf = proto.EncodingProtobuf
+	EncodingTypeJSON   = proto.EncodingTypeJSON
+	EncodingTypeBinary = proto.EncodingTypeBinary
 )

--- a/transport.go
+++ b/transport.go
@@ -16,8 +16,13 @@ type TransportInfo struct {
 type Transport interface {
 	// Name returns a name of transport used for client connection.
 	Name() string
-	// Encoding returns transport encoding used.
-	Encoding() Encoding
+	// Protocol returns underlying transport protocol type used.
+	// At moment this can be for example a JSON streaming based protocol
+	// or Protobuf length-delimited protocol.
+	Protocol() ProtocolType
+	// Encoding() returns payload encoding type used by client. By default
+	// server assumes that payload passed as JSON.
+	Encoding() EncodingType
 	// Info returns transport information.
 	Info() TransportInfo
 }


### PR DESCRIPTION
This is required to properly solve https://github.com/centrifugal/centrifugo/pull/284

Without these changes application backend will receive base64 encoded data even if users use JSON in our mobile clients. All mobile clients use Protobuf protocol but most users still pass JSON as user-level payloads. Now we assume that JSON payloads are used by default. If someone want to proxy binary payloads to application backend then client must explicitly tell server that it will use binary encoding in payloads.