### PR TITLE
Subscribe options, change Broker Publish method signature

### DIFF
--- a/_examples/chat_json/main.go
+++ b/_examples/chat_json/main.go
@@ -78,8 +78,8 @@ func main() {
 		return centrifuge.ConnectReply{
 			Data: []byte(`{}`),
 			// Subscribe to personal several server-side channel.
-			Subscriptions: []centrifuge.Subscription{
-				{Channel: "#" + cred.UserID, Recover: true, Presence: true, JoinLeave: true},
+			Subscriptions: map[string]centrifuge.SubscribeOptions{
+				"#" + cred.UserID: {Recover: true, Presence: true, JoinLeave: true},
 			},
 		}, nil
 	})
@@ -125,9 +125,11 @@ func main() {
 				return
 			}
 			cb(centrifuge.SubscribeReply{
-				Recover:   true,
-				Presence:  true,
-				JoinLeave: true,
+				Options: centrifuge.SubscribeOptions{
+					Recover:   true,
+					Presence:  true,
+					JoinLeave: true,
+				},
 			}, nil)
 		})
 

--- a/_examples/concurrency/main.go
+++ b/_examples/concurrency/main.go
@@ -59,8 +59,8 @@ func main() {
 		return centrifuge.ConnectReply{
 			Data: []byte(`{}`),
 			// Subscribe to personal several server-side channel.
-			Subscriptions: []centrifuge.Subscription{
-				{Channel: "#" + cred.UserID},
+			Subscriptions: map[string]centrifuge.SubscribeOptions{
+				"#" + cred.UserID: {},
 			},
 		}, nil
 	})

