### PR TITLE
Possibility to bypass broker when publishing

### DIFF
--- a/broker_memory.go
+++ b/broker_memory.go
@@ -2,6 +2,7 @@ package centrifuge
 
 import (
 	"container/heap"
+	"context"
 	"sync"
 	"time"
 
@@ -67,6 +68,11 @@ func NewMemoryBroker(n *Node, c MemoryBrokerConfig) (*MemoryBroker, error) {
 func (b *MemoryBroker) Run(h BrokerEventHandler) error {
 	b.eventHandler = h
 	b.historyHub.runCleanups()
+	return nil
+}
+
+// Close is noop for now.
+func (b *MemoryBroker) Close(_ context.Context) error {
 	return nil
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -565,7 +565,7 @@ func testUnexpectedOffsetEpoch(t *testing.T, offset uint64, epoch string) {
 	}), rwWrapper.rw)
 	require.NoError(t, err)
 
-	err = node.handlePublication("test", &protocol.Publication{
+	err = node.handlePublication("test", &Publication{
 		Offset: offset,
 	}, StreamPosition{offset, epoch})
 	require.NoError(t, err)

--- a/hub.go
+++ b/hub.go
@@ -93,18 +93,22 @@ func (h *Hub) removeSub(ch string, c *Client) (bool, error) {
 	return h.subShards[index(ch, numHubShards)].removeSub(ch, c)
 }
 
-// broadcastPublication sends message to all clients subscribed on channel.
-func (h *Hub) broadcastPublication(ch string, pub *protocol.Publication, sp StreamPosition) error {
-	return h.subShards[index(ch, numHubShards)].broadcastPublication(ch, pub, sp)
+// BroadcastPublication sends message to all clients subscribed on a channel on the current Node.
+// Usually this is NOT what you need since in most cases you should use Node.Publish method which
+// uses a Broker to deliver publications to all Nodes in a cluster and maintains publication history
+// in a channel with incremental offset. By calling BroadcastPublication messages will only be sent
+// to the current node subscribers without any defined offset semantics.
+func (h *Hub) BroadcastPublication(ch string, pub *Publication, sp StreamPosition) error {
+	return h.subShards[index(ch, numHubShards)].broadcastPublication(ch, pubToProto(pub), sp)
 }
 
 // broadcastJoin sends message to all clients subscribed on channel.
-func (h *Hub) broadcastJoin(ch string, join *protocol.Join) error {
-	return h.subShards[index(ch, numHubShards)].broadcastJoin(ch, join)
+func (h *Hub) broadcastJoin(ch string, info *ClientInfo) error {
+	return h.subShards[index(ch, numHubShards)].broadcastJoin(ch, &protocol.Join{Info: *infoToProto(info)})
 }
 
-func (h *Hub) broadcastLeave(ch string, leave *protocol.Leave) error {
-	return h.subShards[index(ch, numHubShards)].broadcastLeave(ch, leave)
+func (h *Hub) broadcastLeave(ch string, info *ClientInfo) error {
+	return h.subShards[index(ch, numHubShards)].broadcastLeave(ch, &protocol.Leave{Info: *infoToProto(info)})
 }
 
 // NumSubscribers returns number of current subscribers for a given channel.

--- a/hub_test.go
+++ b/hub_test.go
@@ -282,17 +282,17 @@ func TestHubBroadcastPublication(t *testing.T) {
 			transport.protoType = tc.protocolType
 
 			// Broadcast to not existed channel.
-			err := n.hub.broadcastPublication(
+			err := n.hub.BroadcastPublication(
 				"not_test_channel",
-				&protocol.Publication{Data: []byte(`{"data": "broadcast_data"}`)},
+				&Publication{Data: []byte(`{"data": "broadcast_data"}`)},
 				StreamPosition{},
 			)
 			require.NoError(t, err)
 
 			// Broadcast to existed channel.
-			err = n.hub.broadcastPublication(
+			err = n.hub.BroadcastPublication(
 				"test_channel",
-				&protocol.Publication{Data: []byte(`{"data": "broadcast_data"}`)},
+				&Publication{Data: []byte(`{"data": "broadcast_data"}`)},
 				StreamPosition{},
 			)
 			require.NoError(t, err)
@@ -326,15 +326,11 @@ func TestHubBroadcastJoin(t *testing.T) {
 			transport.protoType = tc.protocolType
 
 			// Broadcast to not existed channel.
-			err := n.hub.broadcastJoin("not_test_channel", &protocol.Join{
-				Info: protocol.ClientInfo{Client: "broadcast_client"},
-			})
+			err := n.hub.broadcastJoin("not_test_channel", &ClientInfo{ClientID: "broadcast_client"})
 			require.NoError(t, err)
 
 			// Broadcast to existed channel.
-			err = n.hub.broadcastJoin("test_channel", &protocol.Join{
-				Info: protocol.ClientInfo{Client: "broadcast_client"},
-			})
+			err = n.hub.broadcastJoin("test_channel", &ClientInfo{ClientID: "broadcast_client"})
 			require.NoError(t, err)
 			select {
 			case data := <-transport.sink:
@@ -366,15 +362,11 @@ func TestHubBroadcastLeave(t *testing.T) {
 			transport.protoType = tc.protocolType
 
 			// Broadcast to not existed channel.
-			err := n.hub.broadcastLeave("not_test_channel", &protocol.Leave{
-				Info: protocol.ClientInfo{Client: "broadcast_client"},
-			})
+			err := n.hub.broadcastLeave("not_test_channel", &ClientInfo{ClientID: "broadcast_client"})
 			require.NoError(t, err)
 
 			// Broadcast to existed channel.
-			err = n.hub.broadcastLeave("test_channel", &protocol.Leave{
-				Info: protocol.ClientInfo{Client: "broadcast_client"},
-			})
+			err = n.hub.broadcastLeave("test_channel", &ClientInfo{ClientID: "broadcast_client"})
 			require.NoError(t, err)
 			select {
 			case data := <-transport.sink:
@@ -526,7 +518,7 @@ func BenchmarkHub_Contention(b *testing.B) {
 		}
 	}
 
-	pub := &protocol.Publication{
+	pub := &Publication{
 		Data: []byte(`{"input": "test"}`),
 	}
 	streamPosition := StreamPosition{}
@@ -540,7 +532,7 @@ func BenchmarkHub_Contention(b *testing.B) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				_ = n.hub.broadcastPublication(channels[(i+numChannels/2)%numChannels], pub, streamPosition)
+				_ = n.hub.BroadcastPublication(channels[(i+numChannels/2)%numChannels], pub, streamPosition)
 			}()
 			_, _ = n.hub.addSub(channels[i%numChannels], clients[i%numClients])
 			wg.Wait()
@@ -559,7 +551,7 @@ var broadcastBenches = []struct {
 // BenchmarkHub_MassiveBroadcast allows estimating time to broadcast
 // a single message to many subscribers inside one channel.
 func BenchmarkHub_MassiveBroadcast(b *testing.B) {
-	pub := &protocol.Publication{Data: []byte(`{"input": "test"}`)}
+	pub := &Publication{Data: []byte(`{"input": "test"}`)}
 	streamPosition := StreamPosition{}
 
 	for _, tt := range broadcastBenches {
@@ -603,7 +595,7 @@ func BenchmarkHub_MassiveBroadcast(b *testing.B) {
 						}
 					}
 				}()
-				_ = n.hub.broadcastPublication(channels[i%numChannels], pub, streamPosition)
+				_ = n.hub.BroadcastPublication(channels[i%numChannels], pub, streamPosition)
 				wg.Wait()
 			}
 		})

--- a/node_test.go
+++ b/node_test.go
@@ -1021,13 +1021,6 @@ func TestNode_OnNotification_NoHandler(t *testing.T) {
 	require.Equal(t, errNotificationHandlerNotRegistered, err)
 }
 
-func TestNode_BypassBroker(t *testing.T) {
-	node := defaultNodeNoHandlers()
-	defer func() { _ = node.Shutdown(context.Background()) }()
-	err := node.BypassBroker().HandlePublication("test", &Publication{}, StreamPosition{})
-	require.NoError(t, err)
-}
-
 func TestErrors(t *testing.T) {
 	err := ErrorUnauthorized
 	protoErr := err.toProto()

--- a/node_test.go
+++ b/node_test.go
@@ -349,18 +349,14 @@ func TestNode_Info(t *testing.T) {
 func TestNode_handleJoin(t *testing.T) {
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
-	err := n.handleJoin("test", &protocol.Join{
-		Info: protocol.ClientInfo{},
-	})
+	err := n.handleJoin("test", &ClientInfo{})
 	require.NoError(t, err)
 }
 
 func TestNode_handleLeave(t *testing.T) {
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
-	err := n.handleLeave("test", &protocol.Leave{
-		Info: protocol.ClientInfo{},
-	})
+	err := n.handleLeave("test", &ClientInfo{})
 	require.NoError(t, err)
 }
 
@@ -1023,6 +1019,13 @@ func TestNode_OnNotification_NoHandler(t *testing.T) {
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	err := node.Notify("notification", []byte(`notification`), "")
 	require.Equal(t, errNotificationHandlerNotRegistered, err)
+}
+
+func TestNode_BypassBroker(t *testing.T) {
+	node := defaultNodeNoHandlers()
+	defer func() { _ = node.Shutdown(context.Background()) }()
+	err := node.BypassBroker().HandlePublication("test", &Publication{}, StreamPosition{})
+	require.NoError(t, err)
 }
 
 func TestErrors(t *testing.T) {

--- a/presence_memory.go
+++ b/presence_memory.go
@@ -1,6 +1,7 @@
 package centrifuge
 
 import (
+	"context"
 	"sync"
 )
 
@@ -53,6 +54,11 @@ func (m *MemoryPresenceManager) Presence(ch string) (map[string]*ClientInfo, err
 // PresenceStats - see PresenceManager interface description.
 func (m *MemoryPresenceManager) PresenceStats(ch string) (PresenceStats, error) {
 	return m.presenceHub.getStats(ch)
+}
+
+// Close is noop for now.
+func (m *MemoryPresenceManager) Close(_ context.Context) error {
+	return nil
 }
 
 type presenceHub struct {


### PR DESCRIPTION
This pr allow bypassing a broker when publishing into a channel. Grafana needs this for plugin stream management - it opens a separate unidirectional stream - one per Grafana server, and whenever plugin publishes data message should only go to local subscribers.