### PR TITLE
Multitenancy, approach #1

### DIFF
--- a/client.go
+++ b/client.go
@@ -106,6 +106,7 @@ type Client struct {
 	uid              string
 	user             string
 	info             []byte
+	env              string
 	publicationsOnce sync.Once
 	closed           bool
 	authenticated    bool
@@ -1151,6 +1152,7 @@ func (c *Client) connectCmd(cmd *protocol.ConnectRequest, rw *replyWriter) *Disc
 		c.user = credentials.UserID
 		c.info = credentials.Info
 		c.exp = credentials.ExpireAt
+		c.env = credentials.Env
 		c.mu.Unlock()
 	case cmd.Token != "":
 		var (
@@ -1170,6 +1172,7 @@ func (c *Client) connectCmd(cmd *protocol.ConnectRequest, rw *replyWriter) *Disc
 		c.mu.Lock()
 		c.user = token.UserID
 		c.exp = token.ExpireAt
+		c.env = token.Env
 		c.mu.Unlock()
 
 		if len(token.Info) > 0 {

--- a/config.go
+++ b/config.go
@@ -90,8 +90,9 @@ type Config struct {
 	// Only users with user ID defined will subscribe to personal channels, anonymous
 	// users are ignored.
 	UserSubscribeToPersonal bool
-	// ChannelEnvDelimiter string
-	ChannelEnvDelimiter string
+	// ChannelEnvDelimiter string. Must contain two ascii symbols. If set to "[]" then a
+	// channel with env set should look like "[env]$public:news"
+	ChannelEnvDelimiters string
 }
 
 // Validate validates config and returns error if problems found
@@ -137,6 +138,12 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("namespace for user personal channel not found: %s", personalChannelNamespace)
 	}
 
+	asciiRegexp := regexp.MustCompile("\\w+")
+
+	if c.ChannelEnvDelimiters != "" && len(c.ChannelEnvDelimiters) != 2 && !asciiRegexp.Match([]byte(c.ChannelEnvDelimiters)) {
+		return errors.New("invalid channel env delimiters")
+	}
+
 	return nil
 }
 
@@ -176,7 +183,6 @@ var DefaultConfig = Config{
 	ChannelNamespaceBoundary: ":", // so namespace "public" can be used as "public:news"
 	ChannelUserBoundary:      "#", // so user limited channel is "user#2694" where "2696" is user ID
 	ChannelUserSeparator:     ",", // so several users limited channel is "dialog#2694,3019"
-	ChannelEnvDelimiter:      "",  // so channel with env set will be like "/env/$public:news"
 
 	ClientPresencePingInterval:      25 * time.Second,
 	ClientPresenceExpireInterval:    60 * time.Second,

--- a/config.go
+++ b/config.go
@@ -90,6 +90,8 @@ type Config struct {
 	// Only users with user ID defined will subscribe to personal channels, anonymous
 	// users are ignored.
 	UserSubscribeToPersonal bool
+	// ChannelEnvDelimiter string
+	ChannelEnvDelimiter string
 }
 
 // Validate validates config and returns error if problems found
@@ -174,6 +176,7 @@ var DefaultConfig = Config{
 	ChannelNamespaceBoundary: ":", // so namespace "public" can be used as "public:news"
 	ChannelUserBoundary:      "#", // so user limited channel is "user#2694" where "2696" is user ID
 	ChannelUserSeparator:     ",", // so several users limited channel is "dialog#2694,3019"
+	ChannelEnvDelimiter:      "",  // so channel with env set will be like "/env/$public:news"
 
 	ClientPresencePingInterval:      25 * time.Second,
 	ClientPresenceExpireInterval:    60 * time.Second,

--- a/config_test.go
+++ b/config_test.go
@@ -29,6 +29,24 @@ func TestConfigValidateInvalidNamespaceName(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestConfigValidateInvalidEnvDelimiters(t *testing.T) {
+	c := DefaultConfig
+	err := c.Validate()
+	require.NoError(t, err)
+	c.ChannelEnvDelimiters = "}"
+	err = c.Validate()
+	require.Error(t, err)
+	c.ChannelEnvDelimiters = "ЬЬ"
+	err = c.Validate()
+	require.Error(t, err)
+	c.ChannelEnvDelimiters = "|||"
+	err = c.Validate()
+	require.Error(t, err)
+	c.ChannelEnvDelimiters = "{}"
+	err = c.Validate()
+	require.NoError(t, err)
+}
+
 func TestConfigValidateDuplicateNamespaceName(t *testing.T) {
 	c := DefaultConfig
 	c.Namespaces = []ChannelNamespace{

--- a/credentials.go
+++ b/credentials.go
@@ -4,6 +4,9 @@ import "context"
 
 // Credentials allows to authenticate connection when set into context.
 type Credentials struct {
+	// Env used to set connection environment. This automatically enables using
+	// environment prefix for channels.
+	Env string
 	// UserID tells library an ID of connecting user.
 	UserID string
 	// ExpireAt allows to set time in future when connection must be validated.

--- a/node.go
+++ b/node.go
@@ -905,6 +905,47 @@ func (n *Node) privateChannel(ch string) bool {
 	return strings.HasPrefix(ch, n.config.ChannelPrivatePrefix)
 }
 
+// stripEnv ...
+func (n *Node) stripEnv(ch string) (string, bool) {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	if n.config.ChannelEnvSeparator == "" {
+		return ch, false
+	}
+	if strings.HasPrefix(ch, n.config.ChannelEnvSeparator) {
+		index := strings.Index(ch[1:], n.config.ChannelEnvSeparator)
+		if index > 0 {
+			return ch[index+2:], true
+		}
+	}
+	return ch, false
+}
+
+func (n *Node) hasEnv(ch string, env string) bool {
+	if env == "" {
+		return true
+	}
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	if !strings.HasPrefix(ch, n.config.ChannelEnvSeparator) || len(ch) < len(env)+2 {
+		return false
+	}
+	return ch[0:1+len(env)] == n.config.ChannelEnvSeparator+env+n.config.ChannelEnvSeparator
+}
+
+// stripEnv ...
+func (n *Node) addEnv(ch string, env string) string {
+	if env == "" {
+		return ch
+	}
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	if n.config.ChannelEnvSeparator == "" {
+		return ch
+	}
+	return n.config.ChannelEnvSeparator + env + n.config.ChannelEnvSeparator + ch
+}
+
 // userAllowed checks if user can subscribe on channel - as channel
 // can contain special part in the end to indicate which users allowed
 // to subscribe on it.

--- a/node_test.go
+++ b/node_test.go
@@ -316,14 +316,53 @@ func BenchmarkHistory(b *testing.B) {
 	}
 
 	b.ResetTimer()
-
-	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := e.node.History(channel)
 		if err != nil {
 			b.Fatal(err)
 		}
 
+	}
+	b.StopTimer()
+	b.ReportAllocs()
+}
+
+var validEnv bool
+
+func BenchmarkHasValidEnv(b *testing.B) {
+	e := testMemoryEngine()
+	conf := e.node.Config()
+	conf.ChannelEnvDelimiters = "()"
+	err := e.node.Reload(conf)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		validEnv = e.node.hasValidEnv("(test)test", "test")
+		if !validEnv {
+			b.Fatal(err)
+		}
+
+	}
+	b.StopTimer()
+	b.ReportAllocs()
+}
+
+var strippedChannel string
+
+func BenchmarkStripEnv(b *testing.B) {
+	e := testMemoryEngine()
+	conf := e.node.Config()
+	conf.ChannelEnvDelimiters = "()"
+	err := e.node.Reload(conf)
+	require.NoError(b, err)
+	channel := "(test)test"
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		strippedChannel, _ = e.node.stripEnv(channel)
+		if strippedChannel != "test" {
+			b.Fatal("env not properly stripped")
+		}
 	}
 	b.StopTimer()
 	b.ReportAllocs()

--- a/node_test.go
+++ b/node_test.go
@@ -127,6 +127,39 @@ func TestUserAllowed(t *testing.T) {
 	require.False(t, node.userAllowed("channel#1,2", "3"))
 }
 
+func TestStripEnv(t *testing.T) {
+	node := nodeWithTestEngine()
+	defer func() { _ = node.Shutdown(context.Background()) }()
+
+	ch, found := node.stripEnv("test")
+	require.Equal(t, "test", ch)
+	require.False(t, found)
+
+	ch, found = node.stripEnv("/xxx/test")
+	require.Equal(t, "test", ch)
+	require.True(t, found)
+
+	ch, found = node.stripEnv("/xxx-test")
+	require.Equal(t, "/xxx-test", ch)
+	require.False(t, found)
+
+	ch, found = node.stripEnv("xxx/test")
+	require.Equal(t, "xxx/test", ch)
+	require.False(t, found)
+
+	ch, found = node.stripEnv("/xxx/yyy/test")
+	require.Equal(t, "yyy/test", ch)
+	require.True(t, found)
+
+	ch, found = node.stripEnv("//")
+	require.Equal(t, "//", ch)
+	require.False(t, found)
+
+	ch, found = node.stripEnv("/")
+	require.Equal(t, "/", ch)
+	require.False(t, found)
+}
+
 func TestSetConfig(t *testing.T) {
 	node := nodeWithTestEngine()
 	defer func() { _ = node.Shutdown(context.Background()) }()

--- a/token_verifier.go
+++ b/token_verifier.go
@@ -7,6 +7,9 @@ type tokenVerifier interface {
 }
 
 type connectToken struct {
+	// Env used to set connection environment. This automatically enables using
+	// environment prefix for channels.
+	Env string
 	// UserID tells library an ID of connecting user.
 	UserID string
 	// ExpireAt allows to set time in future when connection must be validated.

--- a/token_verifier_jwt.go
+++ b/token_verifier_jwt.go
@@ -34,6 +34,7 @@ var (
 )
 
 type connectTokenClaims struct {
+	Env        string          `json:"env,omitempty"`
 	Info       json.RawMessage `json:"info,omitempty"`
 	Base64Info string          `json:"b64info,omitempty"`
 	Channels   []string        `json:"channels,omitempty"`
@@ -165,6 +166,7 @@ func (verifier *tokenVerifierJWT) VerifyConnectToken(t string) (connectToken, er
 	}
 
 	ct := connectToken{
+		Env:      claims.Env,
 		UserID:   claims.StandardClaims.Subject,
 		Info:     claims.Info,
 		Channels: claims.Channels,


### PR DESCRIPTION
This is the first approach for multitenancy for different installations of the same app. Relates to #113 

There are a lot of possible ways to solve actually. This one seems the most straightforward to me at moment.

So what changed here?

1) Define option `ChannelEnvDelimiters` to sth like `[]`
2) Include `env` string as JWT claim or return in `Credentials`, for example `"env": "site_01.com"`
3) After this client will only be able to subscribe or publish to `[site_01.com]namespace:channel` - i.e. only to channels that start with its environment.
4) `[site_01.com]` won't affect namespace configuration