--- a/_examples/custom_broker/main.go
+++ b/_examples/custom_broker/main.go
@@ -64,8 +64,10 @@ func main() {
 		client.OnSubscribe(func(e centrifuge.SubscribeEvent, cb centrifuge.SubscribeCallback) {
 			log.Printf("user %s subscribes on %s", client.UserID(), e.Channel)
 			cb(centrifuge.SubscribeReply{
-				Presence:  true,
-				JoinLeave: true,
+				Options: centrifuge.SubscribeOptions{
+					Presence:  true,
+					JoinLeave: true,
+				},
 			}, nil)
 		})
 

--- a/_examples/custom_broker/natsbroker/broker.go
+++ b/_examples/custom_broker/natsbroker/broker.go
@@ -108,7 +108,11 @@ type push struct {
 }
 
 // Publish - see Engine interface description.
-func (b *NatsBroker) Publish(ch string, pub *centrifuge.Publication, _ centrifuge.PublishOptions) (centrifuge.StreamPosition, error) {
+func (b *NatsBroker) Publish(ch string, data []byte, opts centrifuge.PublishOptions) (centrifuge.StreamPosition, error) {
+	pub := &centrifuge.Publication{
+		Data: data,
+		Info: opts.ClientInfo,
+	}
 	data, err := json.Marshal(pub)
 	if err != nil {
 		return centrifuge.StreamPosition{}, err

--- a/_examples/custom_broker/natsbroker/broker_test.go
+++ b/_examples/custom_broker/natsbroker/broker_test.go
@@ -24,11 +24,10 @@ func NewTestNatsBrokerWithPrefix(prefix string) *NatsBroker {
 
 func BenchmarkNatsEnginePublish(b *testing.B) {
 	broker := newTestNatsBroker()
-	rawData := centrifuge.Raw([]byte(`{"bench": true}`))
-	pub := &centrifuge.Publication{UID: "test UID", Data: rawData}
+	rawData := []byte(`{"bench": true}`)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err := broker.Publish("channel", pub, &centrifuge.ChannelOptions{HistorySize: 0, HistoryLifetime: 0})
+		_, err := broker.Publish("channel", rawData, centrifuge.PublishOptions{})
 		if err != nil {
 			panic(err)
 		}
@@ -37,13 +36,12 @@ func BenchmarkNatsEnginePublish(b *testing.B) {
 
 func BenchmarkNatsEnginePublishParallel(b *testing.B) {
 	broker := newTestNatsBroker()
-	rawData := centrifuge.Raw([]byte(`{"bench": true}`))
-	pub := &centrifuge.Publication{UID: "test UID", Data: rawData}
+	rawData := []byte(`{"bench": true}`)
 	b.SetParallelism(128)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			err := broker.Publish("channel", pub, &centrifuge.ChannelOptions{HistorySize: 0, HistoryLifetime: 0})
+			_, err := broker.Publish("channel", rawData, centrifuge.PublishOptions{})
 			if err != nil {
 				panic(err)
 			}

--- a/_examples/custom_ws_nhooyr/main.go
+++ b/_examples/custom_ws_nhooyr/main.go
@@ -101,7 +101,9 @@ func main() {
 		client.OnSubscribe(func(e centrifuge.SubscribeEvent, cb centrifuge.SubscribeCallback) {
 			log.Printf("user %s subscribes on %s", client.UserID(), e.Channel)
 			cb(centrifuge.SubscribeReply{
-				ExpireAt: time.Now().Unix() + 60,
+				Options: centrifuge.SubscribeOptions{
+					ExpireAt: time.Now().Unix() + 60,
+				},
 			}, nil)
 		})
 

--- a/_examples/jwt_token/main.go
+++ b/_examples/jwt_token/main.go
@@ -69,9 +69,9 @@ func main() {
 			}
 			return centrifuge.ConnectReply{}, centrifuge.DisconnectInvalidToken
 		}
-		subs := make([]centrifuge.Subscription, 0, len(token.Channels))
+		subs := make(map[string]centrifuge.SubscribeOptions, len(token.Channels))
 		for _, ch := range token.Channels {
-			subs = append(subs, centrifuge.Subscription{Channel: ch})
+			subs[ch] = centrifuge.SubscribeOptions{}
 		}
 		return centrifuge.ConnectReply{
 			Credentials: &centrifuge.Credentials{

--- a/_examples/redis_engine/main.go
+++ b/_examples/redis_engine/main.go
@@ -64,9 +64,11 @@ func main() {
 		client.OnSubscribe(func(e centrifuge.SubscribeEvent, cb centrifuge.SubscribeCallback) {
 			log.Printf("user %s subscribes on %s", client.UserID(), e.Channel)
 			cb(centrifuge.SubscribeReply{
-				Presence:  true,
-				JoinLeave: true,
-				Recover:   true,
+				Options: centrifuge.SubscribeOptions{
+					Presence:  true,
+					JoinLeave: true,
+					Recover:   true,
+				},
 			}, nil)
 		})
 
@@ -77,8 +79,10 @@ func main() {
 		client.OnPublish(func(e centrifuge.PublishEvent, cb centrifuge.PublishCallback) {
 			log.Printf("user %s publishes into channel %s: %s", client.UserID(), e.Channel, string(e.Data))
 			cb(centrifuge.PublishReply{
-				HistorySize: 100,
-				HistoryTTL:  5 * time.Second,
+				Options: centrifuge.PublishOptions{
+					HistorySize: 100,
+					HistoryTTL:  5 * time.Second,
+				},
 			}, nil)
 		})
 

--- a/changelog.md
+++ b/changelog.md
@@ -127,7 +127,7 @@ As you can see there are three important changes:
 
 1) You should now set up event handlers inside `node.OnConnect` closure
 2) Event handlers now have callback argument that you should call with corresponding Reply as soon as you have it
-3) For server-side subscriptions you should now return slice of `Subscription` instead of `[]string` Channels slice.
+3) For server-side subscriptions you should now return `Subscriptions` field in `ConnectReply` which is `map[string]SubscribeOptions` instead of `[]string` slice.
 
 See [new example that demonstrates concurrency](https://github.com/centrifugal/centrifuge/tree/master/_examples/concurrency) using bounded semaphore.
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,10 @@ This release solves two important issues from v1.0.0 library milestone. It has A
 
 * [#163](https://github.com/centrifugal/centrifuge/issues/163) Provide a way to add concurrent processing of protocol commands. Before this change protocol commands could only be processed one by one. The obvious drawback in this case is that one slow RPC could result into stopping other requests from being processed thus affecting overall latency. This required changing client handler API and use asynchronous callback style API for returning replies from event handlers. This approach while not being very idiomatic allows using whatever concurrency strategy developer wants without losing the possibility to control event order.
 * [#161](https://github.com/centrifugal/centrifuge/issues/161) Eliminating `ChannelOptionsFunc` – now all channel options can be provided when calling `Publish` operation (history size and TTL) or by returning from event handlers inside `SubscribeReply` (enabling channel presence, join/leave messages, recovery in a channel). This means that channel options can now be controlled per-connection (not only per channel as before). For example if you need admin connection to subscribe to channel but not participate in channel presence – you are able to not enable presence for that connection.  
-* Server-side subscriptions now set over `Subscriptions` field (instead of `Channels`). `Subscription` struct has channel options, so you can explicitly provide them. Again – with per-connection resolution.
+* Server-side subscriptions now set over `Subscriptions` map (instead of `Channels`). Again – subscribe options can be set with per-connection resolution.
+* Change signature of `Publish` method in `Broker` interface – method now accepts `[]byte` data instead of `*Publication`.  
+* Function options for `Unsubbscribe` and `Disconnect` methods now have boolean argument.
+* History functional option `WithNoLimit` removed – use `WithLimit(centrifuge.NoLimit)` instead. 
 
 Since API changes are pretty big, let's look at example program and how to adapt it from v0.12.0 to v0.13.0.
 
@@ -81,8 +84,8 @@ func main() {
 		return centrifuge.ConnectReply{
 			Credentials: &centrifuge.Credentials{UserID: "42"},
 			// Subscribe to server-side channel.
-			Subscriptions: []centrifuge.Subscription{
-				{Channel: "news", Presence: true, JoinLeave: true, Recover: true},
+			Subscriptions: map[string]centrifuge.SubscribeOptions{
+				"news": {Presence: true, JoinLeave: true, Recover: true},
 			},
 		}, nil
 	})
@@ -92,7 +95,11 @@ func main() {
 
 		client.OnSubscribe(func(e centrifuge.SubscribeEvent, cb centrifuge.SubscribeCallback) {
 			cb(centrifuge.SubscribeReply{
-				Presence: true, JoinLeave: true, Recover: true,
+				Options: centrifuge.SubscribeOptions{
+					Presence:  true,
+					JoinLeave: true,
+					Recover:   true,
+				},
 			}, nil)
 		})
 
@@ -100,8 +107,10 @@ func main() {
 			// BTW you can publish here explicitly using node.Publish method – see Result
 			// field of PublishReply and chat_json example.
 			cb(centrifuge.PublishReply{
-				HistorySize: 100,
-				HistoryTTL:  5 * time.Minute,
+				Options: centrifuge.PublishOptions{
+					HistorySize: 100,
+					HistoryTTL:  5 * time.Minute,
+				},
 			}, nil)
 		})
 
@@ -113,6 +122,12 @@ func main() {
 	_ = node.Run()
 }
 ```
+
+As you can see there are three important changes:
+
+1) You should now set up event handlers inside `node.OnConnect` closure
+2) Event handlers now have callback argument that you should call with corresponding Reply as soon as you have it
+3) For server-side subscriptions you should now return slice of `Subscription` instead of `[]string` Channels slice.
 
 See [new example that demonstrates concurrency](https://github.com/centrifugal/centrifuge/tree/master/_examples/concurrency) using bounded semaphore.
 

--- a/client_test.go
+++ b/client_test.go
@@ -381,7 +381,7 @@ func TestClientSubscribeEngineErrorOnStreamTop(t *testing.T) {
 	node.OnConnect(func(client *Client) {
 		client.OnSubscribe(func(event SubscribeEvent, callback SubscribeCallback) {
 			callback(SubscribeReply{
-				Recover: true,
+				Options: SubscribeOptions{Recover: true},
 			}, nil)
 		})
 		client.OnDisconnect(func(event DisconnectEvent) {
@@ -416,9 +416,7 @@ func TestClientSubscribeEngineErrorOnRecoverHistory(t *testing.T) {
 
 	node.OnConnect(func(client *Client) {
 		client.OnSubscribe(func(event SubscribeEvent, callback SubscribeCallback) {
-			callback(SubscribeReply{
-				Recover: true,
-			}, nil)
+			callback(SubscribeReply{Options: SubscribeOptions{Recover: true}}, nil)
 		})
 		client.OnDisconnect(func(event DisconnectEvent) {
 			require.Equal(t, DisconnectServerError, event.Disconnect)
@@ -644,9 +642,9 @@ func TestServerSideSubscriptions(t *testing.T) {
 
 	node.OnConnecting(func(context.Context, ConnectEvent) (ConnectReply, error) {
 		return ConnectReply{
-			Subscriptions: []Subscription{
-				{Channel: "server-side-1"},
-				{Channel: "$server-side-2"},
+			Subscriptions: map[string]SubscribeOptions{
+				"server-side-1":  {},
+				"$server-side-2": {},
 			},
 		}, nil
 	})
@@ -713,9 +711,7 @@ func TestClientSubscribeLast(t *testing.T) {
 
 	node.OnConnect(func(client *Client) {
 		client.OnSubscribe(func(event SubscribeEvent, cb SubscribeCallback) {
-			cb(SubscribeReply{
-				Recover: true,
-			}, nil)
+			cb(SubscribeReply{Options: SubscribeOptions{Recover: true}}, nil)
 		})
 	})
 
@@ -1158,9 +1154,7 @@ func TestClientPresence(t *testing.T) {
 	client := newTestClient(t, node, "42")
 
 	client.OnSubscribe(func(event SubscribeEvent, cb SubscribeCallback) {
-		cb(SubscribeReply{
-			Presence: true,
-		}, nil)
+		cb(SubscribeReply{Options: SubscribeOptions{Presence: true}}, nil)
 	})
 
 	client.OnPresence(func(e PresenceEvent, cb PresenceCallback) {
@@ -1696,7 +1690,7 @@ func TestClientPresenceUpdate(t *testing.T) {
 	node.OnConnect(func(client *Client) {
 		client.OnSubscribe(func(event SubscribeEvent, cb SubscribeCallback) {
 			cb(SubscribeReply{
-				Presence: true,
+				Options: SubscribeOptions{Presence: true},
 			}, nil)
 		})
 	})
@@ -1727,8 +1721,10 @@ func TestClientSubExpired(t *testing.T) {
 	node.OnConnect(func(client *Client) {
 		client.OnSubscribe(func(event SubscribeEvent, cb SubscribeCallback) {
 			cb(SubscribeReply{
-				ExpireAt: time.Now().Unix() + 1,
-				Presence: true,
+				Options: SubscribeOptions{
+					ExpireAt: time.Now().Unix() + 1,
+					Presence: true,
+				},
 			}, nil)
 		})
 
@@ -1984,7 +1980,9 @@ func TestClientSideSubRefresh(t *testing.T) {
 	node.OnConnect(func(client *Client) {
 		client.OnSubscribe(func(_ SubscribeEvent, cb SubscribeCallback) {
 			cb(SubscribeReply{
-				ExpireAt:          time.Now().Unix() + 10,
+				Options: SubscribeOptions{
+					ExpireAt: time.Now().Unix() + 10,
+				},
 				ClientSideRefresh: true,
 			}, nil)
 		})

--- a/engine.go
+++ b/engine.go
@@ -91,8 +91,8 @@ type PublishOptions struct {
 	HistoryTTL time.Duration
 	// HistorySize sets history size limit to prevent infinite stream growth.
 	HistorySize int
-
-	clientInfo *ClientInfo
+	// ClientInfo to include into Publication. By default no ClientInfo will be appended.
+	ClientInfo *ClientInfo
 }
 
 // Broker is responsible for PUB/SUB mechanics.
@@ -119,7 +119,7 @@ type Broker interface {
 	//
 	// StreamPosition returned here describes current stream top offset and epoch.
 	// For channels without history this StreamPosition should be empty.
-	Publish(ch string, pub *Publication, opts PublishOptions) (StreamPosition, error)
+	Publish(ch string, data []byte, opts PublishOptions) (StreamPosition, error)
 	// PublishJoin publishes Join Push message into channel.
 	PublishJoin(ch string, info *ClientInfo) error
 	// PublishLeave publishes Leave Push message into channel.

--- a/engine_memory.go
+++ b/engine_memory.go
@@ -77,16 +77,21 @@ func (e *MemoryEngine) pubLock(ch string) *sync.Mutex {
 
 // Publish adds message into history hub and calls node method to handle message.
 // We don't have any PUB/SUB here as Memory Engine is single node only.
-func (e *MemoryEngine) Publish(ch string, pub *Publication, opts PublishOptions) (StreamPosition, error) {
+func (e *MemoryEngine) Publish(ch string, data []byte, opts PublishOptions) (StreamPosition, error) {
 	mu := e.pubLock(ch)
 	mu.Lock()
 	defer mu.Unlock()
 
+	pub := &Publication{
+		Data: data,
+		Info: opts.ClientInfo,
+	}
 	if opts.HistorySize > 0 && opts.HistoryTTL > 0 {
 		streamTop, err := e.historyHub.add(ch, pub, opts)
 		if err != nil {
 			return StreamPosition{}, err
 		}
+		pub.Offset = streamTop.Offset
 		return streamTop, e.eventHandler.HandlePublication(ch, pub)
 	}
 	return StreamPosition{}, e.eventHandler.HandlePublication(ch, pub)

--- a/engine_memory_test.go
+++ b/engine_memory_test.go
@@ -25,13 +25,17 @@ func newTestPublication() *Publication {
 	return &Publication{Data: []byte("{}")}
 }
 
+func testPublicationData() []byte {
+	return []byte("{}")
+}
+
 func TestMemoryEnginePublishHistory(t *testing.T) {
 	e := testMemoryEngine()
 
 	require.NotEqual(t, nil, e.historyHub)
 	require.NotEqual(t, nil, e.presenceHub)
 
-	_, err := e.Publish("channel", newTestPublication(), PublishOptions{})
+	_, err := e.Publish("channel", testPublicationData(), PublishOptions{})
 	require.NoError(t, err)
 
 	err = e.PublishJoin("channel", &ClientInfo{})
@@ -49,7 +53,7 @@ func TestMemoryEnginePublishHistory(t *testing.T) {
 	pub := newTestPublication()
 
 	// test adding history.
-	_, err = e.Publish("channel", pub, PublishOptions{HistorySize: 4, HistoryTTL: time.Second})
+	_, err = e.Publish("channel", testPublicationData(), PublishOptions{HistorySize: 4, HistoryTTL: time.Second})
 	require.NoError(t, err)
 	pubs, _, err := e.History("channel", HistoryFilter{
 		Limit: -1,
@@ -60,11 +64,11 @@ func TestMemoryEnginePublishHistory(t *testing.T) {
 	require.Equal(t, pubs[0].Data, pub.Data)
 
 	// test history limit.
-	_, err = e.Publish("channel", pub, PublishOptions{HistorySize: 4, HistoryTTL: time.Second})
+	_, err = e.Publish("channel", testPublicationData(), PublishOptions{HistorySize: 4, HistoryTTL: time.Second})
 	require.NoError(t, err)
-	_, err = e.Publish("channel", pub, PublishOptions{HistorySize: 4, HistoryTTL: time.Second})
+	_, err = e.Publish("channel", testPublicationData(), PublishOptions{HistorySize: 4, HistoryTTL: time.Second})
 	require.NoError(t, err)
-	_, err = e.Publish("channel", pub, PublishOptions{HistorySize: 4, HistoryTTL: time.Second})
+	_, err = e.Publish("channel", testPublicationData(), PublishOptions{HistorySize: 4, HistoryTTL: time.Second})
 	require.NoError(t, err)
 	pubs, _, err = e.History("channel", HistoryFilter{
 		Limit: 2,
@@ -74,11 +78,11 @@ func TestMemoryEnginePublishHistory(t *testing.T) {
 	require.Equal(t, 2, len(pubs))
 
 	// test history limit greater than history size
-	_, err = e.Publish("channel", pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second})
+	_, err = e.Publish("channel", testPublicationData(), PublishOptions{HistorySize: 1, HistoryTTL: time.Second})
 	require.NoError(t, err)
-	_, err = e.Publish("channel", pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second})
+	_, err = e.Publish("channel", testPublicationData(), PublishOptions{HistorySize: 1, HistoryTTL: time.Second})
 	require.NoError(t, err)
-	_, err = e.Publish("channel", pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second})
+	_, err = e.Publish("channel", testPublicationData(), PublishOptions{HistorySize: 1, HistoryTTL: time.Second})
 	require.NoError(t, err)
 	pubs, _, err = e.History("channel", HistoryFilter{
 		Limit: 2,
@@ -253,11 +257,8 @@ func TestMemoryHistoryHubMetaTTL(t *testing.T) {
 func TestMemoryEngineRecover(t *testing.T) {
 	e := testMemoryEngine()
 
-	rawData := protocol.Raw("{}")
-
 	for i := 0; i < 5; i++ {
-		pub := &Publication{Data: rawData}
-		_, err := e.Publish("channel", pub, PublishOptions{HistorySize: 10, HistoryTTL: 2 * time.Second})
+		_, err := e.Publish("channel", testPublicationData(), PublishOptions{HistorySize: 10, HistoryTTL: 2 * time.Second})
 		require.NoError(t, err)
 	}
 
@@ -278,8 +279,7 @@ func TestMemoryEngineRecover(t *testing.T) {
 	require.Equal(t, uint64(5), pubs[2].Offset)
 
 	for i := 0; i < 10; i++ {
-		pub := &Publication{Data: rawData}
-		_, err := e.Publish("channel", pub, PublishOptions{HistorySize: 10, HistoryTTL: 2 * time.Second})
+		_, err := e.Publish("channel", testPublicationData(), PublishOptions{HistorySize: 10, HistoryTTL: 2 * time.Second})
 		require.NoError(t, err)
 	}
 
@@ -309,10 +309,9 @@ func TestMemoryEngineRecover(t *testing.T) {
 func BenchmarkMemoryPublish_OneChannel(b *testing.B) {
 	e := testMemoryEngine()
 	rawData := protocol.Raw(`{"bench": true}`)
-	pub := &Publication{Data: rawData}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := e.Publish("channel", pub, PublishOptions{})
+		_, err := e.Publish("channel", rawData, PublishOptions{})
 		if err != nil {
 			panic(err)
 		}
@@ -322,12 +321,11 @@ func BenchmarkMemoryPublish_OneChannel(b *testing.B) {
 func BenchmarkMemoryPublish_OneChannel_Parallel(b *testing.B) {
 	e := testMemoryEngine()
 	rawData := protocol.Raw(`{"bench": true}`)
-	pub := &Publication{Data: rawData}
 	b.SetParallelism(128)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			_, err := e.Publish("channel", pub, PublishOptions{})
+			_, err := e.Publish("channel", rawData, PublishOptions{})
 			if err != nil {
 				panic(err)
 			}
@@ -338,12 +336,11 @@ func BenchmarkMemoryPublish_OneChannel_Parallel(b *testing.B) {
 func BenchmarkMemoryPublish_History_OneChannel(b *testing.B) {
 	e := testMemoryEngine()
 	rawData := protocol.Raw(`{"bench": true}`)
-	pub := &Publication{Data: rawData}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		chOpts := PublishOptions{HistorySize: 100, HistoryTTL: 60 * time.Second}
 		var err error
-		streamTop, err := e.Publish("channel", pub, chOpts)
+		streamTop, err := e.Publish("channel", rawData, chOpts)
 		if err != nil {
 			panic(err)
 		}
@@ -361,9 +358,8 @@ func BenchmarkMemoryPublish_History_OneChannel_Parallel(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			pub := &Publication{Data: rawData}
 			var err error
-			streamTop, err := e.Publish("channel", pub, chOpts)
+			streamTop, err := e.Publish("channel", rawData, chOpts)
 			if err != nil {
 				panic(err)
 			}
@@ -427,9 +423,8 @@ func BenchmarkMemoryPresence_OneChannel_Parallel(b *testing.B) {
 func BenchmarkMemoryHistory_OneChannel(b *testing.B) {
 	e := testMemoryEngine()
 	rawData := protocol.Raw("{}")
-	pub := &Publication{Data: rawData}
 	for i := 0; i < 4; i++ {
-		_, _ = e.Publish("channel", pub, PublishOptions{HistorySize: 4, HistoryTTL: 300 * time.Second})
+		_, _ = e.Publish("channel", rawData, PublishOptions{HistorySize: 4, HistoryTTL: 300 * time.Second})
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -446,9 +441,8 @@ func BenchmarkMemoryHistory_OneChannel(b *testing.B) {
 func BenchmarkMemoryHistory_OneChannel_Parallel(b *testing.B) {
 	e := testMemoryEngine()
 	rawData := protocol.Raw("{}")
-	pub := &Publication{Data: rawData}
 	for i := 0; i < 4; i++ {
-		_, _ = e.Publish("channel", pub, PublishOptions{HistorySize: 4, HistoryTTL: 300 * time.Second})
+		_, _ = e.Publish("channel", rawData, PublishOptions{HistorySize: 4, HistoryTTL: 300 * time.Second})
 	}
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -470,8 +464,7 @@ func BenchmarkMemoryRecover_OneChannel_Parallel(b *testing.B) {
 	numMessages := 1000
 	numMissing := 5
 	for i := 1; i <= numMessages; i++ {
-		pub := &Publication{Data: rawData}
-		_, _ = e.Publish("channel", pub, PublishOptions{HistorySize: numMessages, HistoryTTL: 300 * time.Second})
+		_, _ = e.Publish("channel", rawData, PublishOptions{HistorySize: numMessages, HistoryTTL: 300 * time.Second})
 	}
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -528,7 +521,8 @@ func TestMemoryClientSubscribeRecover(t *testing.T) {
 			node := nodeWithMemoryEngineNoHandlers()
 			node.OnConnect(func(client *Client) {
 				client.OnSubscribe(func(event SubscribeEvent, cb SubscribeCallback) {
-					cb(SubscribeReply{Recover: true}, nil)
+					opts := SubscribeOptions{Recover: true}
+					cb(SubscribeReply{Options: opts}, nil)
 				})
 			})
 
@@ -600,7 +594,7 @@ func (it *historyIterationTest) prepareHistoryIteration(t testing.TB, node *Node
 		require.NoError(t, err)
 	}
 
-	historyResult, err = node.History(channel, WithNoLimit())
+	historyResult, err = node.History(channel, WithLimit(NoLimit))
 	require.NoError(t, err)
 	require.Equal(t, numMessages, len(historyResult.Publications))
 	return startPosition

--- a/engine_redis.go
+++ b/engine_redis.go
@@ -606,8 +606,8 @@ func (e *RedisEngine) Run(h BrokerEventHandler) error {
 }
 
 // Publish - see engine interface description.
-func (e *RedisEngine) Publish(ch string, pub *Publication, opts PublishOptions) (StreamPosition, error) {
-	return e.getShard(ch).Publish(ch, pub, opts)
+func (e *RedisEngine) Publish(ch string, data []byte, opts PublishOptions) (StreamPosition, error) {
+	return e.getShard(ch).Publish(ch, data, opts)
 }
 
 // PublishJoin - see engine interface description.
@@ -1341,8 +1341,12 @@ func (s *shard) runDataPipeline() {
 }
 
 // Publish adds Publication to history Stream or List if needed and sends to PUB/SUB.
-func (s *shard) Publish(ch string, pub *Publication, opts PublishOptions) (StreamPosition, error) {
-	byteMessage, err := pubToProto(pub).Marshal()
+func (s *shard) Publish(ch string, data []byte, opts PublishOptions) (StreamPosition, error) {
+	protoPub := &protocol.Publication{
+		Data: data,
+		Info: infoToProto(opts.ClientInfo),
+	}
+	byteMessage, err := protoPub.Marshal()
 	if err != nil {
 		return StreamPosition{}, err
 	}

--- a/events.go
+++ b/events.go
@@ -2,7 +2,6 @@ package centrifuge
 
 import (
 	"context"
-	"time"
 )
 
 // ConnectEvent contains fields related to connecting event.
@@ -31,25 +30,12 @@ type ConnectReply struct {
 	Credentials *Credentials
 	// Data allows to set custom data in connect reply.
 	Data []byte
-	// Subs slice contains channels to subscribe connection to on server-side.
-	Subscriptions []Subscription
+	// Subscriptions map contains channels to subscribe connection to on server-side.
+	Subscriptions map[string]SubscribeOptions
 	// ClientSideRefresh tells library to use client-side refresh logic:
 	// i.e. send refresh commands with new connection token. If not set
 	// then server-side refresh mechanism will be used.
 	ClientSideRefresh bool
-}
-
-// Subscription describes server-side client subscription to channel.
-type Subscription struct {
-	// Channel to subscribe connection to.
-	Channel string
-	// Recover turns on recovery option for channel. Make sure you are using recovery in channels
-	// that maintain Publication history stream.
-	Recover bool
-	// Presence turns on participating in channel presence.
-	Presence bool
-	// JoinLeave enables sending Join and Leave messages for this client in channel.
-	JoinLeave bool
 }
 
 // ConnectingHandler called when new client authenticates on server.
@@ -136,22 +122,13 @@ type SubscribeCallback func(SubscribeReply, error)
 
 // SubscribeReply contains fields determining the reaction on subscribe event.
 type SubscribeReply struct {
-	// ExpireAt defines time in future when subscription should expire,
-	// zero value means no expiration.
-	ExpireAt int64
-	// ChannelInfo defines custom channel information, zero value means no channel information.
-	ChannelInfo []byte
+	// Options to control subscription.
+	Options SubscribeOptions
+
 	// ClientSideRefresh tells library to use client-side refresh logic: i.e. send
 	// SubRefresh commands with new Subscription Token. If not set then server-side
 	// SubRefresh handler will be used.
 	ClientSideRefresh bool
-	// Recover turns on recovery option for channel. Make sure you are using recovery in channels
-	// that maintain Publication history stream.
-	Recover bool
-	// Presence turns on participating in channel presence.
-	Presence bool
-	// JoinLeave enables sending Join and Leave messages for this client in channel.
-	JoinLeave bool
 }
 
 // SubscribeHandler called when client wants to subscribe on channel.
@@ -180,12 +157,8 @@ type PublishEvent struct {
 
 // PublishReply contains fields determining the result on publish.
 type PublishReply struct {
-	// Control history size.
-	HistorySize int
-	// Control history TTL.
-	HistoryTTL time.Duration
-	// ClientInfo to include into Publication. By default no ClientInfo will be appended.
-	ClientInfo *ClientInfo
+	// Options to control publication.
+	Options PublishOptions
 
 	// Result if set will tell Centrifuge that message already published to
 	// channel by handler code. In this case Centrifuge won't try to publish

--- a/node.go
+++ b/node.go
@@ -463,18 +463,11 @@ func (n *Node) publish(ch string, data []byte, opts ...PublishOption) (PublishRe
 	for _, opt := range opts {
 		opt(pubOpts)
 	}
-
-	pub := &Publication{
-		Data: data,
-		Info: pubOpts.clientInfo,
-	}
-
 	incMessagesSent("publication")
-	streamPos, err := n.broker.Publish(ch, pub, *pubOpts)
+	streamPos, err := n.broker.Publish(ch, data, *pubOpts)
 	if err != nil {
 		return PublishResult{}, err
 	}
-	pub.Offset = streamPos.Offset
 	return PublishResult{StreamPosition: streamPos}, nil
 }
 
@@ -856,7 +849,7 @@ func (n *Node) History(ch string, opts ...HistoryOption) (HistoryResult, error) 
 // recoverHistory recovers publications since last UID seen by client.
 func (n *Node) recoverHistory(ch string, since StreamPosition) (HistoryResult, error) {
 	incActionCount("history_recover")
-	return n.History(ch, WithNoLimit(), Since(since))
+	return n.History(ch, WithLimit(NoLimit), Since(since))
 }
 
 // streamTop returns current stream top position for channel.

--- a/node_test.go
+++ b/node_test.go
@@ -49,7 +49,7 @@ func (e *TestEngine) Run(_ BrokerEventHandler) error {
 	return nil
 }
 
-func (e *TestEngine) Publish(_ string, _ *Publication, _ PublishOptions) (StreamPosition, error) {
+func (e *TestEngine) Publish(_ string, _ []byte, _ PublishOptions) (StreamPosition, error) {
 	atomic.AddInt32(&e.publishCount, 1)
 	if e.errorOnPublish {
 		return StreamPosition{}, errors.New("boom")

--- a/options.go
+++ b/options.go
@@ -16,8 +16,24 @@ func WithHistory(size int, ttl time.Duration) PublishOption {
 // WithClientInfo adds ClientInfo to Publication.
 func WithClientInfo(info *ClientInfo) PublishOption {
 	return func(opts *PublishOptions) {
-		opts.clientInfo = info
+		opts.ClientInfo = info
 	}
+}
+
+// SubscribeOptions define per-subscription options.
+type SubscribeOptions struct {
+	// ExpireAt defines time in future when subscription should expire,
+	// zero value means no expiration.
+	ExpireAt int64
+	// ChannelInfo defines custom channel information, zero value means no channel information.
+	ChannelInfo []byte
+	// Recover turns on recovery option for channel. Make sure you are using recovery in channels
+	// that maintain Publication history stream.
+	Recover bool
+	// Presence turns on participating in channel presence.
+	Presence bool
+	// JoinLeave enables sending Join and Leave messages for this client in channel.
+	JoinLeave bool
 }
 
 // UnsubscribeOptions define some fields to alter behaviour of Unsubscribe operation.
@@ -30,9 +46,9 @@ type UnsubscribeOptions struct {
 type UnsubscribeOption func(*UnsubscribeOptions)
 
 // WithResubscribe allows to set Resubscribe flag to true.
-func WithResubscribe() UnsubscribeOption {
+func WithResubscribe(resubscribe bool) UnsubscribeOption {
 	return func(opts *UnsubscribeOptions) {
-		opts.Resubscribe = true
+		opts.Resubscribe = resubscribe
 	}
 }
 
@@ -46,9 +62,9 @@ type DisconnectOptions struct {
 type DisconnectOption func(options *DisconnectOptions)
 
 // WithReconnect allows to set Reconnect flag to true.
-func WithReconnect() DisconnectOption {
+func WithReconnect(reconnect bool) DisconnectOption {
 	return func(opts *DisconnectOptions) {
-		opts.Reconnect = true
+		opts.Reconnect = reconnect
 	}
 }
 
@@ -67,18 +83,13 @@ type HistoryOptions struct {
 // HistoryOption is a type to represent various History options.
 type HistoryOption func(options *HistoryOptions)
 
+// NoLimit defines that limit should not be applied.
+const NoLimit = -1
+
 // WithLimit allows to set limit.
 func WithLimit(limit int) HistoryOption {
 	return func(opts *HistoryOptions) {
 		opts.Limit = limit
-	}
-}
-
-// WithNoLimit allows to not limit returned Publications amount.
-// Should be used carefully inside large history streams.
-func WithNoLimit() HistoryOption {
-	return func(opts *HistoryOptions) {
-		opts.Limit = -1
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -16,14 +16,14 @@ func TestWithHistory(t *testing.T) {
 }
 
 func TestWithResubscribe(t *testing.T) {
-	opt := WithResubscribe()
+	opt := WithResubscribe(true)
 	opts := &UnsubscribeOptions{}
 	opt(opts)
 	require.Equal(t, true, opts.Resubscribe)
 }
 
 func TestWithReconnect(t *testing.T) {
-	opt := WithReconnect()
+	opt := WithReconnect(true)
 	opts := &DisconnectOptions{}
 	opt(opts)
 	require.Equal(t, true, opts.Reconnect)


### PR DESCRIPTION
More API refactoring to support all possible subscription options for server-side subscriptions.

* Introduce `SubscribeOptions`
* Change signature of `Publish` method in `Broker` interface – method now accepts `[]byte` data instead of `*Publication`.  
* Function options for `Unsubscribe` and `Disconnect` methods now have boolean argument.
* History functional option `WithNoLimit` removed – use `WithLimit(centrifuge.NoLimit)` instead. 