### PR TITLE
[issue #152] Enabled 'presence' for the 'gin_auth' example: 

### DIFF
--- a/_examples/gin_auth/chat.html
+++ b/_examples/gin_auth/chat.html
@@ -112,13 +112,16 @@
 
             function handleMessage(message) {
                 var clientID;
+                var user;
                 if (message.info) {
                     clientID = message.info.client;
+                    user = message.info.user;
                 } else {
                     clientID = null;
+                    user = null;
                 }
                 var inputText = message.data["input"].toString();
-                var text = safeTagsReplace(inputText) + ' <span class="muted">from ' + clientID + '</span>';
+                var text = safeTagsReplace(user + " says: " + inputText) + ' <span class="muted">from ' + clientID + '</span>';
                 drawText(text);
             }
 


### PR DESCRIPTION
- added ChannelOptionsFunc
- added a node.OnPresence handler
- ordered the node handlers alphabetically
- the chat.html page now shows the name of a user when they publish a message