### PR TITLE
Fix subscription cleanup on client close

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -3132,12 +3132,20 @@ type slowHistoryBroker struct {
 	startPublishingCh chan struct{}
 	stopPublishingCh  chan struct{}
 	*MemoryBroker
+	err error
+}
+
+func (b *slowHistoryBroker) setError(err error) {
+	b.err = err
 }
 
 func (b *slowHistoryBroker) History(ch string, filter HistoryFilter) ([]*Publication, StreamPosition, error) {
 	close(b.startPublishingCh)
 	res, sp, err := b.MemoryBroker.History(ch, filter)
 	<-b.stopPublishingCh
+	if b.err != nil {
+		return nil, StreamPosition{}, b.err
+	}
 	return res, sp, err
 }
 
@@ -3318,6 +3326,47 @@ func TestClientSubscribingChannelsCleanupOnClientClose(t *testing.T) {
 	close(stopPublishingCh)
 	client.Disconnect(DisconnectNormal)
 	<-disconnectedCh
-	//time.Sleep(5 * time.Second)
+	require.Len(t, node.Hub().Channels(), 0, node.Hub().Channels())
+}
+
+func TestClientSubscribingChannelsCleanupOnHistoryError(t *testing.T) {
+	c := DefaultConfig
+	c.LogLevel = LogLevelTrace
+	c.LogHandler = func(entry LogEntry) {}
+	node, err := New(c)
+	if err != nil {
+		panic(err)
+	}
+	startPublishingCh := make(chan struct{})
+	stopPublishingCh := make(chan struct{})
+	broker, err := NewMemoryBroker(node, MemoryBrokerConfig{})
+	require.NoError(t, err)
+	slowBroker := &slowHistoryBroker{startPublishingCh: startPublishingCh, stopPublishingCh: stopPublishingCh, MemoryBroker: broker}
+	slowBroker.setError(ErrorNotAvailable)
+	node.SetBroker(slowBroker)
+	err = node.Run()
+	require.NoError(t, err)
+	defer func() { _ = node.Shutdown(context.Background()) }()
+
+	node.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
+			cb(SubscribeReply{
+				Options: SubscribeOptions{
+					Recover: true,
+				},
+			}, nil)
+		})
+	})
+
+	client := newTestClient(t, node, "42")
+	connectClient(t, client)
+
+	close(stopPublishingCh)
+
+	rwWrapper := testReplyWriterWrapper()
+	err = client.handleSubscribe(getJSONEncodedParams(t, &protocol.SubscribeRequest{
+		Channel: "test1",
+	}), rwWrapper.rw)
+	require.NoError(t, err)
 	require.Len(t, node.Hub().Channels(), 0, node.Hub().Channels())
 }


### PR DESCRIPTION
A fix for one more problem found in https://github.com/centrifugal/centrifugo/issues/486 – subscriptions not cleaned up while all clients already gone.

We adding a channel to a hub during a subscribe but not cleaning it up while disconnecting a client. Also we should clean up a subscription in a hub after non-Disconnect error happened during history call. Added reproducing tests for both cases, both now pass.

Thats a regression after https://github.com/centrifugal/centrifuge/pull/207
