### PR TITLE
Refresh with custom token

### DIFF
--- a/_examples/chat_json/index.html
+++ b/_examples/chat_json/index.html
@@ -167,6 +167,7 @@
                     input.val('');
                 });
 
+                // For debug purposes only ...
                 if (getParam("disconnect") === "1") {
                     function reconnect() {
                         setTimeout(function() {
@@ -179,6 +180,7 @@
                     reconnect();
                 }
 
+                // For debug purposes only ...
                 if (getParam("publish") === "1") {
                     const publishInterval = parseInt(getParam("publishInterval")) || 1000;
                     let counter = 0;

--- a/_examples/chat_json/readme.md
+++ b/_examples/chat_json/readme.md
@@ -1,4 +1,4 @@
-Example demonstrates simple chat with JSON protocol.
+Example demonstrates a simple chat with JSON protocol.
 
 Client uses Websocket by default, but you can simply uncomment one line in `index.html` to use SockJS instead. 
 

--- a/_examples/custom_token/index.html
+++ b/_examples/custom_token/index.html
@@ -10,24 +10,7 @@
         <script type="text/javascript" src="//cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
         <script type="text/javascript" src="https://rawgit.com/centrifugal/centrifuge-js/master/dist/centrifuge.min.js"></script>
         <script type="text/javascript">
-            // helper functions to work with escaping html.
-            const tagsToReplace = {'&': '&amp;', '<': '&lt;', '>': '&gt;'};
-            function replaceTag(tag) {return tagsToReplace[tag] || tag;}
-            function safeTagsReplace(str) {return str.replace(/[&<>]/g, replaceTag);}
-
-            function getParam(name, url) {
-                if (!url) url = window.location.href;
-                name = name.replace(/[\[\]]/g, '\\$&');
-                const regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
-                    results = regex.exec(url);
-                if (!results) return null;
-                if (!results[2]) return '';
-                return decodeURIComponent(results[2].replace(/\+/g, ' '));
-            }
-
             $(function () {
-
-                const input = $("#input");
                 const container = $('#messages');
 
                 const centrifuge = new Centrifuge('ws://localhost:8000/connection/websocket', {
@@ -40,12 +23,10 @@
                 // bind listeners on centrifuge object instance events.
                 centrifuge.on('connect', function(ctx){
                     drawText('Connected with client ID ' + ctx.client);
-                    input.attr("disabled", false);
                 });
 
                 centrifuge.on('disconnect', function(ctx){
                     drawText('Disconnected: ' + ctx.reason + (ctx.reconnect?", will try to reconnect":", won't try to reconnect"));
-                    input.attr("disabled", true);
                 });
 
                 // Trigger actual connection establishing with Centrifugo server.
@@ -55,30 +36,6 @@
 
                 function drawText(text) {
                     container.prepend($('<li/>').html([(new Date()).toString(), ' ' + text].join(':')));
-                }
-
-                if (getParam("disconnect") === "1") {
-                    function reconnect() {
-                        setTimeout(function() {
-                            centrifuge.disconnect();
-                            setTimeout(function(){
-                                reconnect();
-                            }, 11000);
-                        }, 4000);
-                    }
-                    reconnect();
-                }
-
-                if (getParam("publish") === "1") {
-                    const publishInterval = parseInt(getParam("publishInterval")) || 1000;
-                    let counter = 0;
-                    setInterval(function(){
-                        sub.publish({"input": counter.toString()}).then(function() {
-                        }, function(err) {
-                            drawText("Publish error: " + JSON.stringify(err));
-                        });
-                        counter++;
-                    }, publishInterval);
                 }
             });
         </script>

--- a/_examples/custom_token/index.html
+++ b/_examples/custom_token/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title></title>
+        <style type="text/css">
+            input[type="text"] { width: 300px; }
+        </style>
+        <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+        <script type="text/javascript" src="//cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+        <script type="text/javascript" src="https://rawgit.com/centrifugal/centrifuge-js/master/dist/centrifuge.min.js"></script>
+        <script type="text/javascript">
+            // helper functions to work with escaping html.
+            const tagsToReplace = {'&': '&amp;', '<': '&lt;', '>': '&gt;'};
+            function replaceTag(tag) {return tagsToReplace[tag] || tag;}
+            function safeTagsReplace(str) {return str.replace(/[&<>]/g, replaceTag);}
+
+            function getParam(name, url) {
+                if (!url) url = window.location.href;
+                name = name.replace(/[\[\]]/g, '\\$&');
+                const regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
+                    results = regex.exec(url);
+                if (!results) return null;
+                if (!results[2]) return '';
+                return decodeURIComponent(results[2].replace(/\+/g, ' '));
+            }
+
+            $(function () {
+
+                const input = $("#input");
+                const container = $('#messages');
+
+                const centrifuge = new Centrifuge('ws://localhost:8000/connection/websocket', {
+                    onRefresh: function(ctx, cb) {
+                        cb({"status": 200, "data": {"token": "I am 12"}});
+                    }
+                });
+                centrifuge.setToken("I am 12");
+
+                // bind listeners on centrifuge object instance events.
+                centrifuge.on('connect', function(ctx){
+                    drawText('Connected with client ID ' + ctx.client);
+                    input.attr("disabled", false);
+                });
+
+                centrifuge.on('disconnect', function(ctx){
+                    drawText('Disconnected: ' + ctx.reason + (ctx.reconnect?", will try to reconnect":", won't try to reconnect"));
+                    input.attr("disabled", true);
+                });
+
+                // Trigger actual connection establishing with Centrifugo server.
+                // At this moment actual client work starts - i.e. subscriptions
+                // defined start subscribing etc.
+                centrifuge.connect();
+
+                function drawText(text) {
+                    container.prepend($('<li/>').html([(new Date()).toString(), ' ' + text].join(':')));
+                }
+
+                if (getParam("disconnect") === "1") {
+                    function reconnect() {
+                        setTimeout(function() {
+                            centrifuge.disconnect();
+                            setTimeout(function(){
+                                reconnect();
+                            }, 11000);
+                        }, 4000);
+                    }
+                    reconnect();
+                }
+
+                if (getParam("publish") === "1") {
+                    const publishInterval = parseInt(getParam("publishInterval")) || 1000;
+                    let counter = 0;
+                    setInterval(function(){
+                        sub.publish({"input": counter.toString()}).then(function() {
+                        }, function(err) {
+                            drawText("Publish error: " + JSON.stringify(err));
+                        });
+                        counter++;
+                    }, publishInterval);
+                }
+            });
+        </script>
+    </head>
+    <body>
+        <ul id="messages"></ul>
+    </body>
+</html>

--- a/_examples/custom_token/main.go
+++ b/_examples/custom_token/main.go
@@ -87,7 +87,7 @@ func main() {
 	node.On().ClientConnected(func(ctx context.Context, client *centrifuge.Client) {
 
 		client.On().Refresh(func(e centrifuge.RefreshEvent) centrifuge.RefreshReply {
-			log.Printf("user %s connection is going to expire, refreshing", client.UserID())
+			log.Printf("user %s sent refresh command with token", client.UserID())
 			if !strings.HasPrefix(e.Token, "I am ") {
 				return centrifuge.RefreshReply{
 					Disconnect: centrifuge.DisconnectInvalidToken,

--- a/_examples/custom_token/main.go
+++ b/_examples/custom_token/main.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	_ "net/http/pprof"
+
+	"github.com/centrifugal/centrifuge"
+)
+
+func handleLog(e centrifuge.LogEntry) {
+	log.Printf("%s: %v", e.Message, e.Fields)
+}
+
+func waitExitSignal(n *centrifuge.Node) {
+	sigCh := make(chan os.Signal, 1)
+	done := make(chan bool, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		n.Shutdown(context.Background())
+		done <- true
+	}()
+	<-done
+}
+
+func main() {
+	cfg := centrifuge.DefaultConfig
+
+	cfg.LogLevel = centrifuge.LogLevelInfo
+	cfg.LogHandler = handleLog
+
+	// Better to keep default in production. Here we just speeding up things a bit.
+	cfg.ClientExpiredCloseDelay = 5 * time.Second
+
+	cfg.Namespaces = []centrifuge.ChannelNamespace{
+		{
+			Name: "chat",
+			ChannelOptions: centrifuge.ChannelOptions{
+				Publish:         true,
+				Presence:        true,
+				JoinLeave:       true,
+				HistoryLifetime: 60,
+				HistorySize:     1000,
+				HistoryRecover:  true,
+			},
+		},
+	}
+
+	if err := cfg.Validate(); err != nil {
+		log.Fatal(err)
+	}
+
+	node, _ := centrifuge.New(cfg)
+
+	engine, _ := centrifuge.NewMemoryEngine(node, centrifuge.MemoryEngineConfig{
+		HistoryMetaTTL: 120 * time.Second,
+	})
+	node.SetEngine(engine)
+
+	node.On().ClientConnecting(func(ctx context.Context, t centrifuge.TransportInfo, e centrifuge.ConnectEvent) centrifuge.ConnectReply {
+		// We need to apply token parsing logic here and return connection credentials.
+		if !strings.HasPrefix(e.Token, "I am ") {
+			return centrifuge.ConnectReply{
+				Disconnect: centrifuge.DisconnectInvalidToken,
+			}
+		}
+		userID := strings.TrimPrefix(e.Token, "I am ")
+		credentials := &centrifuge.Credentials{
+			UserID:   userID,
+			ExpireAt: time.Now().Unix() + 5, // Expire in 5 seconds.
+		}
+
+		return centrifuge.ConnectReply{
+			ClientSideRefresh: true, // This is required to use client-side refresh.
+			Credentials:       credentials,
+		}
+	})
+
+	node.On().ClientConnected(func(ctx context.Context, client *centrifuge.Client) {
+
+		client.On().Refresh(func(e centrifuge.RefreshEvent) centrifuge.RefreshReply {
+			log.Printf("user %s connection is going to expire, refreshing", client.UserID())
+			if !strings.HasPrefix(e.Token, "I am ") {
+				return centrifuge.RefreshReply{
+					Disconnect: centrifuge.DisconnectInvalidToken,
+				}
+			}
+			userID := strings.TrimPrefix(e.Token, "I am ")
+			if userID != client.UserID() {
+				return centrifuge.RefreshReply{
+					Disconnect: centrifuge.DisconnectInvalidToken,
+				}
+			}
+			return centrifuge.RefreshReply{
+				ExpireAt: time.Now().Unix() + 5,
+			}
+		})
+
+		client.On().Disconnect(func(e centrifuge.DisconnectEvent) centrifuge.DisconnectReply {
+			log.Printf("user %s disconnected, disconnect: %s", client.UserID(), e.Disconnect)
+			return centrifuge.DisconnectReply{}
+		})
+
+		log.Printf("user %s connected", client.UserID())
+	})
+
+	if err := node.Run(); err != nil {
+		log.Fatal(err)
+	}
+
+	websocketHandler := centrifuge.NewWebsocketHandler(node, centrifuge.WebsocketConfig{
+		ReadBufferSize:     1024,
+		UseWriteBufferPool: true,
+	})
+	http.Handle("/connection/websocket", websocketHandler)
+	http.Handle("/", http.FileServer(http.Dir("./")))
+
+	go func() {
+		if err := http.ListenAndServe(":8000", nil); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	waitExitSignal(node)
+	log.Println("bye!")
+}

--- a/_examples/custom_token/readme.md
+++ b/_examples/custom_token/readme.md
@@ -1,0 +1,11 @@
+Example demonstrates a possibility to use your own custom token parsing logic for client-side refresh workflow.
+
+In this example we expect a string with user ID `I am <ID>` from client as token to continue working with it. **This is just an example, it's an absolutely insecure approach, never do this in production!**
+
+To start an example run the following command from example directory:
+
+```
+go run main.go
+```
+
+Then go to http://localhost:8000 to see it in action.

--- a/client.go
+++ b/client.go
@@ -811,6 +811,10 @@ func (c *Client) expire() {
 
 	if !clientSideRefresh && c.eventHub.refreshHandler != nil {
 		reply := c.eventHub.refreshHandler(RefreshEvent{})
+		if reply.Disconnect != nil {
+			_ = c.close(reply.Disconnect)
+			return
+		}
 		if reply.Expired {
 			_ = c.close(DisconnectExpired)
 			return
@@ -1480,8 +1484,7 @@ func (c *Client) Subscribe(channel string) error {
 	return c.transportEnqueue(reply)
 }
 
-// refreshCmd handle refresh command to update connection with new
-// timestamp - this is only required when connection lifetime option set.
+// refreshCmd handles refresh command from client to confirm the actual state of connection.
 func (c *Client) refreshCmd(cmd *protocol.RefreshRequest) (*clientproto.RefreshResponse, *Disconnect) {
 	resp := &clientproto.RefreshResponse{}
 
@@ -1492,42 +1495,71 @@ func (c *Client) refreshCmd(cmd *protocol.RefreshRequest) (*clientproto.RefreshR
 
 	config := c.node.Config()
 
-	var (
-		token     connectToken
-		errVerify error
-	)
-	if token, errVerify = c.node.verifyConnectToken(cmd.Token); errVerify != nil {
-		if errVerify == errTokenExpired {
-			resp.Error = ErrorTokenExpired.toProto()
-			return resp, nil
+	c.mu.RLock()
+	clientSideRefresh := c.clientSideRefresh
+	c.mu.RUnlock()
+
+	if !clientSideRefresh {
+		// Client not supposed to send refresh command in case of server-side refresh mechanism.
+		return resp, DisconnectBadRequest
+	}
+
+	var expireAt int64
+	var info []byte
+
+	if c.eventHub.refreshHandler != nil {
+		reply := c.eventHub.refreshHandler(RefreshEvent{
+			Token: cmd.Token,
+		})
+		if reply.Disconnect != nil {
+			return resp, reply.Disconnect
 		}
-		c.node.logger.log(newLogEntry(LogLevelInfo, "invalid refresh token", map[string]interface{}{"error": errVerify.Error(), "client": c.uid}))
-		return resp, DisconnectInvalidToken
+		if reply.Expired {
+			return resp, DisconnectExpired
+		}
+		expireAt = reply.ExpireAt
+		info = reply.Info
+	} else {
+		var (
+			token     connectToken
+			errVerify error
+		)
+		if token, errVerify = c.node.verifyConnectToken(cmd.Token); errVerify != nil {
+			if errVerify == errTokenExpired {
+				resp.Error = ErrorTokenExpired.toProto()
+				return resp, nil
+			}
+			c.node.logger.log(newLogEntry(LogLevelInfo, "invalid refresh token", map[string]interface{}{"error": errVerify.Error(), "client": c.uid}))
+			return resp, DisconnectInvalidToken
+		}
+		expireAt = token.ExpireAt
+		info = token.Info
 	}
 
 	res := &protocol.RefreshResult{
 		Version: config.Version,
-		Expires: token.ExpireAt > 0,
+		Expires: expireAt > 0,
 		Client:  c.uid,
 	}
 
-	if diff := token.ExpireAt - time.Now().Unix(); diff > 0 {
-		res.TTL = uint32(diff)
+	ttl := expireAt - time.Now().Unix()
+
+	if ttl > 0 {
+		res.TTL = uint32(ttl)
 	}
 
 	resp.Result = res
 
-	if token.ExpireAt > 0 {
+	if expireAt > 0 {
 		// connection check enabled
-		timeToExpire := token.ExpireAt - time.Now().Unix()
-		if timeToExpire > 0 {
+		if ttl > 0 {
 			// connection refreshed, update client timestamp and set new expiration timeout
 			c.mu.Lock()
-			c.exp = token.ExpireAt
-			if len(token.Info) > 0 {
-				c.info = token.Info
+			c.exp = expireAt
+			if len(info) > 0 {
+				c.info = info
 			}
-			duration := time.Duration(timeToExpire)*time.Second + config.ClientExpiredCloseDelay
+			duration := time.Duration(ttl)*time.Second + config.ClientExpiredCloseDelay
 			c.addExpireUpdate(duration)
 			c.mu.Unlock()
 		} else {

--- a/client.go
+++ b/client.go
@@ -1254,6 +1254,11 @@ func (c *Client) connectCmd(cmd *protocol.ConnectRequest, rw *replyWriter) *Disc
 		ttl     uint32
 	)
 
+	// Client successfully connected.
+	c.mu.Lock()
+	c.clientSideRefresh = clientSideRefresh
+	c.mu.Unlock()
+
 	switch {
 	case credentials != nil:
 		// Server-side auth.

--- a/client.go
+++ b/client.go
@@ -1254,7 +1254,6 @@ func (c *Client) connectCmd(cmd *protocol.ConnectRequest, rw *replyWriter) *Disc
 		ttl     uint32
 	)
 
-	// Client successfully connected.
 	c.mu.Lock()
 	c.clientSideRefresh = clientSideRefresh
 	c.mu.Unlock()
@@ -1344,7 +1343,6 @@ func (c *Client) connectCmd(cmd *protocol.ConnectRequest, rw *replyWriter) *Disc
 	// Client successfully connected.
 	c.mu.Lock()
 	c.authenticated = true
-	c.clientSideRefresh = clientSideRefresh
 	c.mu.Unlock()
 
 	err := c.node.addClient(c)


### PR DESCRIPTION
Allows to bypass builtin JWT token parsing when using custom token parsing logic and client-side refresh. Relates to #113 