### PR TITLE
Various broadcast optimizations

### DIFF
--- a/client.go
+++ b/client.go
@@ -142,32 +142,32 @@ func newClient(ctx context.Context, n *Node, t transport) (*Client, error) {
 		pubBuffer: make([]*Publication, 0),
 	}
 
+	transportMessagesSentWriter := transportMessagesSent.WithLabelValues(t.Name())
+
 	messageWriterConf := writerConfig{
 		MaxQueueSize: config.ClientQueueMaxSize,
-		WriteFn: func(data ...[]byte) error {
-			if len(data) == 1 {
-				// no need in extra byte buffers in this path.
-				payload := data[0]
-				err := t.Write(payload)
-				if err != nil {
-					go c.Close(DisconnectWriteError)
-					return err
-				}
-				transportMessagesSent.WithLabelValues(t.Name()).Inc()
-			} else {
-				buf := getBuffer()
-				for _, payload := range data {
-					buf.Write(payload)
-				}
-				err := t.Write(buf.Bytes())
-				if err != nil {
-					go c.Close(DisconnectWriteError)
-					putBuffer(buf)
-					return err
-				}
-				putBuffer(buf)
-				transportMessagesSent.WithLabelValues(t.Name()).Add(float64(len(data)))
+		WriteFn: func(data []byte) error {
+			err := t.Write(data)
+			if err != nil {
+				go c.Close(DisconnectWriteError)
+				return err
 			}
+			transportMessagesSentWriter.Inc()
+			return nil
+		},
+		WriteManyFn: func(data ...[]byte) error {
+			buf := getBuffer()
+			for _, payload := range data {
+				buf.Write(payload)
+			}
+			err := t.Write(buf.Bytes())
+			if err != nil {
+				go c.Close(DisconnectWriteError)
+				putBuffer(buf)
+				return err
+			}
+			putBuffer(buf)
+			transportMessagesSentWriter.Add(float64(len(data)))
 			return nil
 		},
 	}

--- a/client.go
+++ b/client.go
@@ -142,7 +142,7 @@ func newClient(ctx context.Context, n *Node, t transport) (*Client, error) {
 		pubBuffer: make([]*Publication, 0),
 	}
 
-	transportMessagesSentWriter := transportMessagesSent.WithLabelValues(t.Name())
+	transportMessagesSentCounter := transportMessagesSent.WithLabelValues(t.Name())
 
 	messageWriterConf := writerConfig{
 		MaxQueueSize: config.ClientQueueMaxSize,
@@ -152,7 +152,7 @@ func newClient(ctx context.Context, n *Node, t transport) (*Client, error) {
 				go c.Close(DisconnectWriteError)
 				return err
 			}
-			transportMessagesSentWriter.Inc()
+			transportMessagesSentCounter.Inc()
 			return nil
 		},
 		WriteManyFn: func(data ...[]byte) error {
@@ -167,7 +167,7 @@ func newClient(ctx context.Context, n *Node, t transport) (*Client, error) {
 				return err
 			}
 			putBuffer(buf)
-			transportMessagesSentWriter.Add(float64(len(data)))
+			transportMessagesSentCounter.Add(float64(len(data)))
 			return nil
 		},
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -277,7 +277,7 @@ func TestClientConnectWithExpiredContextCredentials(t *testing.T) {
 	assert.Equal(t, ErrorExpired, resp.Error)
 }
 
-func connectClient(t *testing.T, client *Client) *proto.ConnectResult {
+func connectClient(t testing.TB, client *Client) *proto.ConnectResult {
 	connectResp, disconnect := client.connectCmd(&proto.ConnectRequest{})
 	assert.Nil(t, disconnect)
 	assert.Nil(t, connectResp.Error)
@@ -295,7 +295,7 @@ func extractSubscribeResult(replies []*proto.Reply) *proto.SubscribeResult {
 	return &res
 }
 
-func subscribeClient(t *testing.T, client *Client, ch string) *proto.SubscribeResult {
+func subscribeClient(t testing.TB, client *Client, ch string) *proto.SubscribeResult {
 	replies := []*proto.Reply{}
 	rw := testReplyWriter(&replies)
 

--- a/handler_websocket_test.go
+++ b/handler_websocket_test.go
@@ -182,7 +182,7 @@ func TestWebsocketHandlerConcurrentConnections(t *testing.T) {
 // BenchmarkWebsocketHandler allows to benchmark full flow with one real
 // Websocket connection subscribed to one channel. This is not very representative
 // in terms of time for operation as network IO involved but useful to look at
-// total allocs and difference between JSON and Protobuf cases.
+// total allocs and difference between JSON and Protobuf cases using various buffer sizes.
 func BenchmarkWebsocketHandler(b *testing.B) {
 	n := nodeWithMemoryEngine()
 	c := n.Config()

--- a/hub_test.go
+++ b/hub_test.go
@@ -16,10 +16,21 @@ type testTransport struct {
 	sink       chan []byte
 	closed     bool
 	disconnect *Disconnect
+	encoding   Encoding
 }
 
 func newTestTransport() *testTransport {
-	return &testTransport{}
+	return &testTransport{
+		encoding: EncodingJSON,
+	}
+}
+
+func (t *testTransport) setEncoding(enc Encoding) {
+	t.encoding = enc
+}
+
+func (t *testTransport) setSink(sink chan []byte) {
+	t.sink = sink
 }
 
 func (t *testTransport) Write(data []byte) error {
@@ -39,7 +50,7 @@ func (t *testTransport) Name() string {
 }
 
 func (t *testTransport) Encoding() Encoding {
-	return proto.EncodingJSON
+	return t.encoding
 }
 
 func (t *testTransport) Info() TransportInfo {

--- a/node_test.go
+++ b/node_test.go
@@ -3,6 +3,7 @@ package centrifuge
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -190,5 +191,67 @@ func BenchmarkNodePublishWithNoopEngine(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		node.Publish("bench", payload)
+	}
+}
+
+func newFakeConn(b testing.TB, node *Node, channel string, enc Encoding, sink chan []byte) {
+	transport := newTestTransport()
+	transport.setEncoding(enc)
+	transport.setSink(sink)
+	ctx := context.Background()
+	newCtx := SetCredentials(ctx, &Credentials{UserID: "42"})
+	client, _ := newClient(newCtx, node, transport)
+	connectClient(b, client)
+	replies := []*proto.Reply{}
+	rw := testReplyWriter(&replies)
+	disconnect := client.subscribeCmd(&proto.SubscribeRequest{
+		Channel: channel,
+	}, rw)
+	assert.Nil(b, disconnect)
+}
+
+func newFakeConnJSON(b testing.TB, node *Node, channel string, sink chan []byte) {
+	newFakeConn(b, node, channel, EncodingJSON, sink)
+}
+
+func newFakeConnProtobuf(b testing.TB, node *Node, channel string, sink chan []byte) {
+	newFakeConn(b, node, channel, EncodingProtobuf, sink)
+}
+
+func BenchmarkBroadcastMemoryEngine(b *testing.B) {
+	benchmarks := []struct {
+		name           string
+		getFakeConn    func(b testing.TB, n *Node, channel string, sink chan []byte)
+		numSubscribers int
+	}{
+		{"JSON", newFakeConnJSON, 1},
+		{"Protobuf", newFakeConnProtobuf, 1},
+		{"JSON", newFakeConnJSON, 10000},
+		{"Protobuf", newFakeConnProtobuf, 10000},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(fmt.Sprintf("%s_%d_subscribers", bm.name, bm.numSubscribers), func(b *testing.B) {
+			n := nodeWithMemoryEngine()
+			c := n.Config()
+			c.ClientInsecure = true
+			n.Reload(c)
+			payload := []byte(`{"input": "test"}`)
+			sink := make(chan []byte, bm.numSubscribers)
+			for i := 0; i < bm.numSubscribers; i++ {
+				bm.getFakeConn(b, n, "test", sink)
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				err := n.Publish("test", payload)
+				if err != nil {
+					panic(err)
+				}
+				for j := 0; j < bm.numSubscribers; j++ {
+					<-sink
+				}
+			}
+			b.ReportAllocs()
+		})
 	}
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -98,8 +98,11 @@ func BenchmarkWriteMerge(b *testing.B) {
 func BenchmarkWriteMergeDisabled(b *testing.B) {
 	transport := newBenchmarkTransport()
 	defer transport.close()
-	writer := newWriter(writerConfig{MaxMessagesInFrame: 1, WriteManyFn: transport.writeCombined})
-
+	writer := newWriter(writerConfig{
+		MaxMessagesInFrame: 1,
+		WriteFn:            transport.writeSingle,
+		WriteManyFn:        transport.writeCombined,
+	})
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		runWrite(writer, transport)
@@ -134,7 +137,11 @@ func (t *fakeTransport) write(buf []byte) error {
 
 func TestWriter(t *testing.T) {
 	transport := newFakeTransport()
-	w := newWriter(writerConfig{MaxMessagesInFrame: 4, WriteFn: transport.write, WriteManyFn: transport.writeMany})
+	w := newWriter(writerConfig{
+		MaxMessagesInFrame: 4,
+		WriteFn:            transport.write,
+		WriteManyFn:        transport.writeMany,
+	})
 	disconnect := w.enqueue([]byte("test"))
 	assert.Nil(t, disconnect)
 	<-transport.ch
@@ -145,7 +152,11 @@ func TestWriter(t *testing.T) {
 
 func TestWriterDisconnect(t *testing.T) {
 	transport := newFakeTransport()
-	w := newWriter(writerConfig{MaxQueueSize: 1, WriteFn: transport.write, WriteManyFn: transport.writeMany})
+	w := newWriter(writerConfig{
+		MaxQueueSize: 1,
+		WriteFn:      transport.write,
+		WriteManyFn:  transport.writeMany,
+	})
 	disconnect := w.enqueue([]byte("test"))
 	assert.NotNil(t, disconnect)
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -53,6 +53,15 @@ func (t *benchmarkTransport) writeCombined(bufs ...[]byte) error {
 	return nil
 }
 
+func (t *benchmarkTransport) writeSingle(data []byte) error {
+	_, err := t.f.Write(data)
+	if err != nil {
+		panic(err)
+	}
+	t.inc(1)
+	return nil
+}
+
 func (t *benchmarkTransport) close() error {
 	return t.f.Close()
 }
@@ -75,7 +84,8 @@ func BenchmarkWriteMerge(b *testing.B) {
 	defer transport.close()
 	writer := newWriter(writerConfig{
 		MaxMessagesInFrame: 4,
-		WriteFn:            transport.writeCombined,
+		WriteFn:            transport.writeSingle,
+		WriteManyFn:        transport.writeCombined,
 	})
 
 	b.ResetTimer()
@@ -88,7 +98,7 @@ func BenchmarkWriteMerge(b *testing.B) {
 func BenchmarkWriteMergeDisabled(b *testing.B) {
 	transport := newBenchmarkTransport()
 	defer transport.close()
-	writer := newWriter(writerConfig{MaxMessagesInFrame: 1, WriteFn: transport.writeCombined})
+	writer := newWriter(writerConfig{MaxMessagesInFrame: 1, WriteManyFn: transport.writeCombined})
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -108,7 +118,7 @@ func newFakeTransport() *fakeTransport {
 	}
 }
 
-func (t *fakeTransport) write(bufs ...[]byte) error {
+func (t *fakeTransport) writeMany(bufs ...[]byte) error {
 	for range bufs {
 		t.count++
 		t.ch <- struct{}{}
@@ -116,9 +126,15 @@ func (t *fakeTransport) write(bufs ...[]byte) error {
 	return nil
 }
 
+func (t *fakeTransport) write(buf []byte) error {
+	t.count++
+	t.ch <- struct{}{}
+	return nil
+}
+
 func TestWriter(t *testing.T) {
 	transport := newFakeTransport()
-	w := newWriter(writerConfig{MaxMessagesInFrame: 4, WriteFn: transport.write})
+	w := newWriter(writerConfig{MaxMessagesInFrame: 4, WriteFn: transport.write, WriteManyFn: transport.writeMany})
 	disconnect := w.enqueue([]byte("test"))
 	assert.Nil(t, disconnect)
 	<-transport.ch
@@ -129,7 +145,7 @@ func TestWriter(t *testing.T) {
 
 func TestWriterDisconnect(t *testing.T) {
 	transport := newFakeTransport()
-	w := newWriter(writerConfig{MaxQueueSize: 1, WriteFn: transport.write})
+	w := newWriter(writerConfig{MaxQueueSize: 1, WriteFn: transport.write, WriteManyFn: transport.writeMany})
 	disconnect := w.enqueue([]byte("test"))
 	assert.NotNil(t, disconnect)
 }


### PR DESCRIPTION
Before:
```
fz@centrifuge: go test -test.run=XXX -bench=BenchmarkBroadcast -cpuprofile=cpu -memprofile=mem
goos: darwin
goarch: amd64
pkg: github.com/centrifugal/centrifuge
BenchmarkBroadcastMemoryEngine/JSON_1_subscribers-4         	  200000	      7901 ns/op	     944 B/op	      26 allocs/op
BenchmarkBroadcastMemoryEngine/Protobuf_1_subscribers-4     	  300000	      4870 ns/op	     465 B/op	      14 allocs/op
BenchmarkBroadcastMemoryEngine/JSON_10000_subscribers-4     	     100	  11249143 ns/op	  481196 B/op	   20025 allocs/op
BenchmarkBroadcastMemoryEngine/Protobuf_10000_subscribers-4 	     100	  12077671 ns/op	  480677 B/op	   20013 allocs/op
```
After:
```
fz@centrifuge: go test -test.run=XXX -bench=BenchmarkBroadcast -cpuprofile=cpu -memprofile=mem
goos: darwin
goarch: amd64
pkg: github.com/centrifugal/centrifuge
BenchmarkBroadcastMemoryEngine/JSON_1_subscribers-4         	  200000	      7698 ns/op	     896 B/op	      24 allocs/op
BenchmarkBroadcastMemoryEngine/Protobuf_1_subscribers-4     	  300000	      4415 ns/op	     417 B/op	      12 allocs/op
BenchmarkBroadcastMemoryEngine/JSON_10000_subscribers-4     	     100	  11217320 ns/op	    1097 B/op	      24 allocs/op
BenchmarkBroadcastMemoryEngine/Protobuf_10000_subscribers-4 	     100	  18144938 ns/op	     828 B/op	      12 allocs/op
```