### PR TITLE
Dissolve subscriptions over queue with delay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+.vscode

--- a/client_test.go
+++ b/client_test.go
@@ -77,6 +77,7 @@ func TestNewClient(t *testing.T) {
 
 func TestClientInitialState(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 	transport := newTestTransport()
 	client, _ := NewClient(context.Background(), node, transport)
 	assert.Equal(t, client.uid, client.ID())
@@ -91,6 +92,7 @@ func TestClientInitialState(t *testing.T) {
 
 func TestClientClosedState(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 	transport := newTestTransport()
 	client, _ := NewClient(context.Background(), node, transport)
 	err := client.Close(nil)
@@ -100,6 +102,7 @@ func TestClientClosedState(t *testing.T) {
 
 func TestClientConnectNoCredentialsNoToken(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 	transport := newTestTransport()
 	client, _ := NewClient(context.Background(), node, transport)
 	_, disconnect := client.connectCmd(&protocol.ConnectRequest{})
@@ -109,6 +112,7 @@ func TestClientConnectNoCredentialsNoToken(t *testing.T) {
 
 func TestClientConnectNoCredentialsNoTokenInsecure(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	config.ClientInsecure = true
@@ -125,6 +129,7 @@ func TestClientConnectNoCredentialsNoTokenInsecure(t *testing.T) {
 
 func TestClientConnectNoCredentialsNoTokenAnonymous(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	config.ClientAnonymous = true
@@ -141,6 +146,7 @@ func TestClientConnectNoCredentialsNoTokenAnonymous(t *testing.T) {
 
 func TestClientConnectWithMalformedToken(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 	transport := newTestTransport()
 	client, _ := NewClient(context.Background(), node, transport)
 	_, disconnect := client.connectCmd(&protocol.ConnectRequest{
@@ -152,6 +158,7 @@ func TestClientConnectWithMalformedToken(t *testing.T) {
 
 func TestClientConnectWithValidToken(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	config.TokenHMACSecretKey = "secret"
@@ -169,6 +176,7 @@ func TestClientConnectWithValidToken(t *testing.T) {
 
 func TestClientConnectWithExpiringToken(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	config.TokenHMACSecretKey = "secret"
@@ -187,6 +195,7 @@ func TestClientConnectWithExpiringToken(t *testing.T) {
 
 func TestClientConnectWithExpiredToken(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	config.TokenHMACSecretKey = "secret"
@@ -204,6 +213,7 @@ func TestClientConnectWithExpiredToken(t *testing.T) {
 
 func TestClientTokenRefresh(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	config.TokenHMACSecretKey = "secret"
@@ -228,6 +238,7 @@ func TestClientTokenRefresh(t *testing.T) {
 
 func TestClientConnectContextCredentials(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	node.Reload(config)
@@ -255,6 +266,7 @@ func TestClientConnectContextCredentials(t *testing.T) {
 
 func TestClientRefreshHandlerClosingExpiredClient(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	node.Reload(config)
@@ -281,6 +293,7 @@ func TestClientRefreshHandlerClosingExpiredClient(t *testing.T) {
 
 func TestClientRefreshHandlerProlongatesClientSession(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	node.Reload(config)
@@ -309,6 +322,7 @@ func TestClientRefreshHandlerProlongatesClientSession(t *testing.T) {
 
 func TestClientConnectWithExpiredContextCredentials(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	node.Reload(config)
@@ -363,6 +377,7 @@ func subscribeClient(t testing.TB, client *Client, ch string) *protocol.Subscrib
 
 func TestClientSubscribe(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 	transport := newTestTransport()
 	ctx := context.Background()
 	newCtx := SetCredentials(ctx, &Credentials{UserID: "42"})
@@ -406,6 +421,7 @@ func TestClientSubscribe(t *testing.T) {
 
 func TestClientSubscribeReceivePublication(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 	transport := newTestTransport()
 	transport.sink = make(chan []byte, 100)
 	ctx := context.Background()
@@ -444,6 +460,7 @@ func TestClientSubscribeReceivePublication(t *testing.T) {
 
 func TestClientSubscribeReceivePublicationWithSequence(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 	config := node.Config()
 	config.HistoryLifetime = 100
 	config.HistorySize = 10
@@ -515,6 +532,7 @@ func TestClientSubscribeReceivePublicationWithSequence(t *testing.T) {
 
 func TestClientSubscribePrivateChannelNoToken(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 	transport := newTestTransport()
 	ctx := context.Background()
 	newCtx := SetCredentials(ctx, &Credentials{UserID: "42"})
@@ -534,6 +552,7 @@ func TestClientSubscribePrivateChannelNoToken(t *testing.T) {
 
 func TestClientSubscribePrivateChannelWithToken(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	config.TokenHMACSecretKey = "secret"
@@ -575,6 +594,7 @@ func TestClientSubscribePrivateChannelWithToken(t *testing.T) {
 
 func TestClientSubscribePrivateChannelWithExpiringToken(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	config.TokenHMACSecretKey = "secret"
@@ -611,6 +631,7 @@ func TestClientSubscribePrivateChannelWithExpiringToken(t *testing.T) {
 
 func TestClientSubscribeLast(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	config.HistorySize = 10
@@ -640,6 +661,8 @@ func TestClientSubscribeLast(t *testing.T) {
 
 func TestClientUnsubscribe(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
+
 	transport := newTestTransport()
 	ctx := context.Background()
 	newCtx := SetCredentials(ctx, &Credentials{UserID: "42"})
@@ -670,6 +693,7 @@ func TestClientUnsubscribe(t *testing.T) {
 
 func TestClientPublish(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 	transport := newTestTransport()
 	ctx := context.Background()
 	newCtx := SetCredentials(ctx, &Credentials{UserID: "42"})
@@ -761,6 +785,7 @@ type testClientMessage struct {
 
 func TestClientPublishHandler(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 	transport := newTestTransport()
 	ctx := context.Background()
 	newCtx := SetCredentials(ctx, &Credentials{UserID: "42"})
@@ -839,6 +864,7 @@ func TestClientPublishHandler(t *testing.T) {
 
 func TestClientPing(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 	transport := newTestTransport()
 	ctx := context.Background()
 	newCtx := SetCredentials(ctx, &Credentials{UserID: "42"})
@@ -854,6 +880,7 @@ func TestClientPing(t *testing.T) {
 
 func TestClientPingWithRecover(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	config.HistoryLifetime = 10
@@ -877,6 +904,7 @@ func TestClientPingWithRecover(t *testing.T) {
 
 func TestClientPresence(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	config.Presence = true
@@ -927,6 +955,7 @@ func TestClientPresence(t *testing.T) {
 
 func TestClientHistory(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	config.HistorySize = 10
@@ -967,6 +996,7 @@ func TestClientHistory(t *testing.T) {
 
 func TestClientHistoryDisabled(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	config.HistorySize = 10
@@ -993,6 +1023,7 @@ func TestClientHistoryDisabled(t *testing.T) {
 
 func TestClientPresenceDisabled(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	config.Presence = true
@@ -1018,6 +1049,7 @@ func TestClientPresenceDisabled(t *testing.T) {
 
 func TestClientCloseUnauthenticated(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	config.ClientStaleCloseDelay = time.Millisecond
@@ -1035,6 +1067,7 @@ func TestClientCloseUnauthenticated(t *testing.T) {
 
 func TestClientPresenceUpdate(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	config := node.Config()
 	config.Presence = true
@@ -1054,6 +1087,7 @@ func TestClientPresenceUpdate(t *testing.T) {
 
 func TestClientSend(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
 
 	transport := newTestTransport()
 	ctx := context.Background()
@@ -1075,6 +1109,8 @@ func TestClientSend(t *testing.T) {
 
 func TestClientClose(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
+
 	transport := newTestTransport()
 	ctx := context.Background()
 	newCtx := SetCredentials(ctx, &Credentials{UserID: "42"})
@@ -1090,6 +1126,8 @@ func TestClientClose(t *testing.T) {
 
 func TestClientHandleMalformedCommand(t *testing.T) {
 	node := nodeWithMemoryEngine()
+	defer node.Shutdown(context.Background())
+
 	transport := newTestTransport()
 	ctx := context.Background()
 	newCtx := SetCredentials(ctx, &Credentials{UserID: "42"})
@@ -1199,6 +1237,8 @@ func TestClientSubscribeRecoverMemory(t *testing.T) {
 			res := extractSubscribeResult(replies)
 			assert.Equal(t, tt.NumRecovered, len(res.Publications))
 			assert.Equal(t, tt.Recovered, res.Recovered)
+
+			node.Shutdown(context.Background())
 		})
 	}
 }

--- a/engine_redis_test.go
+++ b/engine_redis_test.go
@@ -793,6 +793,8 @@ func TestClientSubscribeRecoverRedis(t *testing.T) {
 			res := extractSubscribeResult(replies)
 			assert.Equal(t, tt.NumRecovered, len(res.Publications))
 			assert.Equal(t, tt.Recovered, res.Recovered)
+
+			node.Shutdown(context.Background())
 		})
 	}
 }

--- a/internal/dissolve/dissolve.go
+++ b/internal/dissolve/dissolve.go
@@ -1,0 +1,62 @@
+package dissolve
+
+import (
+	"errors"
+	"runtime"
+)
+
+// Dissolver ...
+type Dissolver struct {
+	queue     Queue
+	semaphore chan struct{}
+	nWorkers  int
+}
+
+// New ...
+func New(maxConcurrency int, nWorkers int) *Dissolver {
+	return &Dissolver{
+		queue:     newQueue(),
+		nWorkers:  nWorkers,
+		semaphore: make(chan struct{}, maxConcurrency),
+	}
+}
+
+// Run ...
+func (d *Dissolver) Run() error {
+	for i := 0; i < d.nWorkers; i++ {
+		go d.runWorker()
+	}
+	return nil
+}
+
+// Close ...
+func (d *Dissolver) Close() error {
+	d.queue.Close()
+	return nil
+}
+
+// Submit ...
+func (d *Dissolver) Submit(job Job) error {
+	if !d.queue.Add(job) {
+		return errors.New("can not submit job to closed dissolver")
+	}
+	return nil
+}
+
+func (d *Dissolver) runWorker() {
+	for {
+		d.semaphore <- struct{}{}
+		job, ok := d.queue.Wait()
+		if !ok {
+			<-d.semaphore
+			break
+		}
+		err := job()
+		if err != nil {
+			// Put to the end of queue.
+			runtime.Gosched()
+			d.queue.Add(job)
+		}
+		<-d.semaphore
+	}
+}

--- a/internal/dissolve/dissolve_test.go
+++ b/internal/dissolve/dissolve_test.go
@@ -1,0 +1,41 @@
+package dissolve
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDissolver(t *testing.T) {
+	d := New(1000, 16)
+	d.Run()
+	defer d.Close()
+	ch := make(chan struct{}, 1)
+	go func() {
+		d.Submit(func() error {
+			ch <- struct{}{}
+			return nil
+		})
+	}()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func BenchmarkEnqueueAddConsume(b *testing.B) {
+	d := New(1000, 16)
+	d.Run()
+	defer d.Close()
+	ch := make(chan struct{}, 1)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.Submit(func() error {
+			ch <- struct{}{}
+			return nil
+		})
+		<-ch
+	}
+	b.StopTimer()
+	b.ReportAllocs()
+}

--- a/internal/dissolve/queue.go
+++ b/internal/dissolve/queue.go
@@ -7,10 +7,10 @@ import (
 // Job to do.
 type Job func() error
 
-// Queue is an unbounded queue of Job.
+// queue is an unbounded queue of Job.
 // The queue is goroutine safe.
 // Inspired by http://blog.dubbelboer.com/2015/04/25/go-faster-queue.html (MIT)
-type Queue interface {
+type queue interface {
 	// Add an Job to the back of the queue
 	// will return false if the queue is closed.
 	// In that case the Job is dropped.
@@ -48,7 +48,7 @@ type Queue interface {
 	Len() int
 }
 
-type byteQueue struct {
+type queueImpl struct {
 	mu      sync.RWMutex
 	cond    *sync.Cond
 	nodes   []Job
@@ -62,9 +62,9 @@ type byteQueue struct {
 
 var initialCapacity = 2
 
-// new ByteQueue returns a new Job queue with initial capacity.
-func newQueue() Queue {
-	sq := &byteQueue{
+// newQueue returns a new Job queue with initial capacity.
+func newQueue() queue {
+	sq := &queueImpl{
 		initCap: initialCapacity,
 		nodes:   make([]Job, initialCapacity),
 	}
@@ -73,7 +73,7 @@ func newQueue() Queue {
 }
 
 // Write mutex must be held when calling
-func (q *byteQueue) resize(n int) {
+func (q *queueImpl) resize(n int) {
 	nodes := make([]Job, n)
 	if q.head < q.tail {
 		copy(nodes, q.nodes[q.head:q.tail])
@@ -90,7 +90,7 @@ func (q *byteQueue) resize(n int) {
 // Add a Job to the back of the queue
 // will return false if the queue is closed.
 // In that case the Job is dropped.
-func (q *byteQueue) Add(i Job) bool {
+func (q *queueImpl) Add(i Job) bool {
 	q.mu.Lock()
 	if q.closed {
 		q.mu.Unlock()
@@ -111,7 +111,7 @@ func (q *byteQueue) Add(i Job) bool {
 
 // Close the queue and discard all entried in the queue
 // all goroutines in wait() will return
-func (q *byteQueue) Close() {
+func (q *queueImpl) Close() {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	q.closed = true
@@ -123,7 +123,7 @@ func (q *byteQueue) Close() {
 
 // CloseRemaining will close the queue and return all entried in the queue.
 // All goroutines in wait() will return.
-func (q *byteQueue) CloseRemaining() []Job {
+func (q *queueImpl) CloseRemaining() []Job {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	if q.closed {
@@ -147,7 +147,7 @@ func (q *byteQueue) CloseRemaining() []Job {
 // Closed returns true if the queue has been closed
 // The call cannot guarantee that the queue hasn't been
 // closed while the function returns, so only "true" has a definite meaning.
-func (q *byteQueue) Closed() bool {
+func (q *queueImpl) Closed() bool {
 	q.mu.RLock()
 	c := q.closed
 	q.mu.RUnlock()
@@ -159,7 +159,7 @@ func (q *byteQueue) Closed() bool {
 // be returned immediately.
 // Will return nil, false if the queue is closed.
 // Otherwise the return value of "remove" is returned.
-func (q *byteQueue) Wait() (Job, bool) {
+func (q *queueImpl) Wait() (Job, bool) {
 	q.mu.Lock()
 	if q.closed {
 		q.mu.Unlock()
@@ -177,7 +177,7 @@ func (q *byteQueue) Wait() (Job, bool) {
 // Remove will remove a Job from the queue.
 // If false is returned, it either means 1) there were no items on the queue
 // or 2) the queue is closed.
-func (q *byteQueue) Remove() (Job, bool) {
+func (q *queueImpl) Remove() (Job, bool) {
 	q.mu.Lock()
 	if q.cnt == 0 {
 		q.mu.Unlock()
@@ -196,7 +196,7 @@ func (q *byteQueue) Remove() (Job, bool) {
 }
 
 // Return the capacity (without allocations)
-func (q *byteQueue) Cap() int {
+func (q *queueImpl) Cap() int {
 	q.mu.RLock()
 	c := cap(q.nodes)
 	q.mu.RUnlock()
@@ -204,7 +204,7 @@ func (q *byteQueue) Cap() int {
 }
 
 // Return the current length of the queue.
-func (q *byteQueue) Len() int {
+func (q *queueImpl) Len() int {
 	q.mu.RLock()
 	l := q.cnt
 	q.mu.RUnlock()

--- a/internal/dissolve/queue.go
+++ b/internal/dissolve/queue.go
@@ -1,0 +1,212 @@
+package dissolve
+
+import (
+	"sync"
+)
+
+// Job to do.
+type Job func() error
+
+// Queue is an unbounded queue of Job.
+// The queue is goroutine safe.
+// Inspired by http://blog.dubbelboer.com/2015/04/25/go-faster-queue.html (MIT)
+type Queue interface {
+	// Add an Job to the back of the queue
+	// will return false if the queue is closed.
+	// In that case the Job is dropped.
+	Add(Job) bool
+
+	// Remove will remove a Job from the queue.
+	// If false is returned, it either means 1) there were no items on the queue
+	// or 2) the queue is closed.
+	Remove() (Job, bool)
+
+	// Close the queue and discard all entried in the queue
+	// all goroutines in wait() will return
+	Close()
+
+	// CloseRemaining will close the queue and return all entried in the queue.
+	// All goroutines in wait() will return
+	CloseRemaining() []Job
+
+	// Closed returns true if the queue has been closed
+	// The call cannot guarantee that the queue hasn't been
+	// closed while the function returns, so only "true" has a definite meaning.
+	Closed() bool
+
+	// Wait for a Job to be added or queue to be closed.
+	// If there is items on the queue the first will
+	// be returned immediately.
+	// Will return "", false if the queue is closed.
+	// Otherwise the return value of "remove" is returned.
+	Wait() (Job, bool)
+
+	// Cap returns the capacity (without allocations).
+	Cap() int
+
+	// Len returns the current length of the queue.
+	Len() int
+}
+
+type byteQueue struct {
+	mu      sync.RWMutex
+	cond    *sync.Cond
+	nodes   []Job
+	head    int
+	tail    int
+	cnt     int
+	size    int
+	closed  bool
+	initCap int
+}
+
+var initialCapacity = 2
+
+// new ByteQueue returns a new Job queue with initial capacity.
+func newQueue() Queue {
+	sq := &byteQueue{
+		initCap: initialCapacity,
+		nodes:   make([]Job, initialCapacity),
+	}
+	sq.cond = sync.NewCond(&sq.mu)
+	return sq
+}
+
+// Write mutex must be held when calling
+func (q *byteQueue) resize(n int) {
+	nodes := make([]Job, n)
+	if q.head < q.tail {
+		copy(nodes, q.nodes[q.head:q.tail])
+	} else {
+		copy(nodes, q.nodes[q.head:])
+		copy(nodes[len(q.nodes)-q.head:], q.nodes[:q.tail])
+	}
+
+	q.tail = q.cnt % n
+	q.head = 0
+	q.nodes = nodes
+}
+
+// Add a Job to the back of the queue
+// will return false if the queue is closed.
+// In that case the Job is dropped.
+func (q *byteQueue) Add(i Job) bool {
+	q.mu.Lock()
+	if q.closed {
+		q.mu.Unlock()
+		return false
+	}
+	if q.cnt == len(q.nodes) {
+		// Also tested a grow rate of 1.5, see: http://stackoverflow.com/questions/2269063/buffer-growth-strategy
+		// In Go this resulted in a higher memory usage.
+		q.resize(q.cnt * 2)
+	}
+	q.nodes[q.tail] = i
+	q.tail = (q.tail + 1) % len(q.nodes)
+	q.cnt++
+	q.cond.Signal()
+	q.mu.Unlock()
+	return true
+}
+
+// Close the queue and discard all entried in the queue
+// all goroutines in wait() will return
+func (q *byteQueue) Close() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.closed = true
+	q.cnt = 0
+	q.nodes = nil
+	q.size = 0
+	q.cond.Broadcast()
+}
+
+// CloseRemaining will close the queue and return all entried in the queue.
+// All goroutines in wait() will return.
+func (q *byteQueue) CloseRemaining() []Job {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		return []Job{}
+	}
+	rem := make([]Job, 0, q.cnt)
+	for q.cnt > 0 {
+		i := q.nodes[q.head]
+		q.head = (q.head + 1) % len(q.nodes)
+		q.cnt--
+		rem = append(rem, i)
+	}
+	q.closed = true
+	q.cnt = 0
+	q.nodes = nil
+	q.size = 0
+	q.cond.Broadcast()
+	return rem
+}
+
+// Closed returns true if the queue has been closed
+// The call cannot guarantee that the queue hasn't been
+// closed while the function returns, so only "true" has a definite meaning.
+func (q *byteQueue) Closed() bool {
+	q.mu.RLock()
+	c := q.closed
+	q.mu.RUnlock()
+	return c
+}
+
+// Wait for a Job to be added.
+// If there is items on the queue the first will
+// be returned immediately.
+// Will return nil, false if the queue is closed.
+// Otherwise the return value of "remove" is returned.
+func (q *byteQueue) Wait() (Job, bool) {
+	q.mu.Lock()
+	if q.closed {
+		q.mu.Unlock()
+		return nil, false
+	}
+	if q.cnt != 0 {
+		q.mu.Unlock()
+		return q.Remove()
+	}
+	q.cond.Wait()
+	q.mu.Unlock()
+	return q.Remove()
+}
+
+// Remove will remove a Job from the queue.
+// If false is returned, it either means 1) there were no items on the queue
+// or 2) the queue is closed.
+func (q *byteQueue) Remove() (Job, bool) {
+	q.mu.Lock()
+	if q.cnt == 0 {
+		q.mu.Unlock()
+		return nil, false
+	}
+	i := q.nodes[q.head]
+	q.head = (q.head + 1) % len(q.nodes)
+	q.cnt--
+
+	if n := len(q.nodes) / 2; n >= q.initCap && q.cnt <= n {
+		q.resize(n)
+	}
+
+	q.mu.Unlock()
+	return i, true
+}
+
+// Return the capacity (without allocations)
+func (q *byteQueue) Cap() int {
+	q.mu.RLock()
+	c := cap(q.nodes)
+	q.mu.RUnlock()
+	return c
+}
+
+// Return the current length of the queue.
+func (q *byteQueue) Len() int {
+	q.mu.RLock()
+	l := q.cnt
+	q.mu.RUnlock()
+	return l
+}

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -4,39 +4,39 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testItem []byte
 
 func TestByteQueueResize(t *testing.T) {
 	q := New()
-	assert.Equal(t, 0, q.Len())
-	assert.Equal(t, false, q.Closed())
+	require.Equal(t, 0, q.Len())
+	require.Equal(t, false, q.Closed())
 
 	for i := 0; i < initialCapacity; i++ {
 		q.Add(testItem([]byte(strconv.Itoa(i))))
 	}
 	q.Add(testItem([]byte("resize here")))
-	assert.Equal(t, initialCapacity*2, q.Cap())
+	require.Equal(t, initialCapacity*2, q.Cap())
 	q.Remove()
 
 	q.Add(testItem([]byte("new resize here")))
-	assert.Equal(t, initialCapacity*2, q.Cap())
+	require.Equal(t, initialCapacity*2, q.Cap())
 	q.Add(testItem([]byte("one more item, no resize must happen")))
-	assert.Equal(t, initialCapacity*2, q.Cap())
+	require.Equal(t, initialCapacity*2, q.Cap())
 
-	assert.Equal(t, initialCapacity+2, q.Len())
+	require.Equal(t, initialCapacity+2, q.Len())
 }
 
 func TestByteQueueSize(t *testing.T) {
 	q := New()
-	assert.Equal(t, 0, q.Size())
+	require.Equal(t, 0, q.Size())
 	q.Add(testItem([]byte("1")))
 	q.Add(testItem([]byte("2")))
-	assert.Equal(t, 2, q.Size())
+	require.Equal(t, 2, q.Size())
 	q.Remove()
-	assert.Equal(t, 1, q.Size())
+	require.Equal(t, 1, q.Size())
 }
 
 func TestByteQueueWait(t *testing.T) {
@@ -45,20 +45,20 @@ func TestByteQueueWait(t *testing.T) {
 	q.Add(testItem([]byte("2")))
 
 	s, ok := q.Wait()
-	assert.Equal(t, true, ok)
-	assert.Equal(t, "1", string(s))
+	require.Equal(t, true, ok)
+	require.Equal(t, "1", string(s))
 
 	s, ok = q.Wait()
-	assert.Equal(t, true, ok)
-	assert.Equal(t, "2", string(s))
+	require.Equal(t, true, ok)
+	require.Equal(t, "2", string(s))
 
 	go func() {
 		q.Add(testItem([]byte("3")))
 	}()
 
 	s, ok = q.Wait()
-	assert.Equal(t, true, ok)
-	assert.Equal(t, "3", string(s))
+	require.Equal(t, true, ok)
+	require.Equal(t, "3", string(s))
 
 }
 
@@ -67,22 +67,22 @@ func TestByteQueueClose(t *testing.T) {
 
 	// test removing from empty queue
 	_, ok := q.Remove()
-	assert.Equal(t, false, ok)
+	require.Equal(t, false, ok)
 
 	q.Add(testItem([]byte("1")))
 	q.Add(testItem([]byte("2")))
 	q.Close()
 
 	ok = q.Add(testItem([]byte("3")))
-	assert.Equal(t, false, ok)
+	require.Equal(t, false, ok)
 
 	_, ok = q.Wait()
-	assert.Equal(t, false, ok)
+	require.Equal(t, false, ok)
 
 	_, ok = q.Remove()
-	assert.Equal(t, false, ok)
+	require.Equal(t, false, ok)
 
-	assert.Equal(t, true, q.Closed())
+	require.Equal(t, true, q.Closed())
 
 }
 
@@ -91,12 +91,12 @@ func TestByteQueueCloseRemaining(t *testing.T) {
 	q.Add(testItem([]byte("1")))
 	q.Add(testItem([]byte("2")))
 	msgs := q.CloseRemaining()
-	assert.Equal(t, 2, len(msgs))
+	require.Equal(t, 2, len(msgs))
 	ok := q.Add(testItem([]byte("3")))
-	assert.Equal(t, false, ok)
-	assert.Equal(t, true, q.Closed())
+	require.Equal(t, false, ok)
+	require.Equal(t, true, q.Closed())
 	msgs = q.CloseRemaining()
-	assert.Equal(t, 0, len(msgs))
+	require.Equal(t, 0, len(msgs))
 }
 
 func BenchmarkQueueAdd(b *testing.B) {

--- a/node.go
+++ b/node.go
@@ -62,7 +62,8 @@ type Node struct {
 }
 
 const (
-	numSubLocks = 16384
+	numSubLocks            = 16384
+	numSubDissolverWorkers = 128
 )
 
 // New creates Node, the only required argument is config.
@@ -86,7 +87,7 @@ func New(c Config) (*Node, error) {
 		controlDecoder: controlproto.NewProtobufDecoder(),
 		eventHub:       &nodeEventHub{},
 		subLocks:       subLocks,
-		subDissolver:   dissolve.New(1000, 16),
+		subDissolver:   dissolve.New(numSubDissolverWorkers),
 	}
 
 	if c.LogHandler != nil {
@@ -218,6 +219,7 @@ func (n *Node) Shutdown(ctx context.Context) error {
 			defer closer.Close(ctx)
 		}
 	}
+	n.subDissolver.Close()
 	return n.hub.shutdown(ctx)
 }
 

--- a/node.go
+++ b/node.go
@@ -63,7 +63,7 @@ type Node struct {
 
 const (
 	numSubLocks            = 16384
-	numSubDissolverWorkers = 128
+	numSubDissolverWorkers = 64
 )
 
 // New creates Node, the only required argument is config.

--- a/node_test.go
+++ b/node_test.go
@@ -122,6 +122,7 @@ func nodeWithMemoryEngine() *Node {
 
 func TestUserAllowed(t *testing.T) {
 	node := nodeWithTestEngine()
+	defer node.Shutdown(context.Background())
 	assert.True(t, node.userAllowed("channel#1", "1"))
 	assert.True(t, node.userAllowed("channel", "1"))
 	assert.False(t, node.userAllowed("channel#1", "2"))
@@ -132,6 +133,7 @@ func TestUserAllowed(t *testing.T) {
 
 func TestSetConfig(t *testing.T) {
 	node := nodeWithTestEngine()
+	defer node.Shutdown(context.Background())
 	err := node.Reload(DefaultConfig)
 	assert.NoError(t, err)
 }
@@ -184,6 +186,7 @@ var testPayload = map[string]interface{}{
 
 func BenchmarkNodePublishWithNoopEngine(b *testing.B) {
 	node := nodeWithTestEngine()
+
 	payload, err := json.Marshal(testPayload)
 	if err != nil {
 		panic(err.Error())
@@ -192,6 +195,8 @@ func BenchmarkNodePublishWithNoopEngine(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		node.Publish("bench", payload)
 	}
+	b.StopTimer()
+	node.Shutdown(context.Background())
 }
 
 func newFakeConn(b testing.TB, node *Node, channel string, protoType ProtocolType, sink chan []byte) {
@@ -251,6 +256,8 @@ func BenchmarkBroadcastMemoryEngine(b *testing.B) {
 					<-sink
 				}
 			}
+			b.StopTimer()
+			n.Shutdown(context.Background())
 			b.ReportAllocs()
 		})
 	}


### PR DESCRIPTION
Allows to fix #77 and adds extra bonus: if last client in channel quickly reconnected to node then unsubscribe in broker won't be called at all.

This is incomplete work at moment.