### PR TITLE
Support Redis cluster

### DIFF
--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -5,7 +5,7 @@ go 1.14
 replace github.com/centrifugal/centrifuge => ../
 
 require (
-	github.com/centrifugal/centrifuge v0.6.0
+	github.com/centrifugal/centrifuge v0.7.0
 	github.com/dchest/uniuri v0.0.0-20200228104902-7aecb25e1fe5
 	github.com/gin-contrib/sessions v0.0.3
 	github.com/gin-gonic/gin v1.5.0

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -83,6 +83,8 @@ github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2y
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/memcachier/mc v2.0.1+incompatible/go.mod h1:7bkvFE61leUBvXz+yxsOnGBQSZpBSPIMUQSmmSHvuXc=
+github.com/mna/redisc v1.1.7 h1:FdmtJsfTjoIjNXiQf4ozgNjuE+zxWH+fJSe+I/dD4vc=
+github.com/mna/redisc v1.1.7/go.mod h1:GXeOb7zyYKiT+K8MKdIiJvuv7MfhDoQGcuzfiJQmqQI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=

--- a/_examples/redis_engine/main.go
+++ b/_examples/redis_engine/main.go
@@ -130,6 +130,23 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Simulate some work.
+	for i := 0; i < 10; i++ {
+		go func(i int) {
+			for {
+				time.Sleep(time.Second)
+				err := node.Publish("chat:"+strconv.Itoa(i), []byte("hello"))
+				if err != nil {
+					panic(err.Error())
+				}
+				_, err = node.History("chat:" + strconv.Itoa(i))
+				if err != nil {
+					panic(err.Error())
+				}
+			}
+		}(i)
+	}
+
 	http.Handle("/connection/websocket", authMiddleware(centrifuge.NewWebsocketHandler(node, centrifuge.WebsocketConfig{})))
 	http.Handle("/", http.FileServer(http.Dir("./")))
 

--- a/client.go
+++ b/client.go
@@ -1177,9 +1177,7 @@ func (c *Client) connectCmd(cmd *protocol.ConnectRequest, rw *replyWriter) *Disc
 			c.mu.Unlock()
 		}
 
