### PR TITLE
Better SockJS tests, refactor writer locking

### DIFF
--- a/handler_sockjs.go
+++ b/handler_sockjs.go
@@ -51,7 +51,12 @@ func (t *sockjsTransport) Write(data []byte) error {
 	case <-t.closeCh:
 		return nil
 	default:
-		return t.session.Send(string(data))
+		println("--->", string(data))
+		err := t.session.Send(string(data))
+		if err != nil {
+			println(err.Error())
+		}
+		return err
 	}
 }
 
@@ -197,7 +202,7 @@ func (s *SockjsHandler) sockJSHandler(sess sockjs.Session) {
 		for {
 			if msg, err := sess.Recv(); err == nil {
 				if ok := c.Handle([]byte(msg)); !ok {
-					return
+					break
 				}
 				continue
 			}

--- a/handler_sockjs.go
+++ b/handler_sockjs.go
@@ -51,12 +51,7 @@ func (t *sockjsTransport) Write(data []byte) error {
 	case <-t.closeCh:
 		return nil
 	default:
-		println("--->", string(data))
-		err := t.session.Send(string(data))
-		if err != nil {
-			println(err.Error())
-		}
-		return err
+		return t.session.Send(string(data))
 	}
 }
 

--- a/handler_sockjs.go
+++ b/handler_sockjs.go
@@ -197,7 +197,7 @@ func (s *SockjsHandler) sockJSHandler(sess sockjs.Session) {
 		for {
 			if msg, err := sess.Recv(); err == nil {
 				if ok := c.Handle([]byte(msg)); !ok {
-					break
+					return
 				}
 				continue
 			}

--- a/handler_sockjs_test.go
+++ b/handler_sockjs_test.go
@@ -104,7 +104,7 @@ func TestSockjsHandler(t *testing.T) {
 
 	select {
 	case <-doneCh:
-	case <-time.After(10 * time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("timeout waiting for closing done channel")
 	}
 }

--- a/handler_sockjs_test.go
+++ b/handler_sockjs_test.go
@@ -84,7 +84,6 @@ func TestSockjsHandler(t *testing.T) {
 	loop:
 		for {
 			_, p, err = conn.ReadMessage()
-			println(string(p))
 			if err != nil {
 				break loop
 			}

--- a/handler_websocket_test.go
+++ b/handler_websocket_test.go
@@ -39,7 +39,7 @@ func TestWebsocketHandlerPing(t *testing.T) {
 	n, _ := New(Config{})
 	mux := http.NewServeMux()
 	mux.Handle("/connection/websocket", NewWebsocketHandler(n, WebsocketConfig{
-		PingInterval: 10 * time.Millisecond,
+		PingInterval: time.Second,
 	}))
 	server := httptest.NewServer(mux)
 	defer server.Close()

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -122,7 +122,7 @@ func (q *byteQueue) Close() {
 	q.cond.Broadcast()
 }
 
-// CloseRemaining will close the queue and return all entried in the queue.
+// CloseRemaining will close the queue and return all entries in the queue.
 // All goroutines in wait() will return.
 func (q *byteQueue) CloseRemaining() [][]byte {
 	q.mu.Lock()

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -36,7 +36,7 @@ type Queue interface {
 	// be returned immediately.
 	// Will return "", false if the queue is closed.
 	// Otherwise the return value of "remove" is returned.
-	Wait() ([]byte, bool)
+	Wait() bool
 
 	// Cap returns the capacity (without allocations).
 	Cap() int
@@ -160,19 +160,19 @@ func (q *byteQueue) Closed() bool {
 // be returned immediately.
 // Will return nil, false if the queue is closed.
 // Otherwise the return value of "remove" is returned.
-func (q *byteQueue) Wait() ([]byte, bool) {
+func (q *byteQueue) Wait() bool {
 	q.mu.Lock()
 	if q.closed {
 		q.mu.Unlock()
-		return nil, false
+		return false
 	}
 	if q.cnt != 0 {
 		q.mu.Unlock()
-		return q.Remove()
+		return true
 	}
 	q.cond.Wait()
 	q.mu.Unlock()
-	return q.Remove()
+	return true
 }
 
 // Remove will remove a []byte from the queue.

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -155,11 +155,10 @@ func (q *byteQueue) Closed() bool {
 	return c
 }
 
-// Wait for a []byte to be added.
-// If there is items on the queue the first will
-// be returned immediately.
-// Will return nil, false if the queue is closed.
-// Otherwise the return value of "remove" is returned.
+// Wait for a message to be added.
+// If there are items on the queue will return immediately.
+// Will return false if the queue is closed.
+// Otherwise returns true.
 func (q *byteQueue) Wait() bool {
 	q.mu.Lock()
 	if q.closed {

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -42,11 +42,15 @@ func TestByteQueueWait(t *testing.T) {
 	q.Add([]byte("1"))
 	q.Add([]byte("2"))
 
-	s, ok := q.Wait()
+	ok := q.Wait()
+	require.Equal(t, true, ok)
+	s, ok := q.Remove()
 	require.Equal(t, true, ok)
 	require.Equal(t, "1", string(s))
 
-	s, ok = q.Wait()
+	ok = q.Wait()
+	require.Equal(t, true, ok)
+	s, ok = q.Remove()
 	require.Equal(t, true, ok)
 	require.Equal(t, "2", string(s))
 
@@ -54,7 +58,9 @@ func TestByteQueueWait(t *testing.T) {
 		q.Add([]byte("3"))
 	}()
 
-	s, ok = q.Wait()
+	ok = q.Wait()
+	require.Equal(t, true, ok)
+	s, ok = q.Remove()
 	require.Equal(t, true, ok)
 	require.Equal(t, "3", string(s))
 }
@@ -73,7 +79,7 @@ func TestByteQueueClose(t *testing.T) {
 	ok = q.Add([]byte("3"))
 	require.Equal(t, false, ok)
 
-	_, ok = q.Wait()
+	ok = q.Wait()
 	require.Equal(t, false, ok)
 
 	_, ok = q.Remove()
@@ -111,10 +117,11 @@ func addAndConsume(q Queue, n int) {
 	go func() {
 		count := 0
 		for {
-			_, ok := q.Wait()
+			ok := q.Wait()
 			if !ok {
 				continue
 			}
+			q.Remove()
 			count++
 			if count == n {
 				close(done)

--- a/writer.go
+++ b/writer.go
@@ -139,10 +139,7 @@ func (w *writer) close() error {
 	remaining := w.messages.CloseRemaining()
 	if len(remaining) > 0 {
 		// TODO: make it respect MaxMessagesInFrame option.
-		err := w.config.WriteManyFn(remaining...)
-		if err != nil {
-			println("remaining", err.Error())
-		}
+		_ = w.config.WriteManyFn(remaining...)
 	}
 
 	return nil

--- a/writer.go
+++ b/writer.go
@@ -35,9 +35,12 @@ const (
 
 func (w *writer) waitSendMessage(maxMessagesInFrame int) bool {
 	// Wait for message from queue.
-	msg, ok := w.messages.Wait()
+	_, ok := w.messages.Wait()
+
 	w.mu.Lock()
 	defer w.mu.Unlock()
+
+	msg, ok := w.messages.Remove()
 	if !ok {
 		if w.messages.Closed() {
 			return false

--- a/writer.go
+++ b/writer.go
@@ -35,7 +35,10 @@ const (
 
 func (w *writer) waitSendMessage(maxMessagesInFrame int) bool {
 	// Wait for message from queue.
-	_, ok := w.messages.Wait()
+	ok := w.messages.Wait()
+	if !ok {
+		return false
+	}
 
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/writer.go
+++ b/writer.go
@@ -33,6 +33,68 @@ const (
 	defaultMaxMessagesInFrame = 4
 )
 
+func (w *writer) waitSendMessage(maxMessagesInFrame int) bool {
+	// Wait for message from queue.
+	msg, ok := w.messages.Wait()
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !ok {
+		if w.messages.Closed() {
+			return false
+		}
+		return true
+	}
+
+	var writeErr error
+
+	messageCount := w.messages.Len()
+	if maxMessagesInFrame > 1 && messageCount > 0 {
+		// There are several more messages left in queue, try to send them in single frame,
+		// but no more than maxMessagesInFrame.
+
+		// Limit message count to get from queue with (maxMessagesInFrame - 1)
+		// (as we already have one message received from queue above).
+		messagesCap := messageCount + 1
+		if messagesCap > maxMessagesInFrame {
+			messagesCap = maxMessagesInFrame
+		}
+
+		msgs := make([][]byte, 0, messagesCap)
+		msgs = append(msgs, msg)
+
+		for messageCount > 0 {
+			messageCount--
+			if len(msgs) >= maxMessagesInFrame {
+				break
+			}
+			m, ok := w.messages.Remove()
+			if ok {
+				msgs = append(msgs, m)
+			} else {
+				if w.messages.Closed() {
+					return false
+				}
+				break
+			}
+		}
+		if len(msgs) > 0 {
+			if len(msgs) == 1 {
+				writeErr = w.config.WriteFn(msgs[0])
+			} else {
+				writeErr = w.config.WriteManyFn(msgs...)
+			}
+		}
+	} else {
+		// Write single message without allocating new [][]byte slice.
+		writeErr = w.config.WriteFn(msg)
+	}
+	if writeErr != nil {
+		// Write failed, transport must close itself, here we just return from routine.
+		return false
+	}
+	return true
+}
+
 // run supposed to be run in goroutine, this goroutine will be closed as
 // soon as queue is closed.
 func (w *writer) run() {
@@ -42,64 +104,8 @@ func (w *writer) run() {
 	}
 
 	for {
-		// Wait for message from queue.
-		msg, ok := w.messages.Wait()
+		ok := w.waitSendMessage(maxMessagesInFrame)
 		if !ok {
-			if w.messages.Closed() {
-				return
-			}
-			continue
-		}
-
-		var writeErr error
-
-		messageCount := w.messages.Len()
-		if maxMessagesInFrame > 1 && messageCount > 0 {
-			// There are several more messages left in queue, try to send them in single frame,
-			// but no more than maxMessagesInFrame.
-
-			// Limit message count to get from queue with (maxMessagesInFrame - 1)
-			// (as we already have one message received from queue above).
-			messagesCap := messageCount + 1
-			if messagesCap > maxMessagesInFrame {
-				messagesCap = maxMessagesInFrame
-			}
-
-			msgs := make([][]byte, 0, messagesCap)
-			msgs = append(msgs, msg)
-
-			for messageCount > 0 {
-				messageCount--
-				if len(msgs) >= maxMessagesInFrame {
-					break
-				}
-				m, ok := w.messages.Remove()
-				if ok {
-					msgs = append(msgs, m)
-				} else {
-					if w.messages.Closed() {
-						return
-					}
-					break
-				}
-			}
-			if len(msgs) > 0 {
-				w.mu.Lock()
-				if len(msgs) == 1 {
-					writeErr = w.config.WriteFn(msgs[0])
-				} else {
-					writeErr = w.config.WriteManyFn(msgs...)
-				}
-				w.mu.Unlock()
-			}
-		} else {
-			// Write single message without allocating new [][]byte slice.
-			w.mu.Lock()
-			writeErr = w.config.WriteFn(msg)
-			w.mu.Unlock()
-		}
-		if writeErr != nil {
-			// Write failed, transport must close itself, here we just return from routine.
 			return
 		}
 	}
@@ -118,19 +124,19 @@ func (w *writer) enqueue(data []byte) *Disconnect {
 
 func (w *writer) close() error {
 	w.mu.Lock()
+	defer w.mu.Unlock()
 	if w.closed {
-		w.mu.Unlock()
 		return nil
 	}
 	w.closed = true
-	w.mu.Unlock()
 
 	remaining := w.messages.CloseRemaining()
 	if len(remaining) > 0 {
-		w.mu.Lock()
 		// TODO: make it respect MaxMessagesInFrame option.
-		_ = w.config.WriteManyFn(remaining...)
-		w.mu.Unlock()
+		err := w.config.WriteManyFn(remaining...)
+		if err != nil {
+			println("remaining", err.Error())
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The important thing here is refactored writer: using updated queue implementation we handle a case when not all messages could be sent on client close since writer routine executed concurrently with close. Now we more accurately lock code to avoid message loss on close.

Also this pr has fixes for custom disconnect code in SockJS transport – handler is now waits until transport closed with a proper disconnect reason before closing normally.