### PR TITLE
fix InsufficientState error when using legacy seq, gen fields

### DIFF
--- a/_examples/redis_engine/index.html
+++ b/_examples/redis_engine/index.html
@@ -35,20 +35,6 @@
                     input.attr("disabled", true);
                 });
 
-                // show how many users currently in channel.
-                function showPresence(sub) {
-                    sub.presence().then(function(result) {
-                        var count = 0;
-                        for (var key in result.presence){
-                            count++;
-                        }
-                        drawText('Now in this room: ' + count + ' clients');
-                    }, function(err) {
-                        console.log("presence error", err);
-                        drawText("Presence error");
-                    });
-                }
-
                 // subscribe on channel and bind various event listeners. Actual
                 // subscription request will be sent after client connects to
                 // a server.
@@ -59,8 +45,6 @@
                         .on("subscribe", handleSubscribe)
                         .on("error", handleSubscribeError);
 
-                showPresence(sub);
-
                 // Trigger actual connection establishing with a server.
                 // At this moment actual client work starts - i.e. subscriptions
                 // defined start subscribing etc.
@@ -68,9 +52,6 @@
 
                 function handleSubscribe(ctx) {
                     drawText('Subscribed on channel ' + ctx.channel + ' (resubscribed: ' + ctx.isResubscribe + ', recovered: ' + ctx.recovered + ')');
-                    if (ctx.isResubscribe) {
-                        showPresence(sub);
-                    }
                 }
 
                 function handleSubscribeError(err) {

--- a/engine_redis.go
+++ b/engine_redis.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/centrifugal/centrifuge/internal/recovery"
 	"github.com/centrifugal/centrifuge/internal/timers"
 
 	"github.com/FZambia/sentinel"
@@ -1874,8 +1873,6 @@ func sliceOfPubsStream(result interface{}, err error) ([]*Publication, error) {
 	}
 	pubs := make([]*Publication, 0, len(values))
 
-	useSeqGen := hasFlag(CompatibilityFlags, UseSeqGen)
-
 	for i := 0; i < len(values); i++ {
 		streamElementValues, err := redis.Values(values[i], nil)
 		if err != nil {
@@ -1912,11 +1909,7 @@ func sliceOfPubsStream(result interface{}, err error) ([]*Publication, error) {
 		if err != nil {
 			return nil, fmt.Errorf("can not unmarshal value to Pub: %v", err)
 		}
-		if useSeqGen {
-			pub.Seq, pub.Gen = recovery.UnpackUint64(offset)
-		} else {
-			pub.Offset = offset
-		}
+		pub.Offset = offset
 		pubs = append(pubs, pubFromProto(&pub))
 	}
 	return pubs, nil
@@ -1928,8 +1921,6 @@ func sliceOfPubs(result interface{}, err error) ([]*Publication, error) {
 		return nil, err
 	}
 	pubs := make([]*Publication, 0, len(values))
-
-	useSeqGen := hasFlag(CompatibilityFlags, UseSeqGen)
 
 	for i := len(values) - 1; i >= 0; i-- {
 		value, okValue := values[i].([]byte)
@@ -1944,12 +1935,7 @@ func sliceOfPubs(result interface{}, err error) ([]*Publication, error) {
 		if err != nil {
 			return nil, fmt.Errorf("can not unmarshal value to Pub: %v", err)
 		}
-
-		if useSeqGen {
-			pub.Seq, pub.Gen = recovery.UnpackUint64(offset)
-		} else {
-			pub.Offset = offset
-		}
+		pub.Offset = offset
 		pubs = append(pubs, pubFromProto(&pub))
 	}
 	return pubs, nil


### PR DESCRIPTION
Without this fix, clients that used legacy seq and gen fields could get InsufficientState error when receiving next Publication after recovery process.