### PR TITLE
Simplify server side subscription api

### DIFF
--- a/_examples/chat_json/main.go
+++ b/_examples/chat_json/main.go
@@ -87,14 +87,10 @@ func main() {
 	node, _ := centrifuge.New(cfg)
 
 	node.On().ClientConnecting(func(ctx context.Context, t centrifuge.TransportInfo, e centrifuge.ConnectEvent) centrifuge.ConnectReply {
-		// Subscribe to several server-side channels.
-		subs := []centrifuge.Subscription{}
-		for i := 0; i < 3; i++ {
-			subs = append(subs, centrifuge.Subscription{Channel: "server-side-" + strconv.Itoa(i)})
-		}
 		return centrifuge.ConnectReply{
-			Data:          centrifuge.Raw(`{}`),
-			Subscriptions: subs,
+			Data: centrifuge.Raw(`{}`),
+			// Subscribe to several server-side channels.
+			Channels: []string{"server-side-1", "server-side-2", "server-side-3"},
 		}
 	})
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+v0.6.0
+======
+
+* Simplify server-side subscription API replacing `[]centrifuge.Subscription` with just `[]string` - i.e. a slice of channels we want to subscribe connection to. For now it seems much more simple to just use a slice of strings and this must be sufficient for most use cases. It is also a bit more efficient for JWT use case in terms of its payload size. More complex logic can be introduced later over separate field of `ConnectReply` or `connectToken` if needed
+* Support server-side subscriptions via JWT using `channels` claim field
+
 v0.5.0
 ======
 

--- a/client.go
+++ b/client.go
@@ -1131,8 +1131,8 @@ func (c *Client) connectCmd(cmd *protocol.ConnectRequest, rw *replyWriter) *Disc
 		if reply.Data != nil {
 			authData = reply.Data
 		}
-		for _, sub := range reply.Subscriptions {
-			channels = append(channels, sub.Channel)
+		for _, ch := range reply.Channels {
+			channels = append(channels, ch)
 		}
 	}
 
@@ -1175,6 +1175,10 @@ func (c *Client) connectCmd(cmd *protocol.ConnectRequest, rw *replyWriter) *Disc
 			c.mu.Lock()
 			c.info = token.Info
 			c.mu.Unlock()
+		}
+
+		for _, ch := range token.Channels {
+			channels = append(channels, ch)
 		}
 	} else {
 		if !insecure && !clientAnonymous {

--- a/client_test.go
+++ b/client_test.go
@@ -577,9 +577,9 @@ func TestServerSideSubscriptions(t *testing.T) {
 
 	node.On().ClientConnecting(func(context.Context, TransportInfo, ConnectEvent) ConnectReply {
 		return ConnectReply{
-			Subscriptions: []Subscription{
-				{Channel: "server-side-1"},
-				{Channel: "server-side-2"},
+			Channels: []string{
+				"server-side-1",
+				"server-side-2",
 			},
 		}
 	})

--- a/events.go
+++ b/events.go
@@ -28,14 +28,8 @@ type ConnectReply struct {
 	Credentials *Credentials
 	// Data allows to set custom data in connect reply.
 	Data Raw
-	// Subscriptions field allows to provide a list of channels to subscribe
-	// connection server side.
-	Subscriptions []Subscription
-}
-
-// Subscription to channel.
-type Subscription struct {
-	Channel string
+	// Channels slice contains channels to subscribe connection to on server-side.
+	Channels []string
 }
 
 // ConnectingHandler called when new client authenticates on server.

--- a/token_verifier.go
+++ b/token_verifier.go
@@ -19,6 +19,8 @@ type connectToken struct {
 	// client directly. In some cases having additional info can be an
 	// overhead – but you are simply free to not use it.
 	Info Raw
+	// Channels slice contains channels to subscribe connection to on server-side.
+	Channels []string
 }
 
 type subscribeToken struct {

--- a/token_verifier_jwt.go
+++ b/token_verifier_jwt.go
@@ -29,8 +29,9 @@ var (
 )
 
 type connectTokenClaims struct {
-	Info       Raw    `json:"info"`
-	Base64Info string `json:"b64info"`
+	Info       Raw      `json:"info"`
+	Base64Info string   `json:"b64info"`
+	Channels   []string `json:"channels"`
 	jwt.StandardClaims
 }
 
@@ -60,6 +61,7 @@ func (verifier *tokenVerifierJWT) VerifyConnectToken(token string) (connectToken
 			UserID:   claims.StandardClaims.Subject,
 			ExpireAt: claims.StandardClaims.ExpiresAt,
 			Info:     claims.Info,
+			Channels: claims.Channels,
 		}
 		if claims.Base64Info != "" {
 			byteInfo, err := base64.StdEncoding.DecodeString(claims.Base64Info)


### PR DESCRIPTION
* Simplify server-side subscription API replacing `[]centrifuge.Subscription` with just `[]string` - i.e. a slice of channels we want to subscribe connection to. For now it seems much more simple to just use a slice of strings and this must be sufficient for most use cases. It is also a bit more efficient for JWT use case in terms of its payload size. More complex logic can be introduced later over separate field of `ConnectReply` or `connectToken` if needed
* Support server-side subscriptions via JWT using `channels` claim field