### PR TITLE
Custom metrics namespace

### DIFF
--- a/config.go
+++ b/config.go
@@ -55,6 +55,9 @@ type Config struct {
 	// If not set then all channels will use default ChannelOptions with all
 	// features off.
 	ChannelOptionsFunc ChannelOptionsFunc
+	// MetricsNamespace is a Prometheus metrics namespace to use for internal metrics.
+	// If not set then default namespace name `centrifuge` will be used.
+	MetricsNamespace string
 }
 
 const (

--- a/handler_sockjs.go
+++ b/handler_sockjs.go
@@ -168,7 +168,7 @@ func newSockJSHandler(s *SockjsHandler, sockjsPrefix string, sockjsOpts sockjs.O
 
 // sockJSHandler called when new client connection comes to SockJS endpoint.
 func (s *SockjsHandler) sockJSHandler(sess sockjs.Session) {
-	transportConnectCount.WithLabelValues(transportSockJS).Inc()
+	incTransportConnect(transportSockJS)
 
 	// Separate goroutine for better GC of caller's data.
 	go func() {

--- a/handler_websocket.go
+++ b/handler_websocket.go
@@ -246,7 +246,7 @@ func NewWebsocketHandler(n *Node, c WebsocketConfig) *WebsocketHandler {
 }
 
 func (s *WebsocketHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
-	transportConnectCount.WithLabelValues(transportWebsocket).Inc()
+	incTransportConnect(transportWebsocket)
 
 	compression := s.config.Compression
 	compressionLevel := s.config.CompressionLevel

--- a/metrics.go
+++ b/metrics.go
@@ -1,12 +1,258 @@
 package centrifuge
 
 import (
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/centrifugal/protocol"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var metricsNamespace = "centrifuge"
+// default namespace for prometheus metrics.
+var defaultMetricsNamespace = "centrifuge"
+
+var registryMu sync.RWMutex
 
 var (
+	messagesSentCount      *prometheus.CounterVec
+	messagesReceivedCount  *prometheus.CounterVec
+	actionCount            *prometheus.CounterVec
+	buildInfoGauge         *prometheus.GaugeVec
+	numClientsGauge        prometheus.Gauge
+	numUsersGauge          prometheus.Gauge
+	numChannelsGauge       prometheus.Gauge
+	numNodesGauge          prometheus.Gauge
+	replyErrorCount        *prometheus.CounterVec
+	serverDisconnectCount  *prometheus.CounterVec
+	commandDurationSummary *prometheus.SummaryVec
+	recoverCount           *prometheus.CounterVec
+	transportConnectCount  *prometheus.CounterVec
+	transportMessagesSent  *prometheus.CounterVec
+
+	messagesReceivedCountPublication prometheus.Counter
+	messagesReceivedCountJoin        prometheus.Counter
+	messagesReceivedCountLeave       prometheus.Counter
+	messagesReceivedCountControl     prometheus.Counter
+
+	messagesSentCountPublication prometheus.Counter
+	messagesSentCountJoin        prometheus.Counter
+	messagesSentCountLeave       prometheus.Counter
+	messagesSentCountControl     prometheus.Counter
+
+	actionCountAddClient        prometheus.Counter
+	actionCountRemoveClient     prometheus.Counter
+	actionCountAddSub           prometheus.Counter
+	actionCountRemoveSub        prometheus.Counter
+	actionCountAddPresence      prometheus.Counter
+	actionCountRemovePresence   prometheus.Counter
+	actionCountPresence         prometheus.Counter
+	actionCountPresenceStats    prometheus.Counter
+	actionCountHistoryFull      prometheus.Counter
+	actionCountHistoryRecover   prometheus.Counter
+	actionCountHistoryStreamTop prometheus.Counter
+	actionCountHistoryRemove    prometheus.Counter
+
+	recoverCountYes prometheus.Counter
+	recoverCountNo  prometheus.Counter
+
+	transportConnectCountWebsocket prometheus.Counter
+	transportConnectCountSockJS    prometheus.Counter
+
+	transportMessagesSentWebsocket prometheus.Counter
+	transportMessagesSentSockJS    prometheus.Counter
+)
+
+func observeCommandDuration(method protocol.MethodType, d time.Duration) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	commandDurationSummary.WithLabelValues(strings.ToLower(protocol.MethodType_name[int32(method)])).Observe(d.Seconds())
+}
+
+func setBuildInfo(version string) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	buildInfoGauge.WithLabelValues(version).Set(1)
+}
+
+func setNumClients(n float64) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	numClientsGauge.Set(n)
+}
+
+func setNumUsers(n float64) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	numUsersGauge.Set(n)
+}
+
+func setNumChannels(n float64) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	numChannelsGauge.Set(n)
+}
+
+func setNumNodes(n float64) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	numNodesGauge.Set(n)
+}
+
+func incReplyError(method protocol.MethodType, code uint32) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	replyErrorCount.WithLabelValues(strings.ToLower(protocol.MethodType_name[int32(method)]), strconv.FormatUint(uint64(code), 10)).Inc()
+}
+
+func incRecover(success bool) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	if success {
+		recoverCountYes.Inc()
+	} else {
+		recoverCountNo.Inc()
+	}
+}
+
+func incTransportConnect(transport string) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	switch transport {
+	case transportWebsocket:
+		transportConnectCountWebsocket.Inc()
+	case transportSockJS:
+		transportConnectCountSockJS.Inc()
+	default:
+		transportConnectCount.WithLabelValues(transport).Inc()
+	}
+}
+
+func incTransportMessagesSent(transport string) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	switch transport {
+	case transportWebsocket:
+		transportMessagesSentWebsocket.Inc()
+	case transportSockJS:
+		transportMessagesSentSockJS.Inc()
+	default:
+		transportMessagesSent.WithLabelValues(transport).Inc()
+	}
+}
+
+func addTransportMessagesSent(transport string, n float64) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	switch transport {
+	case transportWebsocket:
+		transportMessagesSentWebsocket.Add(n)
+	case transportSockJS:
+		transportMessagesSentSockJS.Add(n)
+	default:
+		transportMessagesSent.WithLabelValues(transport).Add(n)
+	}
+}
+
+func incServerDisconnect(code uint32) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	serverDisconnectCount.WithLabelValues(strconv.FormatUint(uint64(code), 10)).Inc()
+}
+
+func incMessagesSent(msgType string) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	switch msgType {
+	case "publication":
+		messagesSentCountPublication.Inc()
+	case "join":
+		messagesSentCountJoin.Inc()
+	case "leave":
+		messagesSentCountLeave.Inc()
+	case "control":
+		messagesSentCountControl.Inc()
+	default:
+		messagesSentCount.WithLabelValues(msgType).Inc()
+	}
+}
+
+func incMessagesReceived(msgType string) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	switch msgType {
+	case "publication":
+		messagesReceivedCountPublication.Inc()
+	case "join":
+		messagesReceivedCountJoin.Inc()
+	case "leave":
+		messagesReceivedCountLeave.Inc()
+	case "control":
+		messagesReceivedCountControl.Inc()
+	default:
+		messagesReceivedCount.WithLabelValues(msgType).Inc()
+	}
+}
+
+func incActionCount(action string) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	switch action {
+	case "add_client":
+		actionCountAddClient.Inc()
+	case "remove_client":
+		actionCountRemoveClient.Inc()
+	case "add_subscription":
+		actionCountAddSub.Inc()
+	case "remove_subscription":
+		actionCountRemoveSub.Inc()
+	case "add_presence":
+		actionCountAddPresence.Inc()
+	case "remove_presence":
+		actionCountRemovePresence.Inc()
+	case "presence":
+		actionCountPresence.Inc()
+	case "presence_stats":
+		actionCountPresenceStats.Inc()
+	case "history_full":
+		actionCountHistoryFull.Inc()
+	case "history_recover":
+		actionCountHistoryRecover.Inc()
+	case "history_stream_top":
+		actionCountHistoryStreamTop.Inc()
+	case "history_remove":
+		actionCountHistoryRemove.Inc()
+	}
+}
+
+func initMetricsRegistry(registry prometheus.Registerer, metricsNamespace string) error {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	if metricsNamespace == "" {
+		metricsNamespace = defaultMetricsNamespace
+	}
+	if registry == nil {
+		registry = prometheus.DefaultRegisterer
+	}
+
 	messagesSentCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricsNamespace,
 		Subsystem: "node",
@@ -40,6 +286,13 @@ var (
 		Subsystem: "node",
 		Name:      "num_users",
 		Help:      "Number of unique users connected.",
+	})
+
+	numNodesGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metricsNamespace,
+		Subsystem: "node",
+		Name:      "num_nodes",
+		Help:      "Number of nodes in cluster.",
 	})
 
 	buildInfoGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -98,34 +351,6 @@ var (
 		Name:      "messages_sent",
 		Help:      "Number of messages sent over specific transport.",
 	}, []string{"transport"})