-		for _, ch := range token.Channels {
-			channels = append(channels, ch)
-		}
+		channels = append(channels, token.Channels...)
 	} else {
 		if !insecure && !clientAnonymous {
 			c.node.logger.log(newLogEntry(LogLevelInfo, "client credentials not found", map[string]interface{}{"client": c.uid}))
@@ -1890,10 +1888,6 @@ func (c *Client) writeJoin(_ string, reply *prepared.Reply) error {
 }
 
 func (c *Client) writeLeave(_ string, reply *prepared.Reply) error {
-	return c.transportEnqueue(reply)
-}
-
-func (c *Client) writeMessage(reply *prepared.Reply) error {
 	return c.transportEnqueue(reply)
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -1336,7 +1336,7 @@ var recoverTests = []struct {
 	{"from_same_position_in_expired_stream", 10, 1, 1, 1, 0, 3, true},
 }
 
-func TestClientSubscribeRecoverMemory(t *testing.T) {
+func TestMemoryClientSubscribeRecover(t *testing.T) {
 	for _, tt := range recoverTests {
 		t.Run(tt.Name, func(t *testing.T) {
 			node := nodeWithMemoryEngine()

--- a/engine_memory_test.go
+++ b/engine_memory_test.go
@@ -179,7 +179,7 @@ func TestMemoryHistoryHub(t *testing.T) {
 	assert.Equal(t, 1, len(hist))
 }
 
-func BenchmarkMemoryEnginePublish(b *testing.B) {
+func BenchmarkMemoryEnginePublish_SingleChannel(b *testing.B) {
 	e := testMemoryEngine()
 	rawData := Raw([]byte(`{"bench": true}`))
 	pub := &Publication{UID: "test UID", Data: rawData}
@@ -192,7 +192,7 @@ func BenchmarkMemoryEnginePublish(b *testing.B) {
 	}
 }
 
-func BenchmarkMemoryEnginePublishParallel(b *testing.B) {
+func BenchmarkMemoryEnginePublish_SingleChannel_Parallel(b *testing.B) {
 	e := testMemoryEngine()
 	rawData := Raw([]byte(`{"bench": true}`))
 	pub := &Publication{UID: "test UID", Data: rawData}
@@ -208,7 +208,7 @@ func BenchmarkMemoryEnginePublishParallel(b *testing.B) {
 	})
 }
 
-func BenchmarkMemoryEnginePublishWithHistory(b *testing.B) {
+func BenchmarkMemoryEnginePublish_WithHistory_SingleChannel(b *testing.B) {
 	e := testMemoryEngine()
 	rawData := Raw([]byte(`{"bench": true}`))
 	pub := &Publication{UID: "test-uid", Data: rawData}
@@ -227,7 +227,7 @@ func BenchmarkMemoryEnginePublishWithHistory(b *testing.B) {
 	}
 }
 
-func BenchmarkMemoryEnginePublishWithHistoryParallel(b *testing.B) {
+func BenchmarkMemoryEnginePublish_WithHistory_SingleChannel_Parallel(b *testing.B) {
 	e := testMemoryEngine()
 	rawData := Raw([]byte(`{"bench": true}`))
 	chOpts := &ChannelOptions{HistorySize: 100, HistoryLifetime: 100}
@@ -249,7 +249,7 @@ func BenchmarkMemoryEnginePublishWithHistoryParallel(b *testing.B) {
 	})
 }
 
-func BenchmarkMemoryEngineAddPresence(b *testing.B) {
+func BenchmarkMemoryEngineAddPresence_SingleChannel(b *testing.B) {
 	e := testMemoryEngine()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -260,7 +260,7 @@ func BenchmarkMemoryEngineAddPresence(b *testing.B) {
 	}
 }
 
-func BenchmarkMemoryEngineAddPresenceParallel(b *testing.B) {
+func BenchmarkMemoryEngineAddPresence_SingleChannel_Parallel(b *testing.B) {
 	e := testMemoryEngine()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -273,7 +273,7 @@ func BenchmarkMemoryEngineAddPresenceParallel(b *testing.B) {
 	})
 }
 
-func BenchmarkMemoryEnginePresence(b *testing.B) {
+func BenchmarkMemoryEnginePresence_SingleChannel(b *testing.B) {
 	e := testMemoryEngine()
 	e.AddPresence("channel", "uid", &ClientInfo{}, 300*time.Second)
 	b.ResetTimer()
@@ -285,7 +285,7 @@ func BenchmarkMemoryEnginePresence(b *testing.B) {
 	}
 }
 
-func BenchmarkMemoryEnginePresenceParallel(b *testing.B) {
+func BenchmarkMemoryEnginePresence_SingleChannel_Parallel(b *testing.B) {
 	e := testMemoryEngine()
 	e.AddPresence("channel", "uid", &ClientInfo{}, 300*time.Second)
 	b.ResetTimer()
@@ -299,7 +299,7 @@ func BenchmarkMemoryEnginePresenceParallel(b *testing.B) {
 	})
 }
 
-func BenchmarkMemoryEngineHistory(b *testing.B) {
+func BenchmarkMemoryEngineHistory_SingleChannel(b *testing.B) {
 	e := testMemoryEngine()
 	rawData := Raw([]byte("{}"))
 	pub := &Publication{UID: "test UID", Data: rawData}
@@ -318,7 +318,7 @@ func BenchmarkMemoryEngineHistory(b *testing.B) {
 	}
 }
 
-func BenchmarkMemoryEngineHistoryParallel(b *testing.B) {
+func BenchmarkMemoryEngineHistory_SingleChannel_Parallel(b *testing.B) {
 	e := testMemoryEngine()
 	rawData := Raw([]byte("{}"))
 	pub := &Publication{UID: "test-uid", Data: rawData}
@@ -339,7 +339,7 @@ func BenchmarkMemoryEngineHistoryParallel(b *testing.B) {
 	})
 }
 
-func BenchmarkMemoryEngineHistoryRecoverParallel(b *testing.B) {
+func BenchmarkMemoryEngineRecover_SingleChannel_Parallel(b *testing.B) {
 	e := testMemoryEngine()
 	rawData := Raw([]byte("{}"))
 	numMessages := 100

--- a/engine_redis.go
+++ b/engine_redis.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/FZambia/sentinel"
 	"github.com/gomodule/redigo/redis"
+	"github.com/mna/redisc"
 )
 
 const (
@@ -33,6 +34,8 @@ const (
 	redisPublishBatchLimit = 512
 	// redisDataBatchLimit is a max amount of data requests in one batch.
 	redisDataBatchLimit = 64
+	// redisNumDataPipelineWorkers is an amount of data pipeline worker goroutines.
+	redisNumDataPipelineWorkers = 8
 )
 
 const (
@@ -71,12 +74,16 @@ type RedisEngine struct {
 
 var _ Engine = (*RedisEngine)(nil)
 
+type redisConnPool interface {
+	Get() redis.Conn
+}
+
 // shard has everything to connect to Redis instance.
 type shard struct {
 	node              *Node
 	engine            *RedisEngine
 	config            RedisShardConfig
-	pool              *redis.Pool
+	pool              redisConnPool
 	subCh             chan subRequest
 	pubCh             chan pubRequest
 	dataCh            chan dataRequest
@@ -143,6 +150,8 @@ type RedisShardConfig struct {
 	MasterName string
 	// SentinelAddrs is a slice of Sentinel addresses.
 	SentinelAddrs []string
+	// ClusterAddrs is a slice of seed cluster addrs for this shard.
+	ClusterAddrs []string
 	// Prefix to use before every channel name and key in Redis.
 	Prefix string
 	// IdleTimeout is timeout after which idle connections to Redis will be closed.
@@ -185,22 +194,15 @@ func (sr *subRequest) result() error {
 	return <-sr.err
 }
 
-func newPool(n *Node, conf RedisShardConfig) *redis.Pool {
+func createPool(addr string, options ...redis.DialOption) (*redis.Pool, error) {
+	return nil, nil
+}
 
-	host := conf.Host
-	port := conf.Port
+func poolFactory(s *shard, n *Node, conf RedisShardConfig) func(addr string, options ...redis.DialOption) (*redis.Pool, error) {
 	password := conf.Password
 	db := conf.DB
 
-	serverAddr := net.JoinHostPort(host, strconv.Itoa(port))
 	useSentinel := conf.MasterName != "" && len(conf.SentinelAddrs) > 0
-
-	usingPassword := password != ""
-	if !useSentinel {
-		n.Log(NewLogEntry(LogLevelInfo, fmt.Sprintf("Redis: %s/%d, using password: %v", serverAddr, db, usingPassword)))
-	} else {
-		n.Log(NewLogEntry(LogLevelInfo, fmt.Sprintf("Redis: Sentinel for name: %s, db: %d, using password: %v", conf.MasterName, db, usingPassword)))
-	}
 
 	var lastMu sync.Mutex
 	var lastMaster string
@@ -249,88 +251,151 @@ func newPool(n *Node, conf RedisShardConfig) *redis.Pool {
 		}()
 	}
 
-	return &redis.Pool{
-		MaxIdle:     maxIdle,
-		MaxActive:   poolSize,
-		Wait:        true,
-		IdleTimeout: conf.IdleTimeout,
-		Dial: func() (redis.Conn, error) {
-			var err error
-			if useSentinel {
-				serverAddr, err = sntnl.MasterAddr()
+	return func(serverAddr string, dialOpts ...redis.DialOption) (*redis.Pool, error) {
+		pool := &redis.Pool{
+			MaxIdle:     maxIdle,
+			MaxActive:   poolSize,
+			Wait:        true,
+			IdleTimeout: conf.IdleTimeout,
+			Dial: func() (redis.Conn, error) {
+				var err error
+				if useSentinel {
+					serverAddr, err = sntnl.MasterAddr()
+					if err != nil {
+						return nil, err
+					}
+					lastMu.Lock()
+					if serverAddr != lastMaster {
+						n.Log(NewLogEntry(LogLevelInfo, "Redis master discovered", map[string]interface{}{"addr": serverAddr}))
+						lastMaster = serverAddr
+					}
+					lastMu.Unlock()
+				}
+
+				c, err := redis.Dial("tcp", serverAddr, dialOpts...)
+				if err != nil {
+					n.Log(NewLogEntry(LogLevelError, "error dialing to Redis", map[string]interface{}{"error": err.Error()}))
+					return nil, err
+				}
+
+				if password != "" {
+					if _, err := c.Do("AUTH", password); err != nil {
+						c.Close()
+						n.Log(NewLogEntry(LogLevelError, "error auth in Redis", map[string]interface{}{"error": err.Error()}))
+						return nil, err
+					}
+				}
+
+				if db != 0 {
+					if _, err := c.Do("SELECT", db); err != nil {
+						c.Close()
+						n.Log(NewLogEntry(LogLevelError, "error selecting Redis db", map[string]interface{}{"error": err.Error()}))
+						return nil, err
+					}
+				}
+
+				err = s.addPresenceScript.Load(c)
 				if err != nil {
 					return nil, err
 				}
-				lastMu.Lock()
-				if serverAddr != lastMaster {
-					n.Log(NewLogEntry(LogLevelInfo, "Redis master discovered", map[string]interface{}{"addr": serverAddr}))
-					lastMaster = serverAddr
-				}
-				lastMu.Unlock()
-			}
-
-			var readTimeout = defaultReadTimeout
-			if conf.ReadTimeout != 0 {
-				readTimeout = conf.ReadTimeout
-			}
-			var writeTimeout = defaultWriteTimeout
-			if conf.WriteTimeout != 0 {
-				writeTimeout = conf.WriteTimeout
-			}
-			var connectTimeout = defaultConnectTimeout
-			if conf.ConnectTimeout != 0 {
-				connectTimeout = conf.ConnectTimeout
-			}
-
-			opts := []redis.DialOption{
-				redis.DialConnectTimeout(connectTimeout),
-				redis.DialReadTimeout(readTimeout),
-				redis.DialWriteTimeout(writeTimeout),
-			}
-			if conf.UseTLS {
-				opts = append(opts, redis.DialUseTLS(true))
-				if conf.TLSConfig != nil {
-					opts = append(opts, redis.DialTLSConfig(conf.TLSConfig))
-				}
-				if conf.TLSSkipVerify {
-					opts = append(opts, redis.DialTLSSkipVerify(true))
-				}
-			}
-			c, err := redis.Dial("tcp", serverAddr, opts...)
-			if err != nil {
-				n.Log(NewLogEntry(LogLevelError, "error dialing to Redis", map[string]interface{}{"error": err.Error()}))
-				return nil, err
-			}
-
-			if password != "" {
-				if _, err := c.Do("AUTH", password); err != nil {
-					c.Close()
-					n.Log(NewLogEntry(LogLevelError, "error auth in Redis", map[string]interface{}{"error": err.Error()}))
+				err = s.presenceScript.Load(c)
+				if err != nil {
 					return nil, err
 				}
-			}
-
-			if db != 0 {
-				if _, err := c.Do("SELECT", db); err != nil {
-					c.Close()
-					n.Log(NewLogEntry(LogLevelError, "error selecting Redis db", map[string]interface{}{"error": err.Error()}))
+				err = s.remPresenceScript.Load(c)
+				if err != nil {
 					return nil, err
 				}
-			}
-
-			return c, err
-		},
-		TestOnBorrow: func(c redis.Conn, t time.Time) error {
-			if useSentinel {
-				if !sentinel.TestRole(c, "master") {
-					return errors.New("failed master role check")
+				err = s.historyScript.Load(c)
+				if err != nil {
+					return nil, err
 				}
-				return nil
-			}
-			_, err := c.Do("PING")
-			return err
-		},
+				err = s.addHistoryScript.Load(c)
+				if err != nil {
+					return nil, err
+				}
+				return c, err
+			},
+			TestOnBorrow: func(c redis.Conn, t time.Time) error {
+				if useSentinel {
+					if !sentinel.TestRole(c, "master") {
+						return errors.New("failed master role check")
+					}
+					return nil
+				}
+				_, err := c.Do("PING")
+				return err
+			},
+		}
+		return pool, nil
 	}
+}
+
+func getDialOpts(conf RedisShardConfig) []redis.DialOption {
+	var readTimeout = defaultReadTimeout
+	if conf.ReadTimeout != 0 {
+		readTimeout = conf.ReadTimeout
+	}
+	var writeTimeout = defaultWriteTimeout
+	if conf.WriteTimeout != 0 {
+		writeTimeout = conf.WriteTimeout
+	}
+	var connectTimeout = defaultConnectTimeout
+	if conf.ConnectTimeout != 0 {
+		connectTimeout = conf.ConnectTimeout
+	}
+
+	dialOpts := []redis.DialOption{
+		redis.DialConnectTimeout(connectTimeout),
+		redis.DialReadTimeout(readTimeout),
+		redis.DialWriteTimeout(writeTimeout),
+	}
+	if conf.UseTLS {
+		dialOpts = append(dialOpts, redis.DialUseTLS(true))
+		if conf.TLSConfig != nil {
+			dialOpts = append(dialOpts, redis.DialTLSConfig(conf.TLSConfig))
+		}
+		if conf.TLSSkipVerify {
+			dialOpts = append(dialOpts, redis.DialTLSSkipVerify(true))
+		}
+	}
+	return dialOpts
+}
+
+func newPool(s *shard, n *Node, conf RedisShardConfig) (redisConnPool, error) {
+	host := conf.Host
+	port := conf.Port
+	password := conf.Password
+	db := conf.DB
+
+	useSentinel := conf.MasterName != "" && len(conf.SentinelAddrs) > 0
+	usingPassword := password != ""
+
+	factory := poolFactory(s, n, conf)
+
+	if len(conf.ClusterAddrs) == 0 {
+		// Cluster not used.
+		serverAddr := net.JoinHostPort(host, strconv.Itoa(port))
+		if !useSentinel {
+			n.Log(NewLogEntry(LogLevelInfo, fmt.Sprintf("Redis: %s/%d, using password: %v", serverAddr, db, usingPassword)))
+		} else {
+			n.Log(NewLogEntry(LogLevelInfo, fmt.Sprintf("Redis: Sentinel for name: %s, db: %d, using password: %v", conf.MasterName, db, usingPassword)))
+		}
+		pool, _ := factory(serverAddr, getDialOpts(conf)...)
+		return pool, nil
+	}
+	// OK, we should work with cluster.
+	n.Log(NewLogEntry(LogLevelInfo, fmt.Sprintf("Redis: cluster addrs: %+v, using password: %v", conf.ClusterAddrs, usingPassword)))
+	cluster := &redisc.Cluster{
+		DialOptions:  getDialOpts(conf),
+		StartupNodes: conf.ClusterAddrs,
+		CreatePool:   factory,
+	}
+	// Initialize cluster mapping.
+	if err := cluster.Refresh(); err != nil {
+		return nil, err
+	}
+	return cluster, nil
 }
 
 // NewRedisEngine initializes Redis Engine.
@@ -584,25 +649,39 @@ func newShard(n *Node, conf RedisShardConfig) (*shard, error) {
 	shard := &shard{
 		node:              n,
 		config:            conf,
-		pool:              newPool(n, conf),
 		addPresenceScript: redis.NewScript(2, addPresenceSource),
 		remPresenceScript: redis.NewScript(2, remPresenceSource),
 		presenceScript:    redis.NewScript(2, presenceSource),
 		historyScript:     redis.NewScript(2, historySource),
 		addHistoryScript:  redis.NewScript(2, addHistorySource),
 	}
+	pool, err := newPool(shard, n, conf)
+	if err != nil {
+		return nil, err
+	}
+	shard.pool = pool
 	shard.pubCh = make(chan pubRequest)
 	shard.subCh = make(chan subRequest)
 	shard.dataCh = make(chan dataRequest)
 	shard.messagePrefix = conf.Prefix + redisClientChannelPrefix
-	go shard.runForever(func() {
-		shard.runDataPipeline()
-	})
+
+	for i := 0; i < redisNumDataPipelineWorkers; i++ {
+		if len(shard.config.ClusterAddrs) != 0 {
+			go shard.runForever(func() {
+				shard.runClusterDataPipeline()
+			})
+		} else {
+			go shard.runForever(func() {
+				shard.runDataPipeline()
+			})
+		}
+	}
+
 	return shard, nil
 }
 
-func (s *shard) messageChannelID(ch string) channelID {
-	return channelID(s.messagePrefix + ch)
+func (s *shard) useCluster() bool {
+	return len(s.config.ClusterAddrs) != 0
 }
 
 func (s *shard) controlChannelID() channelID {
@@ -613,19 +692,38 @@ func (s *shard) pingChannelID() channelID {
 	return channelID(s.config.Prefix + redisPingChannelSuffix)
 }
 
+func (s *shard) messageChannelID(ch string) channelID {
+	if s.useCluster() {
+		ch = "{" + ch + "}"
+	}
+	return channelID(s.messagePrefix + ch)
+}
+
 func (s *shard) presenceHashKey(ch string) channelID {
+	if s.useCluster() {
+		ch = "{" + ch + "}"
+	}
 	return channelID(s.config.Prefix + ".presence.data." + ch)
 }
 
 func (s *shard) presenceSetKey(ch string) channelID {
+	if s.useCluster() {
+		ch = "{" + ch + "}"
+	}
 	return channelID(s.config.Prefix + ".presence.expire." + ch)
 }
 
 func (s *shard) historyListKey(ch string) channelID {
+	if s.useCluster() {
+		ch = "{" + ch + "}"
+	}
 	return channelID(s.config.Prefix + ".history.list." + ch)
 }
 
 func (s *shard) sequenceMetaKey(ch string) channelID {
+	if s.useCluster() {
+		ch = "{" + ch + "}"
+	}
 	return channelID(s.config.Prefix + ".seq.meta." + ch)
 }
 
@@ -1035,51 +1133,90 @@ func (dr *dataRequest) result() *dataResponse {
 	return <-dr.resp
 }
 
-func (s *shard) runDataPipeline() {
-
+func (s *shard) processClusterDataRequest(dr dataRequest) (interface{}, error) {
 	conn := s.pool.Get()
+	defer conn.Close()
 
-	err := s.addPresenceScript.Load(conn)
+	var err error
+
+	// Handle redirections automatically.
+	conn, err = redisc.RetryConn(conn, 3, 100*time.Millisecond)
 	if err != nil {
-		s.node.Log(NewLogEntry(LogLevelError, "error loading add presence Lua", map[string]interface{}{"error": err.Error()}))
-		// Can not proceed if script has not been loaded.
-		conn.Close()
-		return
+		return nil, err
 	}
 
-	err = s.presenceScript.Load(conn)
-	if err != nil {
-		s.node.Log(NewLogEntry(LogLevelError, "error loading presence Lua", map[string]interface{}{"error": err.Error()}))
-		// Can not proceed if script has not been loaded.
-		conn.Close()
-		return
-	}
+	var reply interface{}
 
-	err = s.remPresenceScript.Load(conn)
-	if err != nil {
-		s.node.Log(NewLogEntry(LogLevelError, "error loading remove presence Lua", map[string]interface{}{"error": err.Error()}))
-		// Can not proceed if script has not been loaded.
-		conn.Close()
-		return
+	switch dr.op {
+	case dataOpAddPresence:
+		reply, err = s.addPresenceScript.Do(conn, dr.args...)
+	case dataOpRemovePresence:
+		reply, err = s.remPresenceScript.Do(conn, dr.args...)
+	case dataOpPresence:
+		reply, err = s.presenceScript.Do(conn, dr.args...)
+	case dataOpHistory:
+		reply, err = s.historyScript.Do(conn, dr.args...)
+	case dataOpAddHistory:
+		reply, err = s.addHistoryScript.Do(conn, dr.args...)
+	case dataOpHistoryRemove:
+		reply, err = conn.Do("DEL", dr.args...)
+	case dataOpChannels:
+		reply, err = conn.Do("PUBSUB", dr.args...)
 	}
+	return reply, err
+}
 
-	err = s.historyScript.Load(conn)
-	if err != nil {
-		s.node.Log(NewLogEntry(LogLevelError, "error loading history Lua", map[string]interface{}{"error": err.Error()}))
-		// Can not proceed if script has not been loaded.
-		conn.Close()
-		return
+func (s *shard) runClusterDataPipeline() {
+	for dr := range s.dataCh {
+		reply, err := s.processClusterDataRequest(dr)
+		dr.done(reply, err)
 	}
+}
 
-	err = s.addHistoryScript.Load(conn)
-	if err != nil {
-		s.node.Log(NewLogEntry(LogLevelError, "error loading add history Lua", map[string]interface{}{"error": err.Error()}))
-		// Can not proceed if script has not been loaded.
-		conn.Close()
-		return
-	}
+func (s *shard) runDataPipeline() {
+	// conn := s.pool.Get()
 
-	conn.Close()
+	// err := s.addPresenceScript.Load(conn)
+	// if err != nil {
+	// 	s.node.Log(NewLogEntry(LogLevelError, "error loading add presence Lua", map[string]interface{}{"error": err.Error()}))
+	// 	// Can not proceed if script has not been loaded.
+	// 	conn.Close()
+	// 	return
+	// }
+
+	// err = s.presenceScript.Load(conn)
+	// if err != nil {
+	// 	s.node.Log(NewLogEntry(LogLevelError, "error loading presence Lua", map[string]interface{}{"error": err.Error()}))
+	// 	// Can not proceed if script has not been loaded.
+	// 	conn.Close()
+	// 	return
+	// }
+
+	// err = s.remPresenceScript.Load(conn)
+	// if err != nil {
+	// 	s.node.Log(NewLogEntry(LogLevelError, "error loading remove presence Lua", map[string]interface{}{"error": err.Error()}))
+	// 	// Can not proceed if script has not been loaded.
+	// 	conn.Close()
+	// 	return
+	// }
+
+	// err = s.historyScript.Load(conn)
+	// if err != nil {
+	// 	s.node.Log(NewLogEntry(LogLevelError, "error loading history Lua", map[string]interface{}{"error": err.Error()}))
+	// 	// Can not proceed if script has not been loaded.
+	// 	conn.Close()
+	// 	return
+	// }
+
+	// err = s.addHistoryScript.Load(conn)
+	// if err != nil {
+	// 	s.node.Log(NewLogEntry(LogLevelError, "error loading add history Lua", map[string]interface{}{"error": err.Error()}))
+	// 	// Can not proceed if script has not been loaded.
+	// 	conn.Close()
+	// 	return
+	// }
+
+	// conn.Close()
 
 	var drs []dataRequest
 

--- a/engine_redis_test.go
+++ b/engine_redis_test.go
@@ -100,8 +100,6 @@ func TestRedisEngine(t *testing.T) {
 
 	e := newTestRedisEngine()
 
-	assert.Equal(t, e.name(), "Redis")
-
 	_, err := e.Channels()
 	assert.NoError(t, err)
 

--- a/engine_redis_test.go
+++ b/engine_redis_test.go
@@ -4,10 +4,8 @@ package centrifuge
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/rand"
-	"net"
 	"strconv"
 	"sync"
 	"testing"
@@ -15,7 +13,7 @@ import (
 
 	"github.com/centrifugal/protocol"
 	"github.com/gomodule/redigo/redis"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testRedisConn struct {
@@ -30,64 +28,35 @@ const (
 	testRedisURL      = "redis://:@127.0.0.1:6379/9"
 )
 
-func (t testRedisConn) close() error {
-	_, err := t.Conn.Do("SELECT", testRedisDB)
-	if err != nil {
-		return nil
-	}
-	_, err = t.Conn.Do("FLUSHDB")
-	if err != nil {
-		return err
-	}
-	return t.Conn.Close()
+func getUniquePrefix() string {
+	return "centrifuge-test-" + randString(3) + "-" + strconv.FormatInt(time.Now().UnixNano(), 10)
 }
 
-// Get connection to Redis, select database and if that database not empty
-// then panic to prevent existing data corruption.
-func dial(t *testing.T) testRedisConn {
-	addr := net.JoinHostPort(testRedisHost, strconv.Itoa(testRedisPort))
-	c, err := redis.DialTimeout("tcp", addr, 0, 1*time.Second, 1*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = c.Do("SELECT", testRedisDB)
-	if err != nil {
-		c.Close()
-		t.Fatal(err)
-	}
-
-	n, err := redis.Int(c.Do("DBSIZE"))
-	if err != nil {
-		c.Close()
-		t.Fatal(err)
-	}
-
-	if n != 0 {
-		c.Close()
-		t.Fatal(errors.New("database is not empty, test can not continue"))
-	}
-
-	return testRedisConn{c}
+func newTestRedisEngine(tb testing.TB) *RedisEngine {
+	return NewTestRedisEngineWithPrefix(tb, getUniquePrefix())
 }
 
-func newTestRedisEngine() *RedisEngine {
-	return NewTestRedisEngineWithPrefix("centrifuge-test")
-}
-
-func NewTestRedisEngineWithPrefix(prefix string) *RedisEngine {
+func NewTestRedisEngineWithPrefix(tb testing.TB, prefix string) *RedisEngine {
 	n, _ := New(Config{})
 	redisConf := RedisShardConfig{
+		// TODO: ideally we need separate tests for Redis Cluster.
+		// ClusterAddrs: []string{"localhost:30001", "localhost:30002", "localhost:30003"},
 		Host:        testRedisHost,
 		Port:        testRedisPort,
-		Password:    testRedisPassword,
 		DB:          testRedisDB,
+		Password:    testRedisPassword,
 		Prefix:      prefix,
 		ReadTimeout: 100 * time.Second,
 	}
-	e, _ := NewRedisEngine(n, RedisEngineConfig{SequenceTTL: 300 * time.Second, Shards: []RedisShardConfig{redisConf}})
+	e, err := NewRedisEngine(n, RedisEngineConfig{
+		SequenceTTL: 300 * time.Second,
+		Shards:      []RedisShardConfig{redisConf},
+	})
+	if err != nil {
+		tb.Fatal(err)
+	}
 	n.SetEngine(e)
-	err := n.Run()
+	err = n.Run()
 	if err != nil {
 		panic(err)
 	}
@@ -95,203 +64,200 @@ func NewTestRedisEngineWithPrefix(prefix string) *RedisEngine {
 }
 
 func TestRedisEngine(t *testing.T) {
-	c := dial(t)
-	defer c.close()
-
-	e := newTestRedisEngine()
+	e := newTestRedisEngine(t)
 
 	_, err := e.Channels()
-	assert.NoError(t, err)
+	if e.shards[0].useCluster() {
+		require.Error(t, err)
+	} else {
+		require.NoError(t, err)
+	}
 
 	pub := newTestPublication()
 
-	assert.NoError(t, e.Publish("channel", pub, nil))
-	assert.NoError(t, e.Publish("channel", pub, nil))
-	assert.NoError(t, e.Subscribe("channel"))
-	assert.NoError(t, e.Unsubscribe("channel"))
+	require.NoError(t, e.Publish("channel", pub, nil))
+	require.NoError(t, e.Publish("channel", pub, nil))
+	require.NoError(t, e.Subscribe("channel"))
+	require.NoError(t, e.Unsubscribe("channel"))
 
 	// test adding presence
-	assert.NoError(t, e.AddPresence("channel", "uid", &ClientInfo{}, 25*time.Second))
+	require.NoError(t, e.AddPresence("channel", "uid", &ClientInfo{}, 25*time.Second))
 
 	p, err := e.Presence("channel")
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(p))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(p))
 
 	err = e.RemovePresence("channel", "uid")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	rawData := Raw([]byte("{}"))
 	pub = &Publication{UID: "test UID", Data: rawData}
 
 	// test adding history
 	_, err = e.AddHistory("channel", pub, &ChannelOptions{HistorySize: 4, HistoryLifetime: 1})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	h, _, err := e.History("channel", HistoryFilter{
 		Limit: -1,
 	})
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(h))
-	assert.Equal(t, h[0].UID, "test UID")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(h))
+	require.Equal(t, h[0].UID, "test UID")
 
 	// test history limit
 	_, err = e.AddHistory("channel", pub, &ChannelOptions{HistorySize: 4, HistoryLifetime: 1})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = e.AddHistory("channel", pub, &ChannelOptions{HistorySize: 4, HistoryLifetime: 1})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = e.AddHistory("channel", pub, &ChannelOptions{HistorySize: 4, HistoryLifetime: 1})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	h, _, err = e.History("channel", HistoryFilter{
 		Limit: 2,
 	})
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(h))
+	require.NoError(t, err)
+	require.Equal(t, 2, len(h))
 
 	// test history limit greater than history size
 	_, err = e.AddHistory("channel", pub, &ChannelOptions{HistorySize: 1, HistoryLifetime: 1})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = e.AddHistory("channel", pub, &ChannelOptions{HistorySize: 1, HistoryLifetime: 1})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = e.AddHistory("channel", pub, &ChannelOptions{HistorySize: 1, HistoryLifetime: 1})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// ask all history.
 	h, _, err = e.History("channel", HistoryFilter{
 		Limit: -1,
 	})
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(h))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(h))
 
 	// ask more history than history_size.
 	h, _, err = e.History("channel", HistoryFilter{
 		Limit: 2,
 	})
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(h))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(h))
 
 	// test publishing control message.
 	err = e.PublishControl([]byte(""))
-	assert.NoError(t, nil, err)
+	require.NoError(t, nil, err)
 
 	// test publishing join message.
 	joinMessage := Join{}
-	assert.NoError(t, e.PublishJoin("channel", &joinMessage, nil))
+	require.NoError(t, e.PublishJoin("channel", &joinMessage, nil))
 
 	// test publishing leave message.
 	leaveMessage := Leave{}
-	assert.NoError(t, e.PublishLeave("channel", &leaveMessage, nil))
+	require.NoError(t, e.PublishLeave("channel", &leaveMessage, nil))
 }
 
 func TestRedisCurrentPosition(t *testing.T) {
-	c := dial(t)
-	defer c.close()
-	e := newTestRedisEngine()
+	e := newTestRedisEngine(t)
 
 	channel := "test-current-position"
 
 	_, recoveryPosition, err := e.History(channel, HistoryFilter{
 		Limit: 0,
 	})
-	assert.NoError(t, err)
-	assert.Equal(t, uint32(0), recoveryPosition.Seq)
-	assert.Equal(t, uint32(0), recoveryPosition.Gen)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), recoveryPosition.Seq)
+	require.Equal(t, uint32(0), recoveryPosition.Gen)
 
 	pub := &Publication{Data: Raw([]byte("{}"))}
 	_, err = e.AddHistory(channel, pub, &ChannelOptions{HistorySize: 10, HistoryLifetime: 2})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, recoveryPosition, err = e.History(channel, HistoryFilter{
 		Limit: 0,
 	})
-	assert.NoError(t, err)
-	assert.Equal(t, uint32(1), recoveryPosition.Seq)
-	assert.Equal(t, uint32(0), recoveryPosition.Gen)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), recoveryPosition.Seq)
+	require.Equal(t, uint32(0), recoveryPosition.Gen)
 }
 
 func TestRedisEngineRecover(t *testing.T) {
-
-	c := dial(t)
-	defer c.close()
-
-	e := newTestRedisEngine()
+	e := newTestRedisEngine(t)
 
 	rawData := Raw([]byte("{}"))
 	pub := &Publication{Data: rawData}
 
 	pub.UID = "1"
 	_, err := e.AddHistory("channel", pub, &ChannelOptions{HistorySize: 10, HistoryLifetime: 2})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	pub.UID = "2"
 	_, err = e.AddHistory("channel", pub, &ChannelOptions{HistorySize: 10, HistoryLifetime: 2})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	pub.UID = "3"
 	_, err = e.AddHistory("channel", pub, &ChannelOptions{HistorySize: 10, HistoryLifetime: 2})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	pub.UID = "4"
 	_, err = e.AddHistory("channel", pub, &ChannelOptions{HistorySize: 10, HistoryLifetime: 2})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	pub.UID = "5"
 	_, err = e.AddHistory("channel", pub, &ChannelOptions{HistorySize: 10, HistoryLifetime: 2})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, r, err := e.History("channel", HistoryFilter{
 		Limit: 0,
 		Since: nil,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	pubs, _, err := e.History("channel", HistoryFilter{
 		Limit: -1,
 		Since: &RecoveryPosition{Seq: 2, Gen: 0, Epoch: r.Epoch},
 	})
-	assert.NoError(t, err)
-	assert.Equal(t, 3, len(pubs))
-	assert.Equal(t, uint32(3), pubs[0].Seq)
-	assert.Equal(t, uint32(4), pubs[1].Seq)
-	assert.Equal(t, uint32(5), pubs[2].Seq)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(pubs))
+	require.Equal(t, uint32(3), pubs[0].Seq)
+	require.Equal(t, uint32(4), pubs[1].Seq)
+	require.Equal(t, uint32(5), pubs[2].Seq)
 
 	pubs, _, err = e.History("channel", HistoryFilter{
 		Limit: -1,
 		Since: &RecoveryPosition{Seq: 6, Gen: 0, Epoch: r.Epoch},
 	})
-	assert.NoError(t, err)
-	assert.Equal(t, 5, len(pubs))
+	require.NoError(t, err)
+	require.Equal(t, 5, len(pubs))
 
-	assert.NoError(t, e.RemoveHistory("channel"))
+	require.NoError(t, e.RemoveHistory("channel"))
 	pubs, _, err = e.History("channel", HistoryFilter{
 		Limit: -1,
 		Since: &RecoveryPosition{Seq: 2, Gen: 0, Epoch: r.Epoch},
 	})
-	assert.NoError(t, err)
-	assert.Equal(t, 0, len(pubs))
+	require.NoError(t, err)
+	require.Equal(t, 0, len(pubs))
 }
 
 func TestRedisEngineSubscribeUnsubscribe(t *testing.T) {
-	c := dial(t)
-	defer c.close()
-
 	// Custom prefix to not collide with other tests.
-	e := NewTestRedisEngineWithPrefix("TestRedisEngineSubscribeUnsubscribe")
+	e := NewTestRedisEngineWithPrefix(t, getUniquePrefix())
 
-	e.Subscribe("1-test")
-	e.Subscribe("1-test")
+	if e.shards[0].useCluster() {
+		t.Skip("Channels command is not supported when Redis Cluster is used")
+	}
+
+	require.NoError(t, e.Subscribe("1-test"))
+	require.NoError(t, e.Subscribe("1-test"))
 	channels, err := e.Channels()
-	assert.Equal(t, nil, err)
+	require.NoError(t, err)
 	if len(channels) != 1 {
 		// Redis PUBSUB CHANNELS command looks like eventual consistent, so sometimes
 		// it returns wrong results, sleeping for a while helps in such situations.
 		// See https://gist.github.com/FZambia/80a5241e06b4662f7fe89cfaf24072c3
 		time.Sleep(500 * time.Millisecond)
-		channels, _ := e.Channels()
-		assert.Equal(t, 1, len(channels), fmt.Sprintf("%#v", channels))
+		channels, err := e.Channels()
+		require.NoError(t, err)
+		require.Equal(t, 1, len(channels), fmt.Sprintf("%#v", channels))
 	}
 
-	e.Unsubscribe("1-test")
+	require.NoError(t, e.Unsubscribe("1-test"))
 	channels, err = e.Channels()
-	assert.Equal(t, nil, err)
+	require.NoError(t, err)
 	if len(channels) != 0 {
 		time.Sleep(500 * time.Millisecond)
 		channels, _ := e.Channels()
-		assert.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
+		require.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
 	}
 
 	var wg sync.WaitGroup
@@ -301,18 +267,18 @@ func TestRedisEngineSubscribeUnsubscribe(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			e.Subscribe("2-test")
-			e.Unsubscribe("2-test")
+			require.NoError(t, e.Subscribe("2-test"))
+			require.NoError(t, e.Unsubscribe("2-test"))
 		}()
 	}
 	wg.Wait()
 	channels, err = e.Channels()
-	assert.Equal(t, nil, err)
+	require.NoError(t, err)
 
 	if len(channels) != 0 {
 		time.Sleep(500 * time.Millisecond)
 		channels, _ := e.Channels()
-		assert.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
+		require.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
 	}
 
 	// Different channels in parallel.
@@ -320,44 +286,46 @@ func TestRedisEngineSubscribeUnsubscribe(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			e.Subscribe("3-test-" + strconv.Itoa(i))
-			e.Unsubscribe("3-test-" + strconv.Itoa(i))
+			require.NoError(t, e.Subscribe("3-test-"+strconv.Itoa(i)))
+			require.NoError(t, e.Unsubscribe("3-test-"+strconv.Itoa(i)))
 		}(i)
 	}
 	wg.Wait()
 	channels, err = e.Channels()
-	assert.Equal(t, nil, err)
+	require.Equal(t, nil, err)
 	if len(channels) != 0 {
 		time.Sleep(500 * time.Millisecond)
-		channels, _ := e.Channels()
-		assert.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
+		channels, err := e.Channels()
+		require.NoError(t, err)
+		require.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
 	}
 
 	// The same channel sequential.
 	for i := 0; i < 10000; i++ {
-		e.Subscribe("4-test")
-		e.Unsubscribe("4-test")
+		require.NoError(t, e.Subscribe("4-test"))
+		require.NoError(t, e.Unsubscribe("4-test"))
 	}
 	channels, err = e.Channels()
-	assert.Equal(t, nil, err)
+	require.NoError(t, err)
 	if len(channels) != 0 {
 		time.Sleep(500 * time.Millisecond)
 		channels, _ := e.Channels()
-		assert.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
+		require.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
 	}
 
 	// Different channels sequential.
 	for j := 0; j < 10; j++ {
 		for i := 0; i < 10000; i++ {
-			e.Subscribe("5-test-" + strconv.Itoa(i))
-			e.Unsubscribe("5-test-" + strconv.Itoa(i))
+			require.NoError(t, e.Subscribe("5-test-"+strconv.Itoa(i)))
+			require.NoError(t, e.Unsubscribe("5-test-"+strconv.Itoa(i)))
 		}
 		channels, err = e.Channels()
-		assert.Equal(t, nil, err)
+		require.NoError(t, err)
 		if len(channels) != 0 {
 			time.Sleep(500 * time.Millisecond)
-			channels, _ := e.Channels()
-			assert.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
+			channels, err := e.Channels()
+			require.NoError(t, err)
+			require.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
 		}
 	}
 
@@ -366,16 +334,17 @@ func TestRedisEngineSubscribeUnsubscribe(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			e.Subscribe("6-test-" + strconv.Itoa(i))
+			require.NoError(t, e.Subscribe("6-test-"+strconv.Itoa(i)))
 		}(i)
 	}
 	wg.Wait()
 	channels, err = e.Channels()
-	assert.Equal(t, nil, err)
+	require.NoError(t, err)
 	if len(channels) != 100 {
 		time.Sleep(500 * time.Millisecond)
-		channels, _ := e.Channels()
-		assert.Equal(t, 100, len(channels), fmt.Sprintf("%#v", channels))
+		channels, err := e.Channels()
+		require.NoError(t, err)
+		require.Equal(t, 100, len(channels), fmt.Sprintf("%#v", channels))
 	}
 
 	// Different channels unsubscribe only in parallel.
@@ -383,40 +352,41 @@ func TestRedisEngineSubscribeUnsubscribe(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			e.Unsubscribe("6-test-" + strconv.Itoa(i))
+			require.NoError(t, e.Unsubscribe("6-test-"+strconv.Itoa(i)))
 		}(i)
 	}
 	wg.Wait()
 	channels, err = e.Channels()
-	assert.Equal(t, nil, err)
+	require.NoError(t, err)
 	if len(channels) != 0 {
 		time.Sleep(500 * time.Millisecond)
 		channels, _ := e.Channels()
-		assert.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
+		require.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
 	}
 
 	for i := 0; i < 1000; i++ {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			e.Unsubscribe("7-test-" + strconv.Itoa(i))
-			e.Unsubscribe("8-test-" + strconv.Itoa(i))
-			e.Subscribe("8-test-" + strconv.Itoa(i))
-			e.Unsubscribe("9-test-" + strconv.Itoa(i))
-			e.Subscribe("7-test-" + strconv.Itoa(i))
-			e.Unsubscribe("8-test-" + strconv.Itoa(i))
-			e.Subscribe("9-test-" + strconv.Itoa(i))
-			e.Unsubscribe("9-test-" + strconv.Itoa(i))
-			e.Unsubscribe("7-test-" + strconv.Itoa(i))
+			require.NoError(t, e.Unsubscribe("7-test-"+strconv.Itoa(i)))
+			require.NoError(t, e.Unsubscribe("8-test-"+strconv.Itoa(i)))
+			require.NoError(t, e.Subscribe("8-test-"+strconv.Itoa(i)))
+			require.NoError(t, e.Unsubscribe("9-test-"+strconv.Itoa(i)))
+			require.NoError(t, e.Subscribe("7-test-"+strconv.Itoa(i)))
+			require.NoError(t, e.Unsubscribe("8-test-"+strconv.Itoa(i)))
+			require.NoError(t, e.Subscribe("9-test-"+strconv.Itoa(i)))
+			require.NoError(t, e.Unsubscribe("9-test-"+strconv.Itoa(i)))
+			require.NoError(t, e.Unsubscribe("7-test-"+strconv.Itoa(i)))
 		}(i)
 	}
 	wg.Wait()
 	channels, err = e.Channels()
-	assert.Equal(t, nil, err)
+	require.NoError(t, err)
 	if len(channels) != 0 {
 		time.Sleep(500 * time.Millisecond)
-		channels, _ := e.Channels()
-		assert.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
+		channels, err := e.Channels()
+		require.NoError(t, err)
+		require.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
 	}
 }
 
@@ -430,12 +400,12 @@ func randString(n int) string {
 	return string(b)
 }
 
-// TestConsistentIndex exists to test consistent hashing algorithm we use.
-// As we use random in this test we carefully do asserts here.
+// TestRedisConsistentIndex exists to test consistent hashing algorithm we use.
+// As we use random in this test we carefully do requires here.
 // At least it can protect us from stupid mistakes to certain degree.
 // We just expect +-equal distribution and keeping most of chans on
 // the same shard after resharding.
-func TestConsistentIndex(t *testing.T) {
+func TestRedisConsistentIndex(t *testing.T) {
 
 	rand.Seed(time.Now().UnixNano())
 	numChans := 10000
@@ -478,27 +448,27 @@ func TestConsistentIndex(t *testing.T) {
 	}
 	sameFraction := float64(sameShards) * 100 / float64(len(chans))
 	fmt.Printf("Same shards after resharding: %f%%\n", sameFraction)
-	assert.True(t, sameFraction > 0.7)
+	require.True(t, sameFraction > 0.7)
 }
 
-func TestExtractPushData(t *testing.T) {
+func TestRedisExtractPushData(t *testing.T) {
 	data := []byte(`__16901__\x12\nchat:index\x1aU\"\x0e{\"input\":\"__\"}*C\n\x0242\x12$37cb00a9-bcfa-4284-a1ae-607c7da3a8f4\x1a\x15{\"name\": \"Alexander\"}\"\x00`)
 	pushData, seq, gen := extractPushData(data)
-	assert.Equal(t, uint32(16901), seq)
-	assert.Equal(t, uint32(0), gen)
-	assert.Equal(t, []byte(`\x12\nchat:index\x1aU\"\x0e{\"input\":\"__\"}*C\n\x0242\x12$37cb00a9-bcfa-4284-a1ae-607c7da3a8f4\x1a\x15{\"name\": \"Alexander\"}\"\x00`), pushData)
+	require.Equal(t, uint32(16901), seq)
+	require.Equal(t, uint32(0), gen)
+	require.Equal(t, []byte(`\x12\nchat:index\x1aU\"\x0e{\"input\":\"__\"}*C\n\x0242\x12$37cb00a9-bcfa-4284-a1ae-607c7da3a8f4\x1a\x15{\"name\": \"Alexander\"}\"\x00`), pushData)
 
 	data = []byte(`\x12\nchat:index\x1aU\"\x0e{\"input\":\"__\"}*C\n\x0242\x12$37cb00a9-bcfa-4284-a1ae-607c7da3a8f4\x1a\x15{\"name\": \"Alexander\"}\"\x00`)
 	pushData, seq, gen = extractPushData(data)
-	assert.Equal(t, uint32(0), seq)
-	assert.Equal(t, uint32(0), gen)
-	assert.Equal(t, []byte(`\x12\nchat:index\x1aU\"\x0e{\"input\":\"__\"}*C\n\x0242\x12$37cb00a9-bcfa-4284-a1ae-607c7da3a8f4\x1a\x15{\"name\": \"Alexander\"}\"\x00`), pushData)
+	require.Equal(t, uint32(0), seq)
+	require.Equal(t, uint32(0), gen)
+	require.Equal(t, []byte(`\x12\nchat:index\x1aU\"\x0e{\"input\":\"__\"}*C\n\x0242\x12$37cb00a9-bcfa-4284-a1ae-607c7da3a8f4\x1a\x15{\"name\": \"Alexander\"}\"\x00`), pushData)
 
 	data = []byte(`__4294967337__\x12\nchat:index\x1aU\"\x0e{\"input\":\"__\"}*C\n\x0242\x12$37cb00a9-bcfa-4284-a1ae-607c7da3a8f4\x1a\x15{\"name\": \"Alexander\"}\"\x00`)
 	pushData, seq, gen = extractPushData(data)
-	assert.Equal(t, uint32(41), seq)
-	assert.Equal(t, uint32(1), gen)
-	assert.Equal(t, []byte(`\x12\nchat:index\x1aU\"\x0e{\"input\":\"__\"}*C\n\x0242\x12$37cb00a9-bcfa-4284-a1ae-607c7da3a8f4\x1a\x15{\"name\": \"Alexander\"}\"\x00`), pushData)
+	require.Equal(t, uint32(41), seq)
+	require.Equal(t, uint32(1), gen)
+	require.Equal(t, []byte(`\x12\nchat:index\x1aU\"\x0e{\"input\":\"__\"}*C\n\x0242\x12$37cb00a9-bcfa-4284-a1ae-607c7da3a8f4\x1a\x15{\"name\": \"Alexander\"}\"\x00`), pushData)
 }
 
 func BenchmarkRedisEngineConsistentIndex(b *testing.B) {
@@ -513,8 +483,8 @@ func BenchmarkRedisEngineIndex(b *testing.B) {
 	}
 }
 
-func BenchmarkRedisEnginePublish(b *testing.B) {
-	e := newTestRedisEngine()
+func BenchmarkRedisEnginePublish_SingleChannel(b *testing.B) {
+	e := newTestRedisEngine(b)
 	rawData := Raw([]byte(`{"bench": true}`))
 	pub := &Publication{UID: "test UID", Data: rawData}
 	b.ResetTimer()
@@ -526,8 +496,8 @@ func BenchmarkRedisEnginePublish(b *testing.B) {
 	}
 }
 
-func BenchmarkRedisEnginePublishParallel(b *testing.B) {
-	e := newTestRedisEngine()
+func BenchmarkRedisEnginePublish_SingleChannel_Parallel(b *testing.B) {
+	e := newTestRedisEngine(b)
 	rawData := Raw([]byte(`{"bench": true}`))
 	pub := &Publication{UID: "test UID", Data: rawData}
 	b.SetParallelism(128)
@@ -542,28 +512,36 @@ func BenchmarkRedisEnginePublishParallel(b *testing.B) {
 	})
 }
 
-func BenchmarkRedisEngineSubscribe(b *testing.B) {
-	e := newTestRedisEngine()
+const benchmarkNumDifferentChannels = 1000
+
+func BenchmarkRedisEnginePublish_DifferentChannels(b *testing.B) {
+	e := newTestRedisEngine(b)
+	rawData := Raw([]byte(`{"bench": true}`))
+	pub := &Publication{UID: "test UID", Data: rawData}
 	j := 0
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		channel := "channel" + strconv.Itoa(j%benchmarkNumDifferentChannels)
 		j++
-		err := e.Subscribe("subscribe" + strconv.Itoa(j))
+		err := e.Publish(channel, pub, &ChannelOptions{HistorySize: 0, HistoryLifetime: 0})
 		if err != nil {
 			panic(err)
 		}
 	}
 }
 
-func BenchmarkRedisEngineSubscribeParallel(b *testing.B) {
-	e := newTestRedisEngine()
-	i := 0
+func BenchmarkRedisEnginePublish_DifferentChannels_Parallel(b *testing.B) {
+	e := newTestRedisEngine(b)
+	rawData := Raw([]byte(`{"bench": true}`))
+	pub := &Publication{UID: "test UID", Data: rawData}
 	b.SetParallelism(128)
+	j := 0
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			i++
-			err := e.Subscribe("subscribe" + strconv.Itoa(i))
+			channel := "channel" + strconv.Itoa(j%benchmarkNumDifferentChannels)
+			j++
+			err := e.Publish(channel, pub, &ChannelOptions{HistorySize: 0, HistoryLifetime: 0})
 			if err != nil {
 				panic(err)
 			}
@@ -571,8 +549,8 @@ func BenchmarkRedisEngineSubscribeParallel(b *testing.B) {
 	})
 }
 
-func BenchmarkRedisEnginePublishWithHistory(b *testing.B) {
-	e := newTestRedisEngine()
+func BenchmarkRedisEnginePublish_WithHistory_SingleChannel(b *testing.B) {
+	e := newTestRedisEngine(b)
 	rawData := Raw([]byte(`{"bench": true}`))
 	pub := &Publication{UID: "test-uid", Data: rawData}
 	b.ResetTimer()
@@ -590,8 +568,8 @@ func BenchmarkRedisEnginePublishWithHistory(b *testing.B) {
 	}
 }
 
-func BenchmarkRedisEnginePublishWithHistoryParallel(b *testing.B) {
-	e := newTestRedisEngine()
+func BenchmarkRedisEnginePublish_WithHistory_SingleChannel_Parallel(b *testing.B) {
+	e := newTestRedisEngine(b)
 	rawData := Raw([]byte(`{"bench": true}`))
 	chOpts := &ChannelOptions{HistorySize: 100, HistoryLifetime: 100}
 	b.SetParallelism(128)
@@ -612,8 +590,84 @@ func BenchmarkRedisEnginePublishWithHistoryParallel(b *testing.B) {
 	})
 }
 
-func BenchmarkRedisEngineAddPresence(b *testing.B) {
-	e := newTestRedisEngine()
+func BenchmarkRedisEnginePublish_WithHistory_DifferentChannels(b *testing.B) {
+	e := newTestRedisEngine(b)
+	rawData := Raw([]byte(`{"bench": true}`))
+	pub := &Publication{UID: "test-uid", Data: rawData}
+	j := 0
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		j++
+		channel := "channel" + strconv.Itoa(j%benchmarkNumDifferentChannels)
+		chOpts := &ChannelOptions{HistorySize: 100, HistoryLifetime: 100}
+		var err error
+		pub, err = e.AddHistory(channel, pub, chOpts)
+		if err != nil {
+			panic(err)
+		}
+		err = e.Publish(channel, pub, chOpts)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkRedisEnginePublish_WithHistory_DifferentChannels_Parallel(b *testing.B) {
+	e := newTestRedisEngine(b)
+	rawData := Raw([]byte(`{"bench": true}`))
+	chOpts := &ChannelOptions{HistorySize: 100, HistoryLifetime: 100}
+	b.SetParallelism(128)
+	j := 0
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			j++
+			channel := "channel" + strconv.Itoa(j%benchmarkNumDifferentChannels)
+			pub := &Publication{UID: "test-uid", Data: rawData}
+			var err error
+			pub, err = e.AddHistory(channel, pub, chOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			err = e.Publish(channel, pub, chOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkRedisEngineSubscribe(b *testing.B) {
+	e := newTestRedisEngine(b)
+	j := 0
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		j++
+		err := e.Subscribe("subscribe" + strconv.Itoa(j))
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkRedisEngineSubscribe_Parallel(b *testing.B) {
+	e := newTestRedisEngine(b)
+	i := 0
+	b.SetParallelism(128)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			i++
+			err := e.Subscribe("subscribe" + strconv.Itoa(i))
+			if err != nil {
+				panic(err)
+			}
+		}
+	})
+}
+
+func BenchmarkRedisEngineAddPresence_SingleChannel(b *testing.B) {
+	e := newTestRedisEngine(b)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		err := e.AddPresence("channel", "uid", &ClientInfo{}, 300*time.Second)
@@ -623,8 +677,9 @@ func BenchmarkRedisEngineAddPresence(b *testing.B) {
 	}
 }
 
-func BenchmarkRedisEngineAddPresenceParallel(b *testing.B) {
-	e := newTestRedisEngine()
+func BenchmarkRedisEngineAddPresence_SingleChannel_Parallel(b *testing.B) {
+	e := newTestRedisEngine(b)
+	b.SetParallelism(128)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -636,8 +691,8 @@ func BenchmarkRedisEngineAddPresenceParallel(b *testing.B) {
 	})
 }
 
-func BenchmarkRedisEnginePresence(b *testing.B) {
-	e := newTestRedisEngine()
+func BenchmarkRedisEnginePresence_SingleChannel(b *testing.B) {
+	e := newTestRedisEngine(b)
 	e.AddPresence("channel", "uid", &ClientInfo{}, 300*time.Second)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -648,8 +703,9 @@ func BenchmarkRedisEnginePresence(b *testing.B) {
 	}
 }
 
-func BenchmarkRedisEnginePresenceParallel(b *testing.B) {
-	e := newTestRedisEngine()
+func BenchmarkRedisEnginePresence_SingleChannel_Parallel(b *testing.B) {
+	e := newTestRedisEngine(b)
+	b.SetParallelism(128)
 	e.AddPresence("channel", "uid", &ClientInfo{}, 300*time.Second)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -662,8 +718,41 @@ func BenchmarkRedisEnginePresenceParallel(b *testing.B) {
 	})
 }
 
-func BenchmarkRedisEngineHistory(b *testing.B) {
-	e := newTestRedisEngine()
+func BenchmarkRedisEnginePresence_DifferentChannels(b *testing.B) {
+	e := newTestRedisEngine(b)
+	e.AddPresence("channel", "uid", &ClientInfo{}, 300*time.Second)
+	j := 0
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		j++
+		channel := "channel" + strconv.Itoa(j%benchmarkNumDifferentChannels)
+		_, err := e.Presence(channel)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRedisEnginePresence_DifferentChannels_Parallel(b *testing.B) {
+	e := newTestRedisEngine(b)
+	b.SetParallelism(128)
+	e.AddPresence("channel", "uid", &ClientInfo{}, 300*time.Second)
+	j := 0
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			j++
+			channel := "channel" + strconv.Itoa(j%benchmarkNumDifferentChannels)
+			_, err := e.Presence(channel)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkRedisEngineHistory_SingleChannel(b *testing.B) {
+	e := newTestRedisEngine(b)
 	rawData := Raw([]byte("{}"))
 	pub := &Publication{UID: "test UID", Data: rawData}
 	for i := 0; i < 4; i++ {
@@ -681,8 +770,8 @@ func BenchmarkRedisEngineHistory(b *testing.B) {
 	}
 }
 
-func BenchmarkRedisEngineHistoryParallel(b *testing.B) {
-	e := newTestRedisEngine()
+func BenchmarkRedisEngineHistory_SingleChannel_Parallel(b *testing.B) {
+	e := newTestRedisEngine(b)
 	rawData := Raw([]byte("{}"))
 	pub := &Publication{UID: "test-uid", Data: rawData}
 	for i := 0; i < 4; i++ {
@@ -701,8 +790,8 @@ func BenchmarkRedisEngineHistoryParallel(b *testing.B) {
 	})
 }
 
-func BenchmarkRedisEngineHistoryRecoverParallel(b *testing.B) {
-	e := newTestRedisEngine()
+func BenchmarkRedisEngineRecover_SingleChannel_Parallel(b *testing.B) {
+	e := newTestRedisEngine(b)
 	rawData := Raw([]byte("{}"))
 	numMessages := 100
 	for i := 0; i < numMessages; i++ {
@@ -712,7 +801,7 @@ func BenchmarkRedisEngineHistoryRecoverParallel(b *testing.B) {
 	_, r, err := e.History("channel", HistoryFilter{
 		Limit: 0,
 	})
-	assert.NoError(b, err)
+	require.NoError(b, err)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -727,13 +816,13 @@ func BenchmarkRedisEngineHistoryRecoverParallel(b *testing.B) {
 	})
 }
 
-func nodeWithRedisEngine() *Node {
+func nodeWithRedisEngine(tb testing.TB) *Node {
 	c := DefaultConfig
 	n, err := New(c)
 	if err != nil {
 		panic(err)
 	}
-	e := newTestRedisEngine()
+	e := newTestRedisEngine(tb)
 	n.SetEngine(e)
 	err = n.Run()
 	if err != nil {
@@ -742,13 +831,10 @@ func nodeWithRedisEngine() *Node {
 	return n
 }
 
-func TestClientSubscribeRecoverRedis(t *testing.T) {
-	c := dial(t)
-	defer c.close()
-
+func TestRedisClientSubscribeRecover(t *testing.T) {
 	for _, tt := range recoverTests {
 		t.Run(tt.Name, func(t *testing.T) {
-			node := nodeWithRedisEngine()
+			node := nodeWithRedisEngine(t)
 
 			config := node.Config()
 			config.HistorySize = tt.HistorySize
@@ -785,12 +871,12 @@ func TestClientSubscribeRecoverRedis(t *testing.T) {
 				Gen:     recoveryPosition.Gen,
 				Epoch:   recoveryPosition.Epoch,
 			}, rw, false)
-			assert.Nil(t, subCtx.disconnect)
-			assert.NotEmpty(t, replies)
-			assert.Nil(t, replies[0].Error)
+			require.Nil(t, subCtx.disconnect)
+			require.NotEmpty(t, replies)
+			require.Nil(t, replies[0].Error)
 			res := extractSubscribeResult(replies)
-			assert.Equal(t, tt.NumRecovered, len(res.Publications))
-			assert.Equal(t, tt.Recovered, res.Recovered)
+			require.Equal(t, tt.NumRecovered, len(res.Publications))
+			require.Equal(t, tt.Recovered, res.Recovered)
 
 			node.Shutdown(context.Background())
 		})

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/gorilla/websocket v1.4.1
 	github.com/igm/sockjs-go v0.0.0-20191119074118-cd6986df5bcc
+	github.com/mna/redisc v1.1.7
 	github.com/prometheus/client_golang v0.9.2
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mna/redisc v1.1.7 h1:FdmtJsfTjoIjNXiQf4ozgNjuE+zxWH+fJSe+I/dD4vc=
+github.com/mna/redisc v1.1.7/go.mod h1:GXeOb7zyYKiT+K8MKdIiJvuv7MfhDoQGcuzfiJQmqQI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.2 h1:awm861/B8OKDd2I/6o1dy3ra4BamzKhYOiGItCeZ740=

--- a/hub_test.go
+++ b/hub_test.go
@@ -102,9 +102,7 @@ func TestHubSubscriptions(t *testing.T) {
 	h.addSub("test2", c)
 	assert.Equal(t, 2, h.NumChannels())
 	channels := []string{}
-	for _, ch := range h.Channels() {
-		channels = append(channels, ch)
-	}
+	channels = append(channels, h.Channels()...)
 	assert.True(t, stringInSlice("test1", channels))
 	assert.True(t, stringInSlice("test2", channels))
 	assert.True(t, h.NumSubscribers("test1") > 0)

--- a/node.go
+++ b/node.go
@@ -104,6 +104,9 @@ func New(c Config) (*Node, error) {
 
 // index chooses bucket number in range [0, numBuckets).
 func index(s string, numBuckets int) int {
+	if numBuckets == 1 {
+		return 0
+	}
 	hash := fnv.New64a()
 	hash.Write([]byte(s))
 	return int(hash.Sum64() % uint64(numBuckets))


### PR DESCRIPTION
The original discussion located here: https://github.com/centrifugal/centrifugo/issues/342

An example on how to shard between two different Redis clusters:

```
engine, err := centrifuge.NewRedisEngine(node, centrifuge.RedisEngineConfig{
	PublishOnHistoryAdd: true,
	// And configure a couple of shards to use.
	Shards: []centrifuge.RedisShardConfig{
		centrifuge.RedisShardConfig{
			ClusterAddrs: []string{"localhost:30001", "localhost:30002", "localhost:30003"}
		},
		centrifuge.RedisShardConfig{
			ClusterAddrs: []string{"localhost:30101", "localhost:30102", "localhost:30103"}
		},
	},
})
```