### PR TITLE
Fix concurrent subscribe to the same channel

### DIFF
--- a/client.go
+++ b/client.go
@@ -2332,8 +2332,7 @@ func (c *Client) subscribeCmd(cmd *protocol.SubscribeRequest, reply SubscribeRep
 		res.Epoch = latestEpoch
 		res.Offset = latestOffset
 
-		c.pubSubSync.LockBuffer(channel)
-		bufferedPubs := c.pubSubSync.ReadBuffered(channel)
+		bufferedPubs := c.pubSubSync.LockBufferAndReadBuffered(channel)
 		var okMerge bool
 		recoveredPubs, okMerge = recovery.MergePublications(recoveredPubs, bufferedPubs)
 		if !okMerge {

--- a/client_test.go
+++ b/client_test.go
@@ -3066,3 +3066,130 @@ func TestFlagNotExists(t *testing.T) {
 	var flags uint64
 	require.False(t, hasFlag(flags, PushFlagDisconnect))
 }
+
+func TestConcurrentSameChannelSubscribe(t *testing.T) {
+	node := defaultNodeNoHandlers()
+	defer func() { _ = node.Shutdown(context.Background()) }()
+
+	var wg sync.WaitGroup
+	concurrency := 10
+	wg.Add(concurrency)
+
+	onSubscribe := make(chan struct{})
+
+	node.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
+			go func() {
+				cb(SubscribeReply{
+					Options: SubscribeOptions{
+						Recover: true,
+					},
+				}, nil)
+				close(onSubscribe)
+			}()
+		})
+	})
+
+	client := newTestClient(t, node, "42")
+	connectClient(t, client)
+
+	var subscribeErrors []string
+	var mu sync.Mutex
+
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			defer wg.Done()
+			rwWrapper := testReplyWriterWrapper()
+			err := client.handleSubscribe(getJSONEncodedParams(t, &protocol.SubscribeRequest{
+				Channel: "test1",
+				Recover: true,
+				Offset:  0,
+			}), rwWrapper.rw)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				subscribeErrors = append(subscribeErrors, err.Error())
+			} else {
+				subscribeErrors = append(subscribeErrors, "nil")
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	<-onSubscribe
+
+	var n int
+	for _, e := range subscribeErrors {
+		if e == "105: already subscribed" {
+			n++
+		}
+	}
+	require.Equal(t, concurrency-1, n)
+}
+
+type slowHistoryBroker struct {
+	startPublishingCh chan struct{}
+	stopPublishingCh  chan struct{}
+	*MemoryBroker
+}
+
+func (b *slowHistoryBroker) History(ch string, filter HistoryFilter) ([]*Publication, StreamPosition, error) {
+	close(b.startPublishingCh)
+	<-b.stopPublishingCh
+	return b.MemoryBroker.History(ch, filter)
+}
+
+func TestSubscribeWithBufferedPublications(t *testing.T) {
+	c := DefaultConfig
+	c.LogLevel = LogLevelTrace
+	c.LogHandler = func(entry LogEntry) {}
+	node, err := New(c)
+	if err != nil {
+		panic(err)
+	}
+	startPublishingCh := make(chan struct{})
+	stopPublishingCh := make(chan struct{})
+	broker, err := NewMemoryBroker(node, MemoryBrokerConfig{})
+	require.NoError(t, err)
+	node.SetBroker(&slowHistoryBroker{startPublishingCh: startPublishingCh, stopPublishingCh: stopPublishingCh, MemoryBroker: broker})
+	err = node.Run()
+	require.NoError(t, err)
+	defer func() { _ = node.Shutdown(context.Background()) }()
+
+	node.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
+			cb(SubscribeReply{
+				Options: SubscribeOptions{
+					Recover: true,
+				},
+			}, nil)
+		})
+	})
+
+	client := newTestClient(t, node, "42")
+	connectClient(t, client)
+
+	rwWrapper := testReplyWriterWrapper()
+	go func() {
+		<-startPublishingCh
+		for i := 0; i < 5; i++ {
+			_, err := node.Publish("test1", []byte(`{}`), WithHistory(100, 60*time.Second))
+			require.NoError(t, err)
+		}
+		close(stopPublishingCh)
+	}()
+	err = client.handleSubscribe(getJSONEncodedParams(t, &protocol.SubscribeRequest{
+		Channel: "test1",
+		Recover: true,
+		Offset:  0,
+	}), rwWrapper.rw)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(rwWrapper.replies))
+	require.Nil(t, rwWrapper.replies[0].Error)
+	res := extractSubscribeResult(rwWrapper.replies, client.Transport().Protocol())
+	require.Equal(t, uint64(5), res.Offset)
+	require.True(t, res.Recovered)
+	require.Len(t, res.Publications, 5)
+	require.Equal(t, 1, len(client.Channels()))
+}

--- a/internal/recovery/sync.go
+++ b/internal/recovery/sync.go
@@ -129,14 +129,3 @@ func (c *PubSubSync) appendPubToBuffer(channel string, pub *protocol.Publication
 	s := c.subSync[channel]
 	s.pubBuffer = append(s.pubBuffer, pub)
 }
-
-// ReadBuffered ...
-func (c *PubSubSync) ReadBuffered(channel string) []*protocol.Publication {
-	c.subSyncMu.RLock()
-	defer c.subSyncMu.RUnlock()
-	s := c.subSync[channel]
-	pubs := make([]*protocol.Publication, len(s.pubBuffer))
-	copy(pubs, s.pubBuffer)
-	s.pubBuffer = nil
-	return pubs
-}

--- a/internal/recovery/sync.go
+++ b/internal/recovery/sync.go
@@ -95,6 +95,21 @@ func (c *PubSubSync) LockBuffer(channel string) {
 	s.pubBufferMu.Lock()
 }
 
+func (c *PubSubSync) LockBufferAndReadBuffered(channel string) []*protocol.Publication {
+	c.subSyncMu.Lock()
+	defer c.subSyncMu.Unlock()
+	s, ok := c.subSync[channel]
+	if !ok {
+		return nil
+	}
+	s.pubBufferLocked = true
+	s.pubBufferMu.Lock()
+	pubs := make([]*protocol.Publication, len(s.pubBuffer))
+	copy(pubs, s.pubBuffer)
+	s.pubBuffer = nil
+	return pubs
+}
+
 // UnlockBuffer ...
 func (c *PubSubSync) unlockBuffer(channel string) {
 	c.subSyncMu.Lock()

--- a/internal/recovery/sync_test.go
+++ b/internal/recovery/sync_test.go
@@ -33,8 +33,7 @@ func TestPubSubSync(t *testing.T) {
 			}()
 			go func() {
 				<-wait
-				psSync.LockBuffer(channel)
-				pubs := psSync.ReadBuffered(channel)
+				pubs := psSync.LockBufferAndReadBuffered(channel)
 				require.Equal(t, 10, len(pubs))
 				psSync.StopBuffering(channel)
 				close(done)

--- a/internal/recovery/sync_test.go
+++ b/internal/recovery/sync_test.go
@@ -71,6 +71,7 @@ func BenchmarkPubSubSync(b *testing.B) {
 				}()
 				<-wait
 				_ = psSync.LockBufferAndReadBuffered(channel)
+				psSync.StopBuffering(channel)
 			}(channel)
 		}
 		wg.Wait()

--- a/internal/recovery/sync_test.go
+++ b/internal/recovery/sync_test.go
@@ -70,9 +70,7 @@ func BenchmarkPubSubSync(b *testing.B) {
 					close(wait)
 				}()
 				<-wait
-				psSync.LockBuffer(channel)
-				_ = psSync.ReadBuffered(channel)
-				psSync.StopBuffering(channel)
+				_ = psSync.LockBufferAndReadBuffered(channel)
 			}(channel)
 		}
 		wg.Wait()


### PR DESCRIPTION
When recovery is on and client subscribes to a channel concurrently there is a panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1413f57]

goroutine 138 [running]:
github.com/centrifugal/centrifuge/internal/recovery.(*PubSubSync).ReadBuffered(0xc00007bee0, {0xc0000b836c, 0x5})
	/Users/fz/projects/centrifugal/centrifuge/internal/recovery/sync.go:138 +0xd7
github.com/centrifugal/centrifuge.(*Client).subscribeCmd(0xc000184820, 0xc0002d3c00, {{0x0, {0x0, 0x0, 0x0}, 0x0, 0x0, 0x0, 0x1, ...}, ...}, ...)
	/Users/fz/projects/centrifugal/centrifuge/client.go:2318 +0xc1a
github.com/centrifugal/centrifuge.(*Client).handleSubscribe.func1({{0x0, {0x0, 0x0, 0x0}, 0x0, 0x0, 0x0, 0x1, {0x0, 0x0, ...}, ...}, ...}, ...)
	/Users/fz/projects/centrifugal/centrifuge/client.go:1347 +0xf2
github.com/centrifugal/centrifuge.TestConcurrentSameChannelSubscribe.func3.1.1()
	/Users/fz/projects/centrifugal/centrifuge/client_test.go:3089 +0x3e
created by github.com/centrifugal/centrifuge.TestConcurrentSameChannelSubscribe.func3.1
	/Users/fz/projects/centrifugal/centrifuge/client_test.go:3088 +0x5b
exit status 2
```

This pr fixes this by tracking a map of current subscriptions using `Client.channels` field. On subscribe attempt we add channel to a map, on subscribe error removing it from a map. Since there are some existing logic based on `Client.channels` map we also need to introduce `flagSubscribed` set upon successful subscription and check it in most places where `Client.channels` used. It was possible to add separate map to handle concurrent subscriptions but this would increase memory usage per connection.

Added test that reproduced a panic.

Also added a test case for recovery with buffered publications (and fixed epoch behavior on empty epoch sent from client).