-)
-
-var (
-	messagesReceivedCountPublication prometheus.Counter
-	messagesReceivedCountJoin        prometheus.Counter
-	messagesReceivedCountLeave       prometheus.Counter
-	messagesReceivedCountControl     prometheus.Counter
-
-	messagesSentCountPublication prometheus.Counter
-	messagesSentCountJoin        prometheus.Counter
-	messagesSentCountLeave       prometheus.Counter
-	messagesSentCountControl     prometheus.Counter
-)
-
-func init() {
-	prometheus.MustRegister(messagesSentCount)
-	prometheus.MustRegister(messagesReceivedCount)
-	prometheus.MustRegister(actionCount)
-	prometheus.MustRegister(numClientsGauge)
-	prometheus.MustRegister(numUsersGauge)
-	prometheus.MustRegister(numChannelsGauge)
-	prometheus.MustRegister(commandDurationSummary)
-	prometheus.MustRegister(replyErrorCount)
-	prometheus.MustRegister(serverDisconnectCount)
-	prometheus.MustRegister(recoverCount)
-	prometheus.MustRegister(transportConnectCount)
-	prometheus.MustRegister(transportMessagesSent)
-	prometheus.MustRegister(buildInfoGauge)
 
 	messagesReceivedCountPublication = messagesReceivedCount.WithLabelValues("publication")
 	messagesReceivedCountJoin = messagesReceivedCount.WithLabelValues("join")
@@ -136,4 +361,71 @@ func init() {
 	messagesSentCountJoin = messagesReceivedCount.WithLabelValues("join")
 	messagesSentCountLeave = messagesReceivedCount.WithLabelValues("leave")
 	messagesSentCountControl = messagesReceivedCount.WithLabelValues("control")
+
+	actionCountAddClient = actionCount.WithLabelValues("add_client")
+	actionCountRemoveClient = actionCount.WithLabelValues("remove_client")
+	actionCountAddSub = actionCount.WithLabelValues("add_subscription")
+	actionCountRemoveSub = actionCount.WithLabelValues("remove_subscription")
+	actionCountAddPresence = actionCount.WithLabelValues("add_presence")
+	actionCountRemovePresence = actionCount.WithLabelValues("remove_presence")
+	actionCountPresence = actionCount.WithLabelValues("presence")
+	actionCountPresenceStats = actionCount.WithLabelValues("presence_stats")
+	actionCountHistoryFull = actionCount.WithLabelValues("history_full")
+	actionCountHistoryRecover = actionCount.WithLabelValues("history_recover")
+	actionCountHistoryStreamTop = actionCount.WithLabelValues("history_stream_top")
+	actionCountHistoryRemove = actionCount.WithLabelValues("history_remove")
+
+	recoverCountYes = recoverCount.WithLabelValues("yes")
+	recoverCountNo = recoverCount.WithLabelValues("no")
+
+	transportConnectCountWebsocket = transportConnectCount.WithLabelValues(transportWebsocket)
+	transportConnectCountSockJS = transportConnectCount.WithLabelValues(transportSockJS)
+
+	transportMessagesSentWebsocket = transportMessagesSent.WithLabelValues(transportWebsocket)
+	transportMessagesSentSockJS = transportMessagesSent.WithLabelValues(transportSockJS)
+
+	if err := registry.Register(messagesSentCount); err != nil {
+		return err
+	}
+	if err := registry.Register(messagesReceivedCount); err != nil {
+		return err
+	}
+	if err := registry.Register(actionCount); err != nil {
+		return err
+	}
+	if err := registry.Register(numClientsGauge); err != nil {
+		return err
+	}
+	if err := registry.Register(numUsersGauge); err != nil {
+		return err
+	}
+	if err := registry.Register(numChannelsGauge); err != nil {
+		return err
+	}
+	if err := registry.Register(numNodesGauge); err != nil {
+		return err
+	}
+	if err := registry.Register(commandDurationSummary); err != nil {
+		return err
+	}
+	if err := registry.Register(replyErrorCount); err != nil {
+		return err
+	}
+	if err := registry.Register(serverDisconnectCount); err != nil {
+		return err
+	}
+	if err := registry.Register(recoverCount); err != nil {
+		return err
+	}
+	if err := registry.Register(transportConnectCount); err != nil {
+		return err
+	}
+	if err := registry.Register(transportMessagesSent); err != nil {
+		return err
+	}
+	if err := registry.Register(buildInfoGauge); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
* refactor metrics (should allocate less, simpler to get rid of globals in future)
* provide a way to set custom Prometheus namespace to be used by internal metrics system
* add num nodes gauge