### PR TITLE
Shard hub to reduce lock contention

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -26,15 +26,14 @@ func newClient(ctx context.Context, n *Node, t Transport) (*Client, error) {
 func newTestConnectedClient(t *testing.T, n *Node, userID string) *Client {
 	client := newTestClient(t, n, userID)
 	connectClient(t, client)
-	require.Contains(t, n.hub.users, userID)
-	require.Contains(t, n.hub.conns, client.uid)
+	require.True(t, len(n.hub.userConnections(userID)) > 0)
 	return client
 }
 
 func newTestSubscribedClient(t *testing.T, n *Node, userID, chanID string) *Client {
 	client := newTestConnectedClient(t, n, userID)
 	subscribeClient(t, client, chanID)
-	require.Contains(t, n.hub.subs, chanID)
+	require.True(t, n.hub.NumSubscribers(chanID) > 0)
 	require.Contains(t, client.channels, chanID)
 	return client
 }

--- a/client_test.go
+++ b/client_test.go
@@ -62,7 +62,7 @@ func TestClientInitialState(t *testing.T) {
 	require.NotNil(t, "", client.user)
 	require.Equal(t, 0, len(client.Channels()))
 	require.Equal(t, ProtocolTypeJSON, client.Transport().Protocol())
-	require.Equal(t, "test_transport", client.Transport().Name())
+	require.Equal(t, "websocket", client.Transport().Name())
 	require.True(t, client.status == statusConnecting)
 	require.False(t, client.authenticated)
 }

--- a/hub_test.go
+++ b/hub_test.go
@@ -483,10 +483,7 @@ func BenchmarkHub_Contention(b *testing.B) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				err := h.broadcastPublication(channels[(i+numChannels/2)%numChannels], pub, streamPosition)
-				if err != nil {
-					b.Fatal(err)
-				}
+				_ = h.broadcastPublication(channels[(i+numChannels/2)%numChannels], pub, streamPosition)
 			}()
 			_, _ = h.addSub(channels[i%numChannels], clients[i%numClients])
 			wg.Wait()

--- a/node_test.go
+++ b/node_test.go
@@ -391,7 +391,7 @@ func TestNode_Unsubscribe(t *testing.T) {
 	case <-time.After(time.Second):
 		require.Fail(t, "timeout")
 	}
-	require.NotContains(t, n.hub.subs, "test_channel")
+	require.Zero(t, n.hub.NumSubscribers("test_channel"))
 	require.NotContains(t, client.channels, "test_channel")
 }
 
@@ -411,7 +411,7 @@ func TestNode_Disconnect(t *testing.T) {
 		})
 	})
 
-	client := newTestConnectedClient(t, n, "42")
+	newTestConnectedClient(t, n, "42")
 
 	err = n.Disconnect("42", WithDisconnect(DisconnectBadRequest))
 	require.NoError(t, err)
@@ -420,8 +420,7 @@ func TestNode_Disconnect(t *testing.T) {
 	case <-time.After(time.Second):
 		require.Fail(t, "timeout")
 	}
-	require.NotContains(t, n.hub.conns, client.uid)
-	require.NotContains(t, n.hub.users, "42")
+	require.True(t, len(n.hub.userConnections("42")) == 0)
 }
 
 func TestNode_pubUnsubscribe(t *testing.T) {
@@ -715,7 +714,7 @@ func TestNode_handleControl(t *testing.T) {
 			require.Fail(t, "timeout")
 		}
 		require.NoError(t, err)
-		require.NotContains(t, n.hub.subs, "test_channel")
+		require.Zero(t, n.hub.NumSubscribers("test_channel"))
 	})
 
 	t.Run("Disconnect", func(t *testing.T) {
@@ -763,9 +762,8 @@ func TestNode_handleControl(t *testing.T) {
 			require.Fail(t, "timeout")
 		}
 		require.NoError(t, err)
-		require.NotContains(t, n.hub.subs, "test_channel")
-		require.NotContains(t, n.hub.users, "42")
-		require.NotContains(t, n.hub.conns, client.uid)
+		require.Zero(t, n.hub.NumSubscribers("test_channel"))
+		require.Zero(t, len(n.hub.userConnections("42")))
 	})
 
 	t.Run("Unknown", func(t *testing.T) {

--- a/node_test.go
+++ b/node_test.go
@@ -190,6 +190,31 @@ func defaultNodeNoHandlers() *Node {
 	return n
 }
 
+func defaultTestNodeBenchmark(b *testing.B) *Node {
+	c := DefaultConfig
+	c.LogLevel = LogLevelError
+	c.LogHandler = func(entry LogEntry) {
+		b.Fatal(entry.Message, entry.Fields)
+	}
+	n, err := New(c)
+	if err != nil {
+		panic(err)
+	}
+	n.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
+			cb(SubscribeReply{}, nil)
+		})
+		client.OnPublish(func(e PublishEvent, cb PublishCallback) {
+			cb(PublishReply{}, nil)
+		})
+	})
+	err = n.Run()
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
 func defaultTestNode() *Node {
 	n := defaultNodeNoHandlers()
 	n.OnConnect(func(client *Client) {


### PR DESCRIPTION
The benchmark added here shows 3x difference – but in practice, the effect can be larger a smaller depending on a use-case scenario (channel distribution, connect rate, number of cores etc).

1 shard:
```
go test -run xxx -bench BenchmarkHub_Contention
goos: darwin
goarch: amd64
pkg: github.com/centrifugal/centrifuge
cpu: Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
BenchmarkHub_Contention-8   	    3283	    411077 ns/op
```

64 shards:

```
go test -run xxx -bench BenchmarkHub_Contention
goos: darwin
goarch: amd64
pkg: github.com/centrifugal/centrifuge
cpu: Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
BenchmarkHub_Contention-8   	    9630	    147781 ns/op
```