### PR TITLE
Refactor handler contracts for more idiomatic error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,6 @@ import (
 	"github.com/centrifugal/centrifuge"
 )
 
-// Function to handle Centrifuge internal logs.
-func handleLog(e centrifuge.LogEntry) {
-	log.Printf("%s: %v", e.Message, e.Fields)
-}
-
 // Authentication middleware. Centrifuge expects Credentials with current user ID.
 // Without provided Credentials client connection won't be accepted.
 func auth(h http.Handler) http.Handler {
@@ -94,16 +89,15 @@ func main() {
 	// We use default config here as starting point. Default config contains
 	// reasonable values for available options.
 	cfg := centrifuge.DefaultConfig
-	// Centrifuge library exposes logs with different log level. In your app
-	// you can set special function to handle these log entries in a way you want.
-	cfg.LogLevel = centrifuge.LogLevelDebug
-	cfg.LogHandler = handleLog
 
 	// Node is the core object in Centrifuge library responsible for many useful
 	// things. For example Node allows to publish messages to channels from server
 	// side with its Publish method, but in this example we will publish messages
 	// only from client side.
-	node, _ := centrifuge.New(cfg)
+	node, err := centrifuge.New(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// Set ConnectHandler called when client successfully connected to Node. Your code
 	// inside handler must be synchronized since it will be called concurrently from
@@ -145,7 +139,7 @@ func main() {
 
 	// Run node. This method does not block.
 	if err := node.Run(); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
 	// Now configure HTTP routes.
@@ -159,7 +153,7 @@ func main() {
 
 	log.Printf("Starting server, visit http://localhost:8000")
 	if err := http.ListenAndServe(":8000", nil); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 }
 ```
@@ -218,3 +212,20 @@ Open several browser tabs with http://localhost:8000 and see chat in action.
 This example is only the top of an iceberg. Though it should give you an insight on library API.
 
 Keep in mind that Centrifuge library is not a framework to build chat apps. It's a general purpose real-time transport for your messages with some helpful primitives. You can build many kinds of real-time apps on top of this library including chats but depending on application you may need to write business logic yourself.
+
+### Tips
+
+#### Logging
+
+Centrifuge library exposes logs with different log level. In your app you can set special function to handle these log entries in a way you want.
+
+```go
+// Function to handle Centrifuge internal logs.
+func handleLog(e centrifuge.LogEntry) {
+	log.Printf("%s: %v", e.Message, e.Fields)
+}
+
+cfg := centrifuge.DefaultConfig
+cfg.LogLevel = centrifuge.LogLevelDebug
+cfg.LogHandler = handleLog
+```

--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ func main() {
 	// disconnect client from server if needed. But now we just accept
 	// all subscriptions to all channels. In real life you may use a more
 	// complex permission check here.
-	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) centrifuge.SubscribeReply {
+	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) (centrifuge.SubscribeReply, error) {
 		log.Printf("client subscribes on channel %s", e.Channel)
-		return centrifuge.SubscribeReply{}
+		return centrifuge.SubscribeReply{}, nil
 	})
 
 	// By default, clients can not publish messages into channels. By setting
@@ -127,9 +127,9 @@ func main() {
 	// you have a possibility to validate publication request before message will
 	// be published into channel and reach active subscribers. In our simple chat
 	// app we allow everyone to publish into any channel.
-	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) centrifuge.PublishReply {
+	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) (centrifuge.PublishReply, error) {
 		log.Printf("client publishes into channel %s: %s", e.Channel, string(e.Data))
-		return centrifuge.PublishReply{}
+		return centrifuge.PublishReply{}, nil
 	})
 
 	// Set Disconnect handler to react on client disconnect events.

--- a/_examples/benchmarks/benchmark_gobwas/main.go
+++ b/_examples/benchmarks/benchmark_gobwas/main.go
@@ -54,32 +54,31 @@ func main() {
 
 	node, _ := centrifuge.New(cfg)
 
-	node.On().Connecting(func(ctx context.Context, e centrifuge.ConnectEvent) centrifuge.ConnectReply {
+	node.On().Connecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
 		return centrifuge.ConnectReply{
 			Credentials: &centrifuge.Credentials{
 				UserID: "bench",
 			},
-		}
+		}, nil
 	})
 
 	node.On().Connect(func(c *centrifuge.Client) {})
 
-	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) centrifuge.SubscribeReply {
-		return centrifuge.SubscribeReply{}
+	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) (centrifuge.SubscribeReply, error) {
+		return centrifuge.SubscribeReply{}, nil
 	})
 
-	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) centrifuge.PublishReply {
-		return centrifuge.PublishReply{}
+	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) (centrifuge.PublishReply, error) {
+		return centrifuge.PublishReply{}, nil
 	})
 
-	node.On().Message(func(c *centrifuge.Client, e centrifuge.MessageEvent) centrifuge.MessageReply {
+	node.On().Message(func(c *centrifuge.Client, e centrifuge.MessageEvent) {
 		err := c.Send(e.Data)
 		if err != nil {
 			if err != io.EOF {
 				log.Fatalln("error sending to client:", err.Error())
 			}
 		}
-		return centrifuge.MessageReply{}
 	})
 
 	if err := node.Run(); err != nil {

--- a/_examples/benchmarks/benchmark_gorilla/main.go
+++ b/_examples/benchmarks/benchmark_gorilla/main.go
@@ -59,32 +59,31 @@ func main() {
 		node.SetEngine(engine)
 	}
 
-	node.On().Connecting(func(ctx context.Context, e centrifuge.ConnectEvent) centrifuge.ConnectReply {
+	node.On().Connecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
 		return centrifuge.ConnectReply{
 			Credentials: &centrifuge.Credentials{
 				UserID: "bench",
 			},
-		}
+		}, nil
 	})
 
 	node.On().Connect(func(c *centrifuge.Client) {})
 
-	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) centrifuge.SubscribeReply {
-		return centrifuge.SubscribeReply{}
+	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) (centrifuge.SubscribeReply, error) {
+		return centrifuge.SubscribeReply{}, nil
 	})
 
-	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) centrifuge.PublishReply {
-		return centrifuge.PublishReply{}
+	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) (centrifuge.PublishReply, error) {
+		return centrifuge.PublishReply{}, nil
 	})
 
-	node.On().Message(func(c *centrifuge.Client, e centrifuge.MessageEvent) centrifuge.MessageReply {
+	node.On().Message(func(c *centrifuge.Client, e centrifuge.MessageEvent) {
 		err := c.Send(e.Data)
 		if err != nil {
 			if err != io.EOF {
 				log.Fatalln("error sending to client:", err.Error())
 			}
 		}
-		return centrifuge.MessageReply{}
 	})
 
 	if err := node.Run(); err != nil {

--- a/_examples/benchmarks/benchmark_nhooyr/main.go
+++ b/_examples/benchmarks/benchmark_nhooyr/main.go
@@ -168,32 +168,31 @@ func main() {
 
 	node, _ := centrifuge.New(cfg)
 
-	node.On().Connecting(func(ctx context.Context, e centrifuge.ConnectEvent) centrifuge.ConnectReply {
+	node.On().Connecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
 		return centrifuge.ConnectReply{
 			Credentials: &centrifuge.Credentials{
 				UserID: "bench",
 			},
-		}
+		}, nil
 	})
 
 	node.On().Connect(func(c *centrifuge.Client) {})
 
-	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) centrifuge.SubscribeReply {
-		return centrifuge.SubscribeReply{}
+	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) (centrifuge.SubscribeReply, error) {
+		return centrifuge.SubscribeReply{}, nil
 	})
 
-	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) centrifuge.PublishReply {
-		return centrifuge.PublishReply{}
+	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) (centrifuge.PublishReply, error) {
+		return centrifuge.PublishReply{}, nil
 	})
 
-	node.On().Message(func(c *centrifuge.Client, e centrifuge.MessageEvent) centrifuge.MessageReply {
+	node.On().Message(func(c *centrifuge.Client, e centrifuge.MessageEvent) {
 		err := c.Send(e.Data)
 		if err != nil {
 			if err != io.EOF {
 				log.Fatalln("error sending to client:", err.Error())
 			}
 		}
-		return centrifuge.MessageReply{}
 	})
 
 	if err := node.Run(); err != nil {

--- a/_examples/chat_json/main.go
+++ b/_examples/chat_json/main.go
@@ -159,8 +159,14 @@ func main() {
 		}
 		msg.Timestamp = time.Now().Unix()
 		data, _ := json.Marshal(msg)
-		if _, err := node.Publish(e.Channel, data); err != nil {
+
+		// In this example we take over publish since we want to publish modified data to channel.
+		// We could also return an empty PublishReply to let Centrifuge proceed with publish itself
+		// and just let client publication pass through towards a channel.
+		if result, err := node.Publish(e.Channel, data); err != nil {
 			return reply, err
+		} else {
+			reply.Result = &result
 		}
 		return reply, nil
 	})
@@ -181,9 +187,8 @@ func main() {
 		return reply, nil
 	})
 
-	node.On().Message(func(c *centrifuge.Client, e centrifuge.MessageEvent) error {
+	node.On().Message(func(c *centrifuge.Client, e centrifuge.MessageEvent) {
 		log.Printf("message from user: %s, data: %s", c.UserID(), string(e.Data))
-		return nil
 	})
 
 	node.On().Disconnect(func(c *centrifuge.Client, e centrifuge.DisconnectEvent) {

--- a/_examples/chat_json/main.go
+++ b/_examples/chat_json/main.go
@@ -89,13 +89,13 @@ func main() {
 	})
 	node.SetEngine(engine)
 
-	node.On().Connecting(func(ctx context.Context, e centrifuge.ConnectEvent) centrifuge.ConnectReply {
+	node.On().Connecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
 		cred, _ := centrifuge.GetCredentials(ctx)
 		return centrifuge.ConnectReply{
 			Data: []byte(`{}`),
 			// Subscribe to personal several server-side channel.
 			Channels: []string{"#" + cred.UserID},
-		}
+		}, nil
 	})
 
 	node.On().Connect(func(c *centrifuge.Client) {
@@ -126,56 +126,64 @@ func main() {
 		log.Printf("user %s connection is still active", c.UserID())
 	})
 
-	node.On().Refresh(func(c *centrifuge.Client, e centrifuge.RefreshEvent) centrifuge.RefreshReply {
+	node.On().Refresh(func(c *centrifuge.Client, e centrifuge.RefreshEvent) (centrifuge.RefreshReply, error) {
 		log.Printf("user %s connection is going to expire, refreshing", c.UserID())
-		return centrifuge.RefreshReply{ExpireAt: time.Now().Unix() + 60}
+		return centrifuge.RefreshReply{
+			ExpireAt: time.Now().Unix() + 60,
+		}, nil
 	})
 
-	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) centrifuge.SubscribeReply {
+	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) (centrifuge.SubscribeReply, error) {
+		reply := centrifuge.SubscribeReply{}
 		log.Printf("user %s subscribes on %s", c.UserID(), e.Channel)
 		if !channelSubscribeAllowed(e.Channel) {
-			return centrifuge.SubscribeReply{Error: centrifuge.ErrorPermissionDenied}
+			return reply, centrifuge.ErrorPermissionDenied
 		}
-		return centrifuge.SubscribeReply{}
+		return reply, nil
 	})
 
 	node.On().Unsubscribe(func(c *centrifuge.Client, e centrifuge.UnsubscribeEvent) {
 		log.Printf("user %s unsubscribed from %s", c.UserID(), e.Channel)
 	})
 
-	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) centrifuge.PublishReply {
+	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) (centrifuge.PublishReply, error) {
+		reply := centrifuge.PublishReply{}
 		log.Printf("user %s publishes into channel %s: %s", c.UserID(), e.Channel, string(e.Data))
 		if _, ok := c.Channels()[e.Channel]; !ok {
-			return centrifuge.PublishReply{Error: centrifuge.ErrorPermissionDenied}
+			return reply, centrifuge.ErrorPermissionDenied
 		}
 		var msg clientMessage
 		err := json.Unmarshal(e.Data, &msg)
 		if err != nil {
-			return centrifuge.PublishReply{Error: centrifuge.ErrorBadRequest}
+			return reply, centrifuge.ErrorBadRequest
 		}
 		msg.Timestamp = time.Now().Unix()
 		data, _ := json.Marshal(msg)
-		return centrifuge.PublishReply{
-			Data: data,
+		if _, err := node.Publish(e.Channel, data); err != nil {
+			return reply, err
 		}
+		return reply, nil
 	})
 
-	node.On().RPC(func(c *centrifuge.Client, e centrifuge.RPCEvent) centrifuge.RPCReply {
+	node.On().RPC(func(c *centrifuge.Client, e centrifuge.RPCEvent) (centrifuge.RPCReply, error) {
 		log.Printf("RPC from user: %s, data: %s, method: %s", c.UserID(), string(e.Data), e.Method)
-		return centrifuge.RPCReply{Data: []byte(`{"year": "2020"}`)}
+		return centrifuge.RPCReply{
+			Data: []byte(`{"year": "2020"}`),
+		}, nil
 	})
 
-	node.On().Presence(func(c *centrifuge.Client, e centrifuge.PresenceEvent) centrifuge.PresenceReply {
+	node.On().Presence(func(c *centrifuge.Client, e centrifuge.PresenceEvent) (centrifuge.PresenceReply, error) {
 		log.Printf("user %s calls presence on %s", c.UserID(), e.Channel)
+		reply := centrifuge.PresenceReply{}
 		if _, ok := c.Channels()[e.Channel]; !ok {
-			return centrifuge.PresenceReply{Error: centrifuge.ErrorPermissionDenied}
+			return reply, centrifuge.ErrorPermissionDenied
 		}
-		return centrifuge.PresenceReply{}
+		return reply, nil
 	})
 
-	node.On().Message(func(c *centrifuge.Client, e centrifuge.MessageEvent) centrifuge.MessageReply {
+	node.On().Message(func(c *centrifuge.Client, e centrifuge.MessageEvent) error {
 		log.Printf("message from user: %s, data: %s", c.UserID(), string(e.Data))
-		return centrifuge.MessageReply{}
+		return nil
 	})
 
 	node.On().Disconnect(func(c *centrifuge.Client, e centrifuge.DisconnectEvent) {

--- a/_examples/chat_oauth2/main.go
+++ b/_examples/chat_oauth2/main.go
@@ -106,14 +106,14 @@ func createCentrifugeNode() (*centrifuge.Node, error) {
 		log.Printf("client %s connected via %s", c.UserID(), c.Transport().Name())
 	})
 
-	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) centrifuge.SubscribeReply {
+	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) (centrifuge.SubscribeReply, error) {
 		log.Printf("client %s subscribes on channel %s", c.UserID(), e.Channel)
-		return centrifuge.SubscribeReply{}
+		return centrifuge.SubscribeReply{}, nil
 	})
 
-	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) centrifuge.PublishReply {
+	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) (centrifuge.PublishReply, error) {
 		log.Printf("client %s publishes into channel %s: %s", c.UserID(), e.Channel, string(e.Data))
-		return centrifuge.PublishReply{}
+		return centrifuge.PublishReply{}, nil
 	})
 
 	node.On().Disconnect(func(c *centrifuge.Client, e centrifuge.DisconnectEvent) {

--- a/_examples/chat_protobuf/main.go
+++ b/_examples/chat_protobuf/main.go
@@ -52,10 +52,10 @@ func main() {
 
 	node, _ := centrifuge.New(cfg)
 
-	node.On().Connecting(func(ctx context.Context, e centrifuge.ConnectEvent) centrifuge.ConnectReply {
+	node.On().Connecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
 		return centrifuge.ConnectReply{
 			Data: []byte(`{}`),
-		}
+		}, nil
 	})
 
 	node.On().Connect(func(c *centrifuge.Client) {
@@ -73,37 +73,36 @@ func main() {
 		}()
 	})
 
-	node.On().Refresh(func(c *centrifuge.Client, e centrifuge.RefreshEvent) centrifuge.RefreshReply {
+	node.On().Refresh(func(c *centrifuge.Client, e centrifuge.RefreshEvent) (centrifuge.RefreshReply, error) {
 		log.Printf("user %s connection is going to expire, refreshing", c.UserID())
 		return centrifuge.RefreshReply{
 			ExpireAt: time.Now().Unix() + 10,
-		}
+		}, nil
 	})
 
-	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) centrifuge.SubscribeReply {
+	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) (centrifuge.SubscribeReply, error) {
 		log.Printf("user %s subscribes on %s", c.UserID(), e.Channel)
-		return centrifuge.SubscribeReply{}
+		return centrifuge.SubscribeReply{}, nil
 	})
 
 	node.On().Unsubscribe(func(c *centrifuge.Client, e centrifuge.UnsubscribeEvent) {
 		log.Printf("user %s unsubscribed from %s", c.UserID(), e.Channel)
 	})
 
-	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) centrifuge.PublishReply {
+	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) (centrifuge.PublishReply, error) {
 		log.Printf("user %s publishes into channel %s: %s", c.UserID(), e.Channel, string(e.Data))
-		return centrifuge.PublishReply{}
+		return centrifuge.PublishReply{}, nil
 	})
 
-	node.On().RPC(func(c *centrifuge.Client, e centrifuge.RPCEvent) centrifuge.RPCReply {
+	node.On().RPC(func(c *centrifuge.Client, e centrifuge.RPCEvent) (centrifuge.RPCReply, error) {
 		log.Printf("RPC from user: %s, data: %s", c.UserID(), string(e.Data))
 		return centrifuge.RPCReply{
 			Data: []byte(`{"year": "2020"}`),
-		}
+		}, nil
 	})
 
-	node.On().Message(func(c *centrifuge.Client, e centrifuge.MessageEvent) centrifuge.MessageReply {
+	node.On().Message(func(c *centrifuge.Client, e centrifuge.MessageEvent) {
 		log.Printf("message from user: %s, data: %s", c.UserID(), string(e.Data))
-		return centrifuge.MessageReply{}
 	})
 
 	node.On().Disconnect(func(c *centrifuge.Client, e centrifuge.DisconnectEvent) {

--- a/_examples/custom_broker/main.go
+++ b/_examples/custom_broker/main.go
@@ -63,18 +63,18 @@ func main() {
 		log.Printf("user %s connected via %s with protocol: %s", c.UserID(), transport.Name(), transport.Protocol())
 	})
 
-	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) centrifuge.SubscribeReply {
+	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) (centrifuge.SubscribeReply, error) {
 		log.Printf("user %s subscribes on %s", c.UserID(), e.Channel)
-		return centrifuge.SubscribeReply{}
+		return centrifuge.SubscribeReply{}, nil
 	})
 
 	node.On().Unsubscribe(func(c *centrifuge.Client, e centrifuge.UnsubscribeEvent) {
 		log.Printf("user %s unsubscribed from %s", c.UserID(), e.Channel)
 	})
 
-	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) centrifuge.PublishReply {
+	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) (centrifuge.PublishReply, error) {
 		log.Printf("user %s publishes into channel %s: %s", c.UserID(), e.Channel, string(e.Data))
-		return centrifuge.PublishReply{}
+		return centrifuge.PublishReply{}, nil
 	})
 
 	node.On().Disconnect(func(c *centrifuge.Client, e centrifuge.DisconnectEvent) {

--- a/_examples/custom_ws_gobwas/main.go
+++ b/_examples/custom_ws_gobwas/main.go
@@ -53,12 +53,12 @@ func main() {
 
 	node, _ := centrifuge.New(cfg)
 
-	node.On().Connecting(func(ctx context.Context, e centrifuge.ConnectEvent) centrifuge.ConnectReply {
+	node.On().Connecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
 		return centrifuge.ConnectReply{
 			Credentials: &centrifuge.Credentials{
 				UserID: "",
 			},
-		}
+		}, nil
 	})
 
 	node.On().Connect(func(c *centrifuge.Client) {
@@ -82,23 +82,22 @@ func main() {
 		}()
 	})
 
-	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) centrifuge.SubscribeReply {
+	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) (centrifuge.SubscribeReply, error) {
 		log.Printf("user %s subscribes on %s", c.UserID(), e.Channel)
-		return centrifuge.SubscribeReply{}
+		return centrifuge.SubscribeReply{}, nil
 	})
 
 	node.On().Unsubscribe(func(c *centrifuge.Client, e centrifuge.UnsubscribeEvent) {
 		log.Printf("user %s unsubscribed from %s", c.UserID(), e.Channel)
 	})
 
-	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) centrifuge.PublishReply {
+	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) (centrifuge.PublishReply, error) {
 		log.Printf("user %s publishes into channel %s: %s", c.UserID(), e.Channel, string(e.Data))
-		return centrifuge.PublishReply{}
+		return centrifuge.PublishReply{}, nil
 	})
 
-	node.On().Message(func(c *centrifuge.Client, e centrifuge.MessageEvent) centrifuge.MessageReply {
+	node.On().Message(func(c *centrifuge.Client, e centrifuge.MessageEvent) {
 		log.Printf("Message from user: %s, data: %s", c.UserID(), string(e.Data))
-		return centrifuge.MessageReply{}
 	})
 
 	node.On().Disconnect(func(c *centrifuge.Client, e centrifuge.DisconnectEvent) {

--- a/_examples/gin_auth/main.go
+++ b/_examples/gin_auth/main.go
@@ -116,48 +116,41 @@ func main() {
 		}()
 	})
 
-	node.On().Refresh(func(c *centrifuge.Client, e centrifuge.RefreshEvent) centrifuge.RefreshReply {
+	node.On().Refresh(func(c *centrifuge.Client, e centrifuge.RefreshEvent) (centrifuge.RefreshReply, error) {
 		log.Printf("user %s connection is going to expire, refreshing", c.UserID())
 		return centrifuge.RefreshReply{
 			ExpireAt: time.Now().Unix() + 10,
-		}
+		}, nil
 	})
 
-	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) centrifuge.SubscribeReply {
+	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) (centrifuge.SubscribeReply, error) {
 		log.Printf("user %s subscribes on %s", c.UserID(), e.Channel)
-		return centrifuge.SubscribeReply{}
+		return centrifuge.SubscribeReply{}, nil
 	})
 
 	node.On().Unsubscribe(func(c *centrifuge.Client, e centrifuge.UnsubscribeEvent) {
 		log.Printf("user %s unsubscribed from %s", c.UserID(), e.Channel)
 	})
 
-	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) centrifuge.PublishReply {
+	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) (centrifuge.PublishReply, error) {
 		log.Printf("user %s publishes into channel %s: %s", c.UserID(), e.Channel, string(e.Data))
 		var msg clientMessage
 		err := json.Unmarshal(e.Data, &msg)
 		if err != nil {
-			return centrifuge.PublishReply{
-				Error: centrifuge.ErrorBadRequest,
-			}
+			return centrifuge.PublishReply{}, centrifuge.ErrorBadRequest
 		}
-		msg.Timestamp = time.Now().Unix()
-		data, _ := json.Marshal(msg)
-		return centrifuge.PublishReply{
-			Data: data,
-		}
+		return centrifuge.PublishReply{}, nil
 	})
 
-	node.On().RPC(func(c *centrifuge.Client, e centrifuge.RPCEvent) centrifuge.RPCReply {
+	node.On().RPC(func(c *centrifuge.Client, e centrifuge.RPCEvent) (centrifuge.RPCReply, error) {
 		log.Printf("RPC from user: %s, data: %s", c.UserID(), string(e.Data))
 		return centrifuge.RPCReply{
 			Data: []byte(`{"year": "2020"}`),
-		}
+		}, nil
 	})
 
-	node.On().Message(func(c *centrifuge.Client, e centrifuge.MessageEvent) centrifuge.MessageReply {
+	node.On().Message(func(c *centrifuge.Client, e centrifuge.MessageEvent) {
 		log.Printf("Message from user: %s, data: %s", c.UserID(), string(e.Data))
-		return centrifuge.MessageReply{}
 	})
 
 	node.On().Disconnect(func(c *centrifuge.Client, e centrifuge.DisconnectEvent) {

--- a/_examples/redis_engine/main.go
+++ b/_examples/redis_engine/main.go
@@ -63,18 +63,18 @@ func main() {
 		log.Printf("user %s connected via %s with protocol: %s", c.UserID(), transport.Name(), transport.Protocol())
 	})
 
-	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) centrifuge.SubscribeReply {
+	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) (centrifuge.SubscribeReply, error) {
 		log.Printf("user %s subscribes on %s", c.UserID(), e.Channel)
-		return centrifuge.SubscribeReply{}
+		return centrifuge.SubscribeReply{}, nil
 	})
 
 	node.On().Unsubscribe(func(c *centrifuge.Client, e centrifuge.UnsubscribeEvent) {
 		log.Printf("user %s unsubscribed from %s", c.UserID(), e.Channel)
 	})
 
-	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) centrifuge.PublishReply {
+	node.On().Publish(func(c *centrifuge.Client, e centrifuge.PublishEvent) (centrifuge.PublishReply, error) {
 		log.Printf("user %s publishes into channel %s: %s", c.UserID(), e.Channel, string(e.Data))
-		return centrifuge.PublishReply{}
+		return centrifuge.PublishReply{}, nil
 	})
 
 	node.On().Disconnect(func(c *centrifuge.Client, e centrifuge.DisconnectEvent) {

--- a/_examples/worms/main.go
+++ b/_examples/worms/main.go
@@ -53,28 +53,27 @@ func main() {
 
 	node, _ := centrifuge.New(cfg)
 
-	node.On().Connecting(func(ctx context.Context, e centrifuge.ConnectEvent) centrifuge.ConnectReply {
+	node.On().Connecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
 		return centrifuge.ConnectReply{
 			Credentials: &centrifuge.Credentials{
 				UserID: "",
 			},
-		}
+		}, nil
 	})
 
 	node.On().Connect(func(c *centrifuge.Client) {
 		log.Printf("worm connected via %s", c.Transport().Name())
 	})
 
-	node.On().Message(func(c *centrifuge.Client, e centrifuge.MessageEvent) centrifuge.MessageReply {
+	node.On().Message(func(c *centrifuge.Client, e centrifuge.MessageEvent) {
 		var ev event
 		_ = json.Unmarshal(e.Data, &ev)
 		_, _ = node.Publish("moving", ev.Payload)
-		return centrifuge.MessageReply{}
 	})
 
-	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) centrifuge.SubscribeReply {
+	node.On().Subscribe(func(c *centrifuge.Client, e centrifuge.SubscribeEvent) (centrifuge.SubscribeReply, error) {
 		log.Printf("worm subscribed on %s", e.Channel)
-		return centrifuge.SubscribeReply{}
+		return centrifuge.SubscribeReply{}, nil
 	})
 
 	node.On().Unsubscribe(func(c *centrifuge.Client, e centrifuge.UnsubscribeEvent) {

--- a/changelog.md
+++ b/changelog.md
@@ -3,11 +3,16 @@ v0.10.0
 
 This release is a massive rewrite of Centrifuge library (actually of some part of it) which should make library a more generic solution. Several opinionated and restrictive parts removed to make Centrifuge feel as a reasonably thin wrapper on top of strict client-server protocol.
 
+Most work done inside [#129](https://github.com/centrifugal/centrifuge/pull/129) pr and relates to [#128](https://github.com/centrifugal/centrifuge/issues/128) issue.
+
+Release highlights:
+
 * Layer with namespace configuration and channel rules removed. Now developer is responsible for all permission checks and channel rules.
 * Hard dependency on JWT and predefined claims removed. Users are now free to use any token implementation – like [Paceto](https://github.com/paragonie/paseto) tokens for example, use any custom claims etc.
 * Event handlers that not set now always lead to `Not available` error returned to client.
 * All event handlers now should be set to `Node` before calling its `Run` method.
 * Centrifuge still needs to know some core options for channels to understand whether to use presence inside channels, keep Publication history stream or not. It's now done over user-defined callback function in Node Config called `ChannelOptionsFunc`. See its detailed description in [library docs](https://godoc.org/github.com/centrifugal/centrifuge#ChannelOptionsFunc).
+* More idiomatic error handling in event handlers, see [#134](https://github.com/centrifugal/centrifuge/pull/134).
 
 Look at updated [example in README](https://github.com/centrifugal/centrifuge#quick-example) and [examples](https://github.com/centrifugal/centrifuge/tree/master/_examples) folder to find out more. 
 

--- a/client.go
+++ b/client.go
@@ -292,7 +292,7 @@ func (c *Client) checkSubscriptionExpiration(channel string, channelContext Chan
 					return false
 				}
 			}
-			if reply.Expired || (reply.ExpireAt > 0 && reply.ExpireAt < now) {
+			if reply.ExpireAt > 0 && reply.ExpireAt < now {
 				return false
 			}
 			c.mu.Lock()
@@ -496,13 +496,13 @@ func (c *Client) sendUnsub(ch string, resubscribe bool) error {
 	return nil
 }
 
-// Close client connection with specific disconnect reason.
+// Disconnect client connection with specific disconnect code and reason.
 // This method internally creates a new goroutine at moment to do
 // closing stuff. An extra goroutine is required to solve disconnect
 // and alive callback ordering/sync problems. Will be a noop if client
 // already closed. Since this method runs a separate goroutine client
 // connection will be closed eventually (i.e. not immediately).
-func (c *Client) Close(disconnect *Disconnect) error {
+func (c *Client) Disconnect(disconnect *Disconnect) error {
 	go func() {
 		_ = c.close(disconnect)
 	}()
@@ -793,10 +793,6 @@ func (c *Client) expire() {
 				_ = c.close(DisconnectServerError)
 				return
 			}
-		}
-		if reply.Expired {
-			_ = c.close(DisconnectExpired)
-			return
 		}
 		if reply.ExpireAt > 0 {
 			c.mu.Lock()
@@ -1492,9 +1488,6 @@ func (c *Client) refreshCmd(cmd *protocol.RefreshRequest) (*clientproto.RefreshR
 				return resp, DisconnectServerError
 			}
 		}
-		if reply.Expired {
-			return resp, DisconnectExpired
-		}
 		expireAt = reply.ExpireAt
 		info = reply.Info
 	} else {
@@ -1990,9 +1983,6 @@ func (c *Client) subRefreshCmd(cmd *protocol.SubRefreshRequest) (*clientproto.Su
 				return resp, DisconnectServerError
 			}
 		}
-		if reply.Expired {
-			return resp, DisconnectExpired
-		}
 		expireAt = reply.ExpireAt
 		info = reply.Info
 	} else {
@@ -2108,7 +2098,7 @@ func (c *Client) publishCmd(cmd *protocol.PublishRequest) (*clientproto.PublishR
 	c.mu.RUnlock()
 
 	if c.node.clientEvents.publishHandler != nil && c.hasEvent(EventPublish) {
-		reply, err := c.node.clientEvents.publishHandler(c, PublishEvent{
+		_, err := c.node.clientEvents.publishHandler(c, PublishEvent{
 			Channel: ch,
 			Data:    data,
 			Info: &ClientInfo{
@@ -2126,9 +2116,6 @@ func (c *Client) publishCmd(cmd *protocol.PublishRequest) (*clientproto.PublishR
 				resp.Error = toClientErr(err).toProto()
 				return resp, nil
 			}
-		}
-		if reply.Data != nil {
-			data = reply.Data
 		}
 	} else {
 		resp.Error = ErrorNotAvailable.toProto()

--- a/config.go
+++ b/config.go
@@ -6,13 +6,19 @@ import (
 
 // Config contains Node configuration options.
 type Config struct {
-	// Version of server – will be sent to client on connection
-	// establishment phase in response to connect request.
+	// Version of server – will be sent to client on connection establishment
+	// phase in response to connect request.
 	Version string
-	// Name of this server node - must be unique, used as human readable
-	// and meaningful node identifier. If not set then os.Hostname will be
-	// used.
+	// Name of this server node - must be unique, used as human readable and
+	// meaningful node identifier. If not set then os.Hostname will be used.
 	Name string
+	// LogLevel is a log level to use. By default nothing will be logged.
+	LogLevel LogLevel
+	// LogHandler is a handler func node will send logs to.
+	LogHandler LogHandler
+	// NodeInfoMetricsAggregateInterval sets interval for automatic metrics
+	// aggregation. It's not reasonable to have it less than one second.
+	NodeInfoMetricsAggregateInterval time.Duration
 	// ClientPresenceUpdateInterval is an interval how often connected
 	// clients must update presence information.
 	ClientPresenceUpdateInterval time.Duration
@@ -35,13 +41,6 @@ type Config struct {
 	// client position check in channel. If client does not pass check it will
 	// be disconnected with DisconnectInsufficientState.
 	ClientChannelPositionCheckDelay time.Duration
-	// NodeInfoMetricsAggregateInterval sets interval for automatic metrics
-	// aggregation. It's not reasonable to have it less than one second.
-	NodeInfoMetricsAggregateInterval time.Duration
-	// LogLevel is a log level to use. By default nothing will be logged.
-	LogLevel LogLevel
-	// LogHandler is a handler func node will send logs to.
-	LogHandler LogHandler
 	// ClientQueueMaxSize is a maximum size of client's message queue in bytes.
 	// After this queue size exceeded Centrifugo closes client's connection.
 	ClientQueueMaxSize int

--- a/disconnect.go
+++ b/disconnect.go
@@ -31,6 +31,11 @@ func (d *Disconnect) String() string {
 	return fmt.Sprintf("code: %d, reason: %s, reconnect: %t", d.Code, d.Reason, d.Reconnect)
 }
 
+// Error representation.
+func (d *Disconnect) Error() string {
+	return fmt.Sprintf("disconnected: code: %d, reason: %s, reconnect: %t", d.Code, d.Reason, d.Reconnect)
+}
+
 // CloseText allows to build disconnect advice sent inside Close frame.
 // At moment we don't encode Code here to not duplicate information
 // since it is sent separately as Code of WebSocket/SockJS Close Frame.

--- a/engine_redis_test.go
+++ b/engine_redis_test.go
@@ -871,11 +871,11 @@ func nodeWithRedisEngine(tb testing.TB, useStreams bool) *Node {
 	if err != nil {
 		panic(err)
 	}
-	n.On().Subscribe(func(_ *Client, _ SubscribeEvent) SubscribeReply {
-		return SubscribeReply{}
+	n.On().Subscribe(func(_ *Client, _ SubscribeEvent) (SubscribeReply, error) {
+		return SubscribeReply{}, nil
 	})
-	n.On().Publish(func(_ *Client, _ PublishEvent) PublishReply {
-		return PublishReply{}
+	n.On().Publish(func(_ *Client, _ PublishEvent) (PublishReply, error) {
+		return PublishReply{}, nil
 	})
 	return n
 }

--- a/events.go
+++ b/events.go
@@ -20,10 +20,6 @@ type ConnectEvent struct {
 type ConnectReply struct {
 	// Context allows to return modified context.
 	Context context.Context
-	// Error for connect command reply.
-	Error *Error
-	// Disconnect client.
-	Disconnect *Disconnect
 	// Credentials should be set if app wants to authenticate connection.
 	// This field still optional as auth could be provided through HTTP
 	// middleware or via JWT token.
@@ -44,7 +40,7 @@ type ConnectReply struct {
 // ConnectingHandler called when new client authenticates on server.
 // This handler will be called from many goroutines, remember to synchronize
 // your operations inside.
-type ConnectingHandler func(context.Context, ConnectEvent) ConnectReply
+type ConnectingHandler func(context.Context, ConnectEvent) (ConnectReply, error)
 
 // ConnectHandler called when client connected to server and ready to communicate.
 type ConnectHandler func(*Client)
@@ -64,8 +60,6 @@ type RefreshReply struct {
 	ExpireAt int64
 	// Info allows to modify connection information, zero value means no modification.
 	Info []byte
-	// Disconnect client.
-	Disconnect *Disconnect
 }
 
 // RefreshHandler called when it's time to validate client connection and
@@ -87,7 +81,7 @@ type RefreshReply struct {
 // yourself in a custom way. In you rely on builtin Centrifuge JWT support then
 // connection refresh will happen without involving your application at all so
 // you must skip setting this handler on connection.
-type RefreshHandler func(*Client, RefreshEvent) RefreshReply
+type RefreshHandler func(*Client, RefreshEvent) (RefreshReply, error)
 
 // AliveHandler called periodically while connection alive. This is a helper
 // to do periodic things which can tolerate some approximation in time. This
@@ -122,10 +116,6 @@ type SubscribeEvent struct {
 
 // SubscribeReply contains fields determining the reaction on subscribe event.
 type SubscribeReply struct {
-	// Error to return, nil value means no error.
-	Error *Error
-	// Disconnect client, nil value means no disconnect.
-	Disconnect *Disconnect
 	// ExpireAt defines time in future when subscription should expire,
 	// zero value means no expiration.
 	ExpireAt int64
@@ -138,7 +128,7 @@ type SubscribeReply struct {
 }
 
 // SubscribeHandler called when client wants to subscribe on channel.
-type SubscribeHandler func(*Client, SubscribeEvent) SubscribeReply
+type SubscribeHandler func(*Client, SubscribeEvent) (SubscribeReply, error)
 
 // UnsubscribeEvent contains fields related to unsubscribe event.
 type UnsubscribeEvent struct {
@@ -162,19 +152,11 @@ type PublishEvent struct {
 	Info *ClientInfo
 }
 
-// PublishReply contains fields determining the reaction on publish event.
-type PublishReply struct {
-	// Error to return, nil value means no error.
-	Error *Error
-	// Disconnect client, nil value means no disconnect.
-	Disconnect *Disconnect
-	// Data is modified data to publish, zero value means no modification
-	// of original data published by client.
-	Data []byte
-}
+// PublishReply contains fields determining the result on publish.
+type PublishReply struct{}
 
 // PublishHandler called when client publishes into channel.
-type PublishHandler func(*Client, PublishEvent) PublishReply
+type PublishHandler func(*Client, PublishEvent) (PublishReply, error)
 
 // SubRefreshEvent contains fields related to subscription refresh event.
 type SubRefreshEvent struct {
@@ -188,11 +170,11 @@ type SubRefreshEvent struct {
 // subscription refresh event.
 type SubRefreshReply struct {
 	// Expired when set mean that connection must be closed with DisconnectExpired reason.
-	Expired  bool
+	Expired bool
+	// ExpireAt is a new Unix time of expiration. Zero value means no expiration.
 	ExpireAt int64
-	Info     []byte
-	// Disconnect client.
-	Disconnect *Disconnect
+	// Info is a new channel-scope info. Zero value means do not change previous one.
+	Info []byte
 }
 
 // SubRefreshHandler called when it's time to validate client subscription to channel and
@@ -206,7 +188,7 @@ type SubRefreshReply struct {
 // in a custom way. In you rely on builtin Centrifuge JWT support then connection
 // refresh will happen without involving your application at all so you must skip
 // setting this handler on connection.
-type SubRefreshHandler func(*Client, SubRefreshEvent) SubRefreshReply
+type SubRefreshHandler func(*Client, SubRefreshEvent) (SubRefreshReply, error)
 
 // RPCEvent contains fields related to rpc request.
 type RPCEvent struct {
@@ -219,16 +201,12 @@ type RPCEvent struct {
 
 // RPCReply contains fields determining the reaction on rpc request.
 type RPCReply struct {
-	// Error to return, nil value means no error.
-	Error *Error
-	// Disconnect client, nil value means no disconnect.
-	Disconnect *Disconnect
 	// Data to return in RPC reply to client.
 	Data []byte
 }
 
 // RPCHandler must handle incoming command from client.
-type RPCHandler func(*Client, RPCEvent) RPCReply
+type RPCHandler func(*Client, RPCEvent) (RPCReply, error)
 
 // MessageEvent contains fields related to message request.
 type MessageEvent struct {
@@ -236,59 +214,38 @@ type MessageEvent struct {
 	Data []byte
 }
 
-// MessageReply contains fields determining the reaction on message request.
-type MessageReply struct {
-	// Disconnect allows to disconnect client.
-	Disconnect *Disconnect
-}
-
 // MessageHandler must handle incoming async message from client.
-type MessageHandler func(*Client, MessageEvent) MessageReply
+type MessageHandler func(*Client, MessageEvent) error
 
-// PresenceEvent contains info of presence call.
+// PresenceEvent has channel operation called for.
 type PresenceEvent struct {
 	Channel string
 }
 
 // PresenceReply contains fields determining the reaction on presence request.
-type PresenceReply struct {
-	// Error to return, nil value means no error.
-	Error *Error
-	// Disconnect client, nil value means no disconnect.
-	Disconnect *Disconnect
-}
+type PresenceReply struct{}
 
 // PresenceHandler called when presence request received from client.
-type PresenceHandler func(*Client, PresenceEvent) PresenceReply
+type PresenceHandler func(*Client, PresenceEvent) (PresenceReply, error)
 
-// PresenceStatsEvent ...
+// PresenceStatsEvent has channel operation called for.
 type PresenceStatsEvent struct {
 	Channel string
 }
 
 // PresenceStatsReply contains fields determining the reaction on presence request.
-type PresenceStatsReply struct {
-	// Error to return, nil value means no error.
-	Error *Error
-	// Disconnect client, nil value means no disconnect.
-	Disconnect *Disconnect
-}
+type PresenceStatsReply struct{}
 
 // PresenceStatsHandler must handle incoming command from client.
-type PresenceStatsHandler func(*Client, PresenceStatsEvent) PresenceStatsReply
+type PresenceStatsHandler func(*Client, PresenceStatsEvent) (PresenceStatsReply, error)
 
-// HistoryEvent ...
+// HistoryEvent has channel operation called for.
 type HistoryEvent struct {
 	Channel string
 }
 
 // HistoryReply contains fields determining the reaction on history request.
-type HistoryReply struct {
-	// Error to return, nil value means no error.
-	Error *Error
-	// Disconnect client, nil value means no disconnect.
-	Disconnect *Disconnect
-}
+type HistoryReply struct{}
 
 // HistoryHandler must handle incoming command from client.
-type HistoryHandler func(*Client, HistoryEvent) HistoryReply
+type HistoryHandler func(*Client, HistoryEvent) (HistoryReply, error)

--- a/events.go
+++ b/events.go
@@ -53,12 +53,11 @@ type RefreshEvent struct {
 
 // RefreshReply contains fields determining the reaction on refresh event.
 type RefreshReply struct {
-	// Expired when set mean that connection must be closed with DisconnectExpired reason.
-	Expired bool
 	// ExpireAt defines time in future when connection should expire,
 	// zero value means no expiration.
 	ExpireAt int64
-	// Info allows to modify connection information, zero value means no modification.
+	// Info allows to modify connection information,
+	// zero value means no modification of current connection Info.
 	Info []byte
 }
 
@@ -169,8 +168,6 @@ type SubRefreshEvent struct {
 // SubRefreshReply contains fields determining the reaction on
 // subscription refresh event.
 type SubRefreshReply struct {
-	// Expired when set mean that connection must be closed with DisconnectExpired reason.
-	Expired bool
 	// ExpireAt is a new Unix time of expiration. Zero value means no expiration.
 	ExpireAt int64
 	// Info is a new channel-scope info. Zero value means do not change previous one.

--- a/events.go
+++ b/events.go
@@ -155,7 +155,11 @@ type PublishEvent struct {
 // PublishReply contains fields determining the result on publish.
 type PublishReply struct {
 	// Result if set will tell Centrifuge that message already published to
-	// channel by handler code.
+	// channel by handler code. In this case Centrifuge won't try to publish
+	// into channel again after handler returned PublishReply. This can be
+	// useful if you need to know new Publication offset in your code or you
+	// want to make sure message successfully published to Engine on server
+	// side (otherwise only client will get an error).
 	Result *PublishResult
 }
 

--- a/node_test.go
+++ b/node_test.go
@@ -118,11 +118,11 @@ func nodeWithMemoryEngineNoHandlers() *Node {
 
 func nodeWithMemoryEngine() *Node {
 	n := nodeWithMemoryEngineNoHandlers()
-	n.On().Subscribe(func(_ *Client, _ SubscribeEvent) SubscribeReply {
-		return SubscribeReply{}
+	n.On().Subscribe(func(_ *Client, _ SubscribeEvent) (SubscribeReply, error) {
+		return SubscribeReply{}, nil
 	})
-	n.On().Publish(func(_ *Client, _ PublishEvent) PublishReply {
-		return PublishReply{}
+	n.On().Publish(func(_ *Client, _ PublishEvent) (PublishReply, error) {
+		return PublishReply{}, nil
 	})
 	return n
 }


### PR DESCRIPTION
So instead pseudo-code like this:

```
if bad token:
  return SubscribeReply{Disconnect: DisconnectBadToken}
else if not admin:
  return SubscribeReply{Error: ErrorPermissionDenied}
return SubscribeReply{}
```

We can use:

```
if bad token:
  return SubscribeReply{}, DisconnectBadToken
else if not admin:
  return SubscribeReply{}, ErrorPermissionDenied
return SubscribeReply{}, nil
```

Non-protocol error will be automatically transformed to `ErrorInternal`. Also added possibility to take over on publish operation in Publish Handler.