### PR TITLE
Max check position failures

### DIFF
--- a/_examples/redis_engine/main.go
+++ b/_examples/redis_engine/main.go
@@ -97,7 +97,7 @@ func main() {
 	})
 
 	engine, err := centrifuge.NewRedisEngine(node, centrifuge.RedisEngineConfig{
-		PublishOnHistoryAdd: false,
+		PublishOnHistoryAdd: true, // This allows to publish into Redis channels atomically when adding Publication to history.
 		Shards: []centrifuge.RedisShardConfig{
 			centrifuge.RedisShardConfig{
 				Host: "localhost",

--- a/client.go
+++ b/client.go
@@ -335,20 +335,20 @@ func (c *Client) checkPosition(checkDelay time.Duration, ch string, channelConte
 	}
 
 	isValidPosition := streamPosition.Seq == position.Seq && streamPosition.Gen == position.Gen && streamPosition.Epoch == position.Epoch
-	var needDisconnect bool
+	keepConnection := true
 	c.mu.Lock()
 	if channelContext, ok = c.channels[ch]; ok {
 		channelContext.positionCheckTime = nowUnix
 		if !isValidPosition {
 			channelContext.positionCheckFailures++
-			needDisconnect = channelContext.positionCheckFailures == maxCheckPositionFailures
+			keepConnection = channelContext.positionCheckFailures < maxCheckPositionFailures
 		} else {
 			channelContext.positionCheckFailures = 0
 		}
 		c.channels[ch] = channelContext
 	}
 	c.mu.Unlock()
-	return needDisconnect
+	return keepConnection
 }
 
 // ID returns unique client connection id.

--- a/engine_memory.go
+++ b/engine_memory.go
@@ -2,7 +2,6 @@ package centrifuge
 
 import (
 	"container/heap"
-	"math"
 	"strconv"
 	"sync"
 	"time"
@@ -290,10 +289,6 @@ func (h *historyHub) next(ch string) uint64 {
 	return val
 }
 
-func unpackUint64(val uint64) (uint32, uint32) {
-	return uint32(val), uint32(val >> 32)
-}
-
 func (h *historyHub) getSequence(ch string) (uint32, uint32, string) {
 	h.sequencesMu.Lock()
 	defer h.sequencesMu.Unlock()
@@ -431,8 +426,3 @@ func (h *historyHub) remove(ch string) error {
 	}
 	return nil
 }
-
-const (
-	maxSeq uint32 = math.MaxUint32 // maximum uint32 value
-	maxGen uint32 = math.MaxUint32 // maximum uint32 value
-)

--- a/util.go
+++ b/util.go
@@ -2,7 +2,13 @@ package centrifuge
 
 import (
 	"bytes"
+	"math"
 	"sync"
+)
+
+const (
+	maxSeq uint32 = math.MaxUint32 // maximum uint32 value
+	maxGen uint32 = math.MaxUint32 // maximum uint32 value
 )
 
 func nextSeqGen(currentSeq, currentGen uint32) (uint32, uint32) {
@@ -15,6 +21,14 @@ func nextSeqGen(currentSeq, currentGen uint32) (uint32, uint32) {
 		nextSeq = currentSeq + 1
 	}
 	return nextSeq, nextGen
+}
+
+func uint64Sequence(currentSeq, currentGen uint32) uint64 {
+	return uint64(currentGen)*uint64(math.MaxUint32) + uint64(currentSeq)
+}
+
+func unpackUint64(val uint64) (uint32, uint32) {
+	return uint32(val), uint32(val >> 32)
 }
 
 func stringInSlice(a string, list []string) bool {

--- a/util_test.go
+++ b/util_test.go
@@ -28,6 +28,20 @@ func TestNextSeqGen(t *testing.T) {
 	assert.Equal(t, uint32(0), nextGen)
 }
 
+func TestUint64Sequence(t *testing.T) {
+	s := uint64Sequence(0, 0)
+	assert.Equal(t, uint64(0), s)
+
+	s = uint64Sequence(1, 0)
+	assert.Equal(t, uint64(1), s)
+
+	s = uint64Sequence(0, 1)
+	assert.Equal(t, uint64(1<<32-1), s)
+
+	s = uint64Sequence(1, 1)
+	assert.Equal(t, uint64(1<<32), s)
+}
+
 func TestStringInSlice(t *testing.T) {
 	assert.True(t, stringInSlice("test", []string{"boom", "test"}))
 	assert.False(t, stringInSlice("test", []string{"boom", "testing"}))


### PR DESCRIPTION
Some improvements to position check algorithm:
* position check attempts to not disconnect after first position check fail - only 2 fails in a row now result into disconnect with insufficient state
* do not disconnect when PUB/SUB publication sequence less than client position sequence