### PR TITLE
Force stream epoch from application code

### DIFF
--- a/_examples/chat_json/main.go
+++ b/_examples/chat_json/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"log"
 	"net/http"
 	"os"
@@ -89,24 +88,24 @@ func main() {
 		transport := client.Transport()
 		log.Printf("user %s connected via %s with protocol: %s", client.UserID(), transport.Name(), transport.Protocol())
 
-		// Event handler should not block, so start separate goroutine to
-		// periodically send messages to client.
-		go func() {
-			for {
-				select {
-				case <-client.Context().Done():
-					return
-				case <-time.After(5000 * time.Second):
-					err := client.Send([]byte(`{"time": "` + strconv.FormatInt(time.Now().Unix(), 10) + `"}`))
-					if err != nil {
-						if err == io.EOF {
-							return
-						}
-						log.Printf("error sending message: %s", err)
-					}
-				}
-			}
-		}()
+		//// Event handler should not block, so start separate goroutine to
+		//// periodically send messages to client.
+		//go func() {
+		//	for {
+		//		select {
+		//		case <-client.Context().Done():
+		//			return
+		//		case <-time.After(5000 * time.Second):
+		//			err := client.Send([]byte(`{"time": "` + strconv.FormatInt(time.Now().Unix(), 10) + `"}`))
+		//			if err != nil {
+		//				if err == io.EOF {
+		//					return
+		//				}
+		//				log.Printf("error sending message: %s", err)
+		//			}
+		//		}
+		//	}
+		//}()
 
 		client.OnAlive(func() {
 			log.Printf("user %s connection is still active", client.UserID())

--- a/_examples/chat_json/main.go
+++ b/_examples/chat_json/main.go
@@ -222,7 +222,7 @@ func main() {
 				centrifuge.WithMeta(map[string]string{"nodeId": node.ID()}),
 			)
 			if err != nil {
-				log.Printf("error publishing to personal channel: %s", err)
+				log.Printf("error publishing to channel: %s", err)
 			}
 			i++
 			time.Sleep(10000 * time.Millisecond)

--- a/_examples/chat_json/main.go
+++ b/_examples/chat_json/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -88,24 +89,24 @@ func main() {
 		transport := client.Transport()
 		log.Printf("user %s connected via %s with protocol: %s", client.UserID(), transport.Name(), transport.Protocol())
 
-		//// Event handler should not block, so start separate goroutine to
-		//// periodically send messages to client.
-		//go func() {
-		//	for {
-		//		select {
-		//		case <-client.Context().Done():
-		//			return
-		//		case <-time.After(5000 * time.Second):
-		//			err := client.Send([]byte(`{"time": "` + strconv.FormatInt(time.Now().Unix(), 10) + `"}`))
-		//			if err != nil {
-		//				if err == io.EOF {
-		//					return
-		//				}
-		//				log.Printf("error sending message: %s", err)
-		//			}
-		//		}
-		//	}
-		//}()
+		// Event handler should not block, so start separate goroutine to
+		// periodically send messages to client.
+		go func() {
+			for {
+				select {
+				case <-client.Context().Done():
+					return
+				case <-time.After(5000 * time.Second):
+					err := client.Send([]byte(`{"time": "` + strconv.FormatInt(time.Now().Unix(), 10) + `"}`))
+					if err != nil {
+						if err == io.EOF {
+							return
+						}
+						log.Printf("error sending message: %s", err)
+					}
+				}
+			}
+		}()
 
 		client.OnAlive(func() {
 			log.Printf("user %s connection is still active", client.UserID())

--- a/_examples/redis_broker_presence/main.go
+++ b/_examples/redis_broker_presence/main.go
@@ -111,7 +111,7 @@ func main() {
 	broker, err := centrifuge.NewRedisBroker(node, centrifuge.RedisBrokerConfig{
 		// Use reasonably large expiration interval for stream meta key,
 		// much bigger than maximum HistoryLifetime value in Node config.
-		// This way stream meta data will expire, in some cases you may want
+		// This way stream metadata will expire, in some cases you may want
 		// to prevent its expiration setting this to zero value.
 		HistoryMetaTTL: 7 * 24 * time.Hour,
 

--- a/broker.go
+++ b/broker.go
@@ -55,7 +55,8 @@ type HistoryFilter struct {
 	Limit int
 	// Reverse direction.
 	Reverse bool
-	// Epoch if set instructs history request to set an epoch for a stream.
+	// Epoch if set instructs history request to set an epoch for a stream. On new
+	// epoch stream will be reset.
 	Epoch string
 }
 
@@ -93,7 +94,8 @@ type PublishOptions struct {
 	ClientInfo *ClientInfo
 	// Meta is a custom meta information for the Publication.
 	Meta map[string]string
-	// Epoch ...
+	// Epoch if set instructs publish request to set an epoch for a stream. On new
+	// epoch stream will be reset.
 	Epoch string
 }
 

--- a/broker.go
+++ b/broker.go
@@ -55,6 +55,8 @@ type HistoryFilter struct {
 	Limit int
 	// Reverse direction.
 	Reverse bool
+	// Epoch ...
+	Epoch string
 }
 
 // StreamPosition contains fields to describe position in stream.
@@ -91,6 +93,8 @@ type PublishOptions struct {
 	ClientInfo *ClientInfo
 	// Meta is a custom meta information for the Publication.
 	Meta map[string]string
+	// Epoch ...
+	Epoch string
 }
 
 // Broker is responsible for PUB/SUB mechanics.

--- a/broker.go
+++ b/broker.go
@@ -55,7 +55,7 @@ type HistoryFilter struct {
 	Limit int
 	// Reverse direction.
 	Reverse bool
-	// Epoch ...
+	// Epoch if set instructs history request to set an epoch for a stream.
 	Epoch string
 }
 

--- a/broker_memory_test.go
+++ b/broker_memory_test.go
@@ -198,6 +198,39 @@ func TestMemoryHistoryHubMetaTTL(t *testing.T) {
 	h.RUnlock()
 }
 
+func testBrokerEpoch(t *testing.T, b Broker) {
+	t.Helper()
+	sp, err := b.Publish("test", []byte("1"), PublishOptions{HistorySize: 10, HistoryTTL: time.Minute, Epoch: "xyz"})
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), sp.Offset)
+	require.Equal(t, "xyz", sp.Epoch)
+	_, sp, err = b.History("test", HistoryFilter{})
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), sp.Offset)
+	require.Equal(t, "xyz", sp.Epoch)
+	sp, err = b.Publish("test", []byte("1"), PublishOptions{HistorySize: 10, HistoryTTL: time.Minute, Epoch: ""})
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), sp.Offset)
+	require.Equal(t, "xyz", sp.Epoch)
+	sp, err = b.Publish("test", []byte("1"), PublishOptions{HistorySize: 10, HistoryTTL: time.Minute, Epoch: "xxx"})
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), sp.Offset)
+	require.Equal(t, "xxx", sp.Epoch)
+	_, sp, err = b.History("test", HistoryFilter{})
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), sp.Offset)
+	require.Equal(t, "xxx", sp.Epoch)
+	_, sp, err = b.History("test", HistoryFilter{Epoch: "zzz"})
+	require.NoError(t, err)
+	require.Zero(t, sp.Offset)
+	require.Equal(t, "zzz", sp.Epoch)
+}
+
+func TestMemoryBrokerEpoch(t *testing.T) {
+	b := testMemoryBroker()
+	testBrokerEpoch(t, b)
+}
+
 func TestMemoryBrokerRecover(t *testing.T) {
 	e := testMemoryBroker()
 

--- a/broker_redis.go
+++ b/broker_redis.go
@@ -187,7 +187,7 @@ return {offset, epoch}
 	// ARGV[3] - stream lifetime
 	// ARGV[4] - channel to publish message to if needed
 	// ARGV[5] - history meta key expiration time
-	// ARGV[6] - optional stream epoch, TODO: should we "reset" stream on new epoch?
+	// ARGV[6] - optional stream epoch.
 	addHistoryStreamSource = `
 redis.replicate_commands()
 local epoch
@@ -203,10 +203,10 @@ if epoch == false or epoch == nil then
   redis.call("hset", KEYS[2], "e", epoch)
 else
   if ARGV[6] ~= "" and epoch ~= ARGV[6] then
-	epoch = ARGV[6]
-	redis.call("hset", KEYS[2], "e", epoch)
+    epoch = ARGV[6]
+    redis.call("hset", KEYS[2], "e", epoch)
     redis.call("hset", KEYS[2], "s", "0")
-	redis.call("del", KEYS[1])
+    redis.call("del", KEYS[1])
   end
 end
 local offset = redis.call("hincrby", KEYS[2], "s", 1)
@@ -257,7 +257,7 @@ return {offset, epoch, pubs}
 	// ARGV[3] - limit
 	// ARGV[4] - reverse
 	// ARGV[5] - stream meta hash key expiration time
-	// ARGV[6] - optional stream epoch, TODO: should we "reset" stream on new epoch?
+	// ARGV[6] - optional stream epoch.
 	historyStreamSource = `
 redis.replicate_commands()
 local epoch
@@ -273,10 +273,10 @@ if epoch == false or epoch == nil then
   redis.call("hset", KEYS[2], "e", epoch)
 else
   if ARGV[6] ~= "" and epoch ~= ARGV[6] then
-	epoch = ARGV[6]
-	redis.call("hset", KEYS[2], "e", epoch)
-	redis.call("hset", KEYS[2], "s", "0")
-	redis.call("del", KEYS[1])
+    epoch = ARGV[6]
+    redis.call("hset", KEYS[2], "e", epoch)
+    redis.call("hset", KEYS[2], "s", "0")
+    redis.call("del", KEYS[1])
   end
 end
 local offset = redis.call("hget", KEYS[2], "s")

--- a/broker_redis_test.go
+++ b/broker_redis_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package centrifuge
@@ -496,6 +497,20 @@ func randString(n int) string {
 		b[i] = letterRunes[random.Intn(len(letterRunes))]
 	}
 	return string(b)
+}
+
+func TestRedisBrokerEpoch(t *testing.T) {
+	node := testNode(t)
+	b := newTestRedisBroker(t, node, true, false)
+	defer func() { _ = node.Shutdown(context.Background()) }()
+	testBrokerEpoch(t, b)
+}
+
+func TestRedisBrokerEpochCluster(t *testing.T) {
+	node := testNode(t)
+	b := newTestRedisBroker(t, node, true, true)
+	defer func() { _ = node.Shutdown(context.Background()) }()
+	testBrokerEpoch(t, b)
 }
 
 // TestRedisConsistentIndex exists to test consistent hashing algorithm we use.
@@ -1209,7 +1224,7 @@ func testRedisClientSubscribeRecover(t *testing.T, tt recoverTest, useStreams bo
 	})
 	require.NoError(t, err)
 
-	historyResult, err := node.recoverHistory(channel, StreamPosition{tt.SinceOffset, streamTop.Epoch})
+	historyResult, err := node.recoverHistory(channel, StreamPosition{tt.SinceOffset, streamTop.Epoch}, "")
 	require.NoError(t, err)
 	recoveredPubs, recovered := isRecovered(historyResult, tt.SinceOffset, streamTop.Epoch)
 	require.Equal(t, tt.NumRecovered, len(recoveredPubs))

--- a/client.go
+++ b/client.go
@@ -2659,7 +2659,7 @@ func (c *Client) subscribeCmd(cmd *protocol.SubscribeRequest, reply SubscribeRep
 				incRecover(res.Recovered)
 			}
 		} else {
-			streamTop, err := c.node.streamTop(channel, cmd.Epoch)
+			streamTop, err := c.node.streamTop(channel, reply.Options.Epoch)
 			if err != nil {
 				c.node.logger.log(newLogEntry(LogLevelError, "error getting recovery state for channel", map[string]interface{}{"channel": channel, "user": c.user, "client": c.uid, "error": err.Error()}))
 				c.pubSubSync.StopBuffering(channel)
@@ -2685,7 +2685,7 @@ func (c *Client) subscribeCmd(cmd *protocol.SubscribeRequest, reply SubscribeRep
 			return ctx
 		}
 	} else if reply.Options.Position {
-		streamTop, err := c.node.streamTop(channel, cmd.Epoch)
+		streamTop, err := c.node.streamTop(channel, reply.Options.Epoch)
 		if err != nil {
 			c.node.logger.log(newLogEntry(LogLevelError, "error getting stream top for channel", map[string]interface{}{"channel": channel, "user": c.user, "client": c.uid, "error": err.Error()}))
 			if clientErr, ok := err.(*Error); ok && clientErr != ErrorInternal {

--- a/client.go
+++ b/client.go
@@ -644,7 +644,7 @@ func (c *Client) checkPosition(checkDelay time.Duration, ch string, chCtx channe
 		return true
 	}
 	position := chCtx.streamPosition
-	streamTop, err := c.node.streamTop(ch)
+	streamTop, err := c.node.streamTop(ch, "")
 	if err != nil {
 		return true
 	}
@@ -2632,7 +2632,7 @@ func (c *Client) subscribeCmd(cmd *protocol.SubscribeRequest, reply SubscribeRep
 
 			// Client provided subscribe request with recover flag on. Try to recover missed
 			// publications automatically from history (we suppose here that history configured wisely).
-			historyResult, err := c.node.recoverHistory(channel, StreamPosition{cmdOffset, cmd.Epoch})
+			historyResult, err := c.node.recoverHistory(channel, StreamPosition{cmdOffset, cmd.Epoch}, reply.Options.Epoch)
 			if err != nil {
 				if errors.Is(err, ErrorUnrecoverablePosition) {
 					// Result contains stream position in case of ErrorUnrecoverablePosition
@@ -2659,7 +2659,7 @@ func (c *Client) subscribeCmd(cmd *protocol.SubscribeRequest, reply SubscribeRep
 				incRecover(res.Recovered)
 			}
 		} else {
-			streamTop, err := c.node.streamTop(channel)
+			streamTop, err := c.node.streamTop(channel, cmd.Epoch)
 			if err != nil {
 				c.node.logger.log(newLogEntry(LogLevelError, "error getting recovery state for channel", map[string]interface{}{"channel": channel, "user": c.user, "client": c.uid, "error": err.Error()}))
 				c.pubSubSync.StopBuffering(channel)
@@ -2685,7 +2685,7 @@ func (c *Client) subscribeCmd(cmd *protocol.SubscribeRequest, reply SubscribeRep
 			return ctx
 		}
 	} else if reply.Options.Position {
-		streamTop, err := c.node.streamTop(channel)
+		streamTop, err := c.node.streamTop(channel, cmd.Epoch)
 		if err != nil {
 			c.node.logger.log(newLogEntry(LogLevelError, "error getting stream top for channel", map[string]interface{}{"channel": channel, "user": c.user, "client": c.uid, "error": err.Error()}))
 			if clientErr, ok := err.(*Error); ok && clientErr != ErrorInternal {

--- a/client.go
+++ b/client.go
@@ -271,6 +271,9 @@ func NewClient(ctx context.Context, n *Node, t Transport) (*Client, ClientCloseF
 					return nil
 				}
 			}
+			if client.node.LogEnabled(LogLevelTrace) {
+				client.trace("-->", item.Data)
+			}
 			if err := t.Write(item.Data); err != nil {
 				switch v := err.(type) {
 				case *Disconnect:
@@ -286,6 +289,9 @@ func NewClient(ctx context.Context, n *Node, t Transport) (*Client, ClientCloseF
 		WriteManyFn: func(items ...queue.Item) error {
 			messages := make([][]byte, 0, len(items))
 			for i := 0; i < len(items); i++ {
+				if client.node.LogEnabled(LogLevelTrace) {
+					client.trace("-->", items[i].Data)
+				}
 				if client.eventHub.transportWriteHandler != nil {
 					pass := client.eventHub.transportWriteHandler(TransportWriteEvent(items[i]))
 					if !pass {
@@ -389,10 +395,8 @@ func (c *Client) unidirectionalConnect(connectRequest *protocol.ConnectRequest) 
 		var data []byte
 		if c.transport.ProtocolVersion() == ProtocolVersion1 {
 			data = rep.Result
-			c.trace("-->", data)
 		} else {
 			data = prepared.NewReply(rep, c.transport.Protocol().toProto()).PushData()
-			c.trace("-->", data)
 		}
 		disconnect := c.messageWriter.enqueue(queue.Item{Data: data})
 		if disconnect != nil {
@@ -505,7 +509,6 @@ func (c *Client) transportEnqueue(reply *prepared.Reply) error {
 	} else {
 		data = reply.Data()
 	}
-	c.trace("-->", data)
 	disconnect := c.messageWriter.enqueue(queue.Item{
 		Data: data,
 	})
@@ -871,9 +874,6 @@ func (c *Client) close(disconnect *Disconnect) error {
 }
 
 func (c *Client) trace(msg string, data []byte) {
-	if !c.node.LogEnabled(LogLevelTrace) {
-		return
-	}
 	c.mu.RLock()
 	user := c.user
 	c.mu.RUnlock()
@@ -917,7 +917,9 @@ func (c *Client) Handle(data []byte) bool {
 		return false
 	}
 
-	c.trace("<--", data)
+	if c.node.LogEnabled(LogLevelTrace) {
+		c.trace("<--", data)
+	}
 
 	protoType := c.transport.Protocol().toProto()
 	decoder := protocol.GetCommandDecoder(protoType, data)
@@ -1026,7 +1028,6 @@ func (c *Client) dispatchCommandV2(cmd *protocol.Command) *Disconnect {
 			c.node.logger.log(newLogEntry(LogLevelError, "error encoding reply", map[string]interface{}{"reply": fmt.Sprintf("%v", rep), "client": c.ID(), "user": c.UserID(), "error": encodeErr.Error()}))
 			return encodeErr
 		}
-		c.trace("-->", replyData)
 		disconnect := c.messageWriter.enqueue(queue.Item{Data: replyData})
 		if disconnect != nil {
 			if c.node.logger.enabled(LogLevelDebug) {
@@ -1140,7 +1141,6 @@ func (c *Client) dispatchCommandV1(cmd *protocol.Command) *Disconnect {
 			c.node.logger.log(newLogEntry(LogLevelError, "error encoding reply", map[string]interface{}{"reply": fmt.Sprintf("%v", rep), "client": c.ID(), "user": c.UserID(), "error": encodeErr.Error()}))
 			return encodeErr
 		}
-		c.trace("-->", replyData)
 		disconnect := c.messageWriter.enqueue(queue.Item{Data: replyData})
 		if disconnect != nil {
 			if c.node.logger.enabled(LogLevelDebug) {

--- a/client_test.go
+++ b/client_test.go
@@ -2998,7 +2998,7 @@ func TestClientCheckPosition(t *testing.T) {
 
 	// valid position resets positionCheckFailures.
 	require.NotZero(t, client.channels["channel"].positionCheckFailures)
-	sp, _ := node.streamTop("channel")
+	sp, _ := node.streamTop("channel", "")
 	got = client.checkPosition(50*time.Second, "channel", channelContext{
 		positionCheckTime: 50, flags: flagRecover, streamPosition: sp,
 	})

--- a/internal/memstream/stream.go
+++ b/internal/memstream/stream.go
@@ -39,11 +39,14 @@ type Stream struct {
 }
 
 // New creates new Stream.
-func New() *Stream {
+func New(epoch string) *Stream {
+	if epoch == "" {
+		epoch = genEpoch()
+	}
 	return &Stream{
 		list:  list.New(),
 		index: make(map[uint64]*list.Element),
-		epoch: genEpoch(),
+		epoch: epoch,
 	}
 }
 
@@ -76,9 +79,12 @@ func (s *Stream) Epoch() string {
 }
 
 // Reset stream.
-func (s *Stream) Reset() {
+func (s *Stream) Reset(epoch string) {
+	if epoch == "" {
+		epoch = genEpoch()
+	}
 	s.top = 0
-	s.epoch = genEpoch()
+	s.epoch = epoch
 	s.Clear()
 }
 

--- a/internal/memstream/stream_test.go
+++ b/internal/memstream/stream_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestStream(t *testing.T) {
-	s := New()
+	s := New("")
 
 	const streamSize = 5
 
@@ -87,7 +87,7 @@ func TestStream(t *testing.T) {
 	require.Equal(t, streamTop, uint64(7))
 	require.Equal(t, 5, len(s.index))
 
-	s.Reset()
+	s.Reset("")
 	require.Equal(t, uint64(0), s.Top())
 	require.Equal(t, 0, len(s.index))
 	require.Equal(t, 0, s.list.Len())
@@ -96,7 +96,7 @@ func TestStream(t *testing.T) {
 }
 
 func TestStreamGetAll(t *testing.T) {
-	s := New()
+	s := New("")
 	items, streamTop, err := s.Get(0, false, 0, false)
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), streamTop)
@@ -109,7 +109,7 @@ func TestStreamGetAll(t *testing.T) {
 }
 
 func TestStreamClear(t *testing.T) {
-	s := New()
+	s := New("")
 	const streamSize = 5
 	_, err := s.Add([]byte("1"), streamSize)
 	require.NoError(t, err)
@@ -120,12 +120,12 @@ func TestStreamClear(t *testing.T) {
 }
 
 func TestStreamReset(t *testing.T) {
-	s := New()
+	s := New("")
 	epoch := s.Epoch()
 	const streamSize = 5
 	_, err := s.Add([]byte("1"), streamSize)
 	require.NoError(t, err)
-	s.Reset()
+	s.Reset("")
 	require.Zero(t, s.Top())
 	require.Equal(t, 0, len(s.index))
 	require.Equal(t, 0, s.list.Len())
@@ -133,7 +133,7 @@ func TestStreamReset(t *testing.T) {
 }
 
 func TestStreamOffset(t *testing.T) {
-	s := New()
+	s := New("")
 	const streamSize = 5
 	for i := 0; i < streamSize; i++ {
 		_, err := s.Add([]byte("elem"), streamSize)
@@ -151,7 +151,7 @@ func TestStreamOffset(t *testing.T) {
 }
 
 func TestStreamOffsetReverseNonExistingOffset(t *testing.T) {
-	s := New()
+	s := New("")
 	const streamSize = 2
 	for i := 0; i < 10; i++ {
 		_, err := s.Add([]byte("elem"), streamSize)
@@ -163,7 +163,7 @@ func TestStreamOffsetReverseNonExistingOffset(t *testing.T) {
 }
 
 func TestStreamNoLimitWithMiddle(t *testing.T) {
-	s := New()
+	s := New("")
 	const streamSize = 10
 	for i := 0; i < streamSize; i++ {
 		_, err := s.Add([]byte("elem"), streamSize)

--- a/internal/prepared/reply.go
+++ b/internal/prepared/reply.go
@@ -6,13 +6,13 @@ import (
 	"github.com/centrifugal/protocol"
 )
 
-// Reply is structure for encoding reply only once.
+// Reply is a structure for encoding reply only once.
 type Reply struct {
-	ProtoType protocol.Type
 	Reply     *protocol.Reply
+	protoType protocol.Type
 	data      []byte
-	pushData  []byte
 	once      sync.Once
+	pushData  []byte
 	pushOnce  sync.Once
 }
 
@@ -20,24 +20,24 @@ type Reply struct {
 func NewReply(reply *protocol.Reply, protoType protocol.Type) *Reply {
 	return &Reply{
 		Reply:     reply,
-		ProtoType: protoType,
+		protoType: protoType,
 	}
 }
 
-// Data returns data associated with reply which is only calculated once.
+// Data returns encoded Reply.
 func (r *Reply) Data() []byte {
 	r.once.Do(func() {
-		encoder := protocol.GetReplyEncoder(r.ProtoType)
+		encoder := protocol.GetReplyEncoder(r.protoType)
 		data, _ := encoder.Encode(r.Reply)
 		r.data = data
 	})
 	return r.data
 }
 
-// Data returns data associated with reply which is only calculated once.
+// PushData returns encoded Push part of Reply.
 func (r *Reply) PushData() []byte {
 	r.pushOnce.Do(func() {
-		encoder := protocol.GetPushEncoder(r.ProtoType)
+		encoder := protocol.GetPushEncoder(r.protoType)
 		pushData, _ := encoder.Encode(r.Reply.Push)
 		r.pushData = pushData
 	})

--- a/node.go
+++ b/node.go
@@ -1289,6 +1289,8 @@ func (n *Node) History(ch string, opts ...HistoryOption) (HistoryResult, error) 
 		builder.WriteString(strconv.Itoa(historyOpts.Limit))
 		builder.WriteString(",reverse:")
 		builder.WriteString(strconv.FormatBool(historyOpts.Reverse))
+		builder.WriteString(",epoch:")
+		builder.WriteString(historyOpts.Epoch)
 		key := builder.String()
 
 		result, err, _ := historyGroup.Do(key, func() (interface{}, error) {
@@ -1300,20 +1302,20 @@ func (n *Node) History(ch string, opts ...HistoryOption) (HistoryResult, error) 
 }
 
 // recoverHistory recovers publications since StreamPosition last seen by client.
-func (n *Node) recoverHistory(ch string, since StreamPosition) (HistoryResult, error) {
+func (n *Node) recoverHistory(ch string, since StreamPosition, epoch string) (HistoryResult, error) {
 	incActionCount("history_recover")
 	limit := NoLimit
 	maxPublicationLimit := n.config.RecoveryMaxPublicationLimit
 	if maxPublicationLimit > 0 {
 		limit = maxPublicationLimit
 	}
-	return n.History(ch, WithLimit(limit), WithSince(&since))
+	return n.History(ch, WithLimit(limit), WithSince(&since), WithHistoryEpoch(epoch))
 }
 
 // streamTop returns current stream top StreamPosition for a channel.
-func (n *Node) streamTop(ch string) (StreamPosition, error) {
+func (n *Node) streamTop(ch string, epoch string) (StreamPosition, error) {
 	incActionCount("history_stream_top")
-	historyResult, err := n.History(ch)
+	historyResult, err := n.History(ch, WithHistoryEpoch(epoch))
 	if err != nil {
 		return StreamPosition{}, err
 	}

--- a/options.go
+++ b/options.go
@@ -27,7 +27,7 @@ func WithMeta(meta map[string]string) PublishOption {
 	}
 }
 
-// WithEpoch allows publishing with specified stream epoch.
+// WithEpoch allows publishing with specified stream epoch – see PublishOptions.Epoch.
 func WithEpoch(epoch string) PublishOption {
 	return func(opts *PublishOptions) {
 		opts.Epoch = epoch
@@ -61,7 +61,7 @@ type SubscribeOptions struct {
 	Data []byte
 	// RecoverSince will try to subscribe a client and recover from a certain StreamPosition.
 	RecoverSince *StreamPosition
-	// Epoch ...
+	// Epoch to set for a stream (only works for positioned streams at the moment).
 	Epoch string
 	// clientID to subscribe.
 	clientID string
@@ -70,7 +70,7 @@ type SubscribeOptions struct {
 // SubscribeOption is a type to represent various Subscribe options.
 type SubscribeOption func(*SubscribeOptions)
 
-// WithExpireAt allows to set ExpireAt field.
+// WithExpireAt allows setting ExpireAt field.
 func WithExpireAt(expireAt int64) SubscribeOption {
 	return func(opts *SubscribeOptions) {
 		opts.ExpireAt = expireAt
@@ -131,6 +131,13 @@ func WithSubscribeData(data []byte) SubscribeOption {
 func WithRecoverSince(since *StreamPosition) SubscribeOption {
 	return func(opts *SubscribeOptions) {
 		opts.RecoverSince = since
+	}
+}
+
+// WithSubscribeEpoch allows setting SubscribeOptions.Epoch.
+func WithSubscribeEpoch(epoch string) SubscribeOption {
+	return func(opts *SubscribeOptions) {
+		opts.Epoch = epoch
 	}
 }
 
@@ -243,7 +250,8 @@ type HistoryOptions struct {
 	Limit int
 	// Reverse direction
 	Reverse bool
-	// Epoch ...
+	// Epoch if set instructs history request to set an epoch for a stream. On new
+	// epoch stream will be reset.
 	Epoch string
 }
 

--- a/options.go
+++ b/options.go
@@ -27,6 +27,13 @@ func WithMeta(meta map[string]string) PublishOption {
 	}
 }
 
+// WithEpoch allows publishing with specified stream epoch.
+func WithEpoch(epoch string) PublishOption {
+	return func(opts *PublishOptions) {
+		opts.Epoch = epoch
+	}
+}
+
 // SubscribeOptions define per-subscription options.
 type SubscribeOptions struct {
 	// ExpireAt defines time in future when subscription should expire,
@@ -54,6 +61,8 @@ type SubscribeOptions struct {
 	Data []byte
 	// RecoverSince will try to subscribe a client and recover from a certain StreamPosition.
 	RecoverSince *StreamPosition
+	// Epoch ...
+	Epoch string
 	// clientID to subscribe.
 	clientID string
 }
@@ -234,6 +243,8 @@ type HistoryOptions struct {
 	Limit int
 	// Reverse direction
 	Reverse bool
+	// Epoch ...
+	Epoch string
 }
 
 // HistoryOption is a type to represent various History options.
@@ -242,23 +253,30 @@ type HistoryOption func(options *HistoryOptions)
 // NoLimit defines that limit should not be applied.
 const NoLimit = -1
 
-// WithLimit allows to set HistoryOptions.Limit.
+// WithLimit allows setting HistoryOptions.Limit.
 func WithLimit(limit int) HistoryOption {
 	return func(opts *HistoryOptions) {
 		opts.Limit = limit
 	}
 }
 
-// WithSince allows to set HistoryOptions.Since option.
+// WithSince allows setting HistoryOptions.Since option.
 func WithSince(sp *StreamPosition) HistoryOption {
 	return func(opts *HistoryOptions) {
 		opts.Since = sp
 	}
 }
 
-// WithSince allows to set HistoryOptions.Since option.
+// WithReverse allows setting HistoryOptions.Reverse option.
 func WithReverse(reverse bool) HistoryOption {
 	return func(opts *HistoryOptions) {
 		opts.Reverse = reverse
+	}
+}
+
+// WithHistoryEpoch allows setting HistoryOptions.Epoch option.
+func WithHistoryEpoch(epoch string) HistoryOption {
+	return func(opts *HistoryOptions) {
+		opts.Epoch = epoch
 	}
 }

--- a/options.go
+++ b/options.go
@@ -61,7 +61,7 @@ type SubscribeOptions struct {
 	Data []byte
 	// RecoverSince will try to subscribe a client and recover from a certain StreamPosition.
 	RecoverSince *StreamPosition
-	// Epoch to set for a stream (only works for positioned streams at the moment).
+	// Epoch to set for a stream (only works for positioned streams).
 	Epoch string
 	// clientID to subscribe.
 	clientID string

--- a/options_test.go
+++ b/options_test.go
@@ -22,6 +22,13 @@ func TestWithMeta(t *testing.T) {
 	require.Equal(t, "value", opts.Meta["test"])
 }
 
+func TestWithEpoch(t *testing.T) {
+	opt := WithEpoch("test")
+	opts := &PublishOptions{}
+	opt(opts)
+	require.Equal(t, "test", opts.Epoch)
+}
+
 func TestSubscribeOptions(t *testing.T) {
 	subscribeOpts := []SubscribeOption{
 		WithExpireAt(1),
@@ -30,6 +37,7 @@ func TestSubscribeOptions(t *testing.T) {
 		WithPosition(true),
 		WithRecover(true),
 		WithChannelInfo([]byte(`test`)),
+		WithSubscribeEpoch("test"),
 	}
 	opts := &SubscribeOptions{}
 	for _, opt := range subscribeOpts {
@@ -41,6 +49,7 @@ func TestSubscribeOptions(t *testing.T) {
 	require.True(t, opts.Position)
 	require.True(t, opts.Recover)
 	require.Equal(t, []byte(`test`), opts.ChannelInfo)
+	require.Equal(t, "test", opts.Epoch)
 }
 
 func TestWithDisconnect(t *testing.T) {

--- a/redis_shard.go
+++ b/redis_shard.go
@@ -173,13 +173,13 @@ type RedisShardConfig struct {
 	// ReadTimeout is a timeout on read operations. Note that at moment it should be greater
 	// than node ping publish interval in order to prevent timing out Pub/Sub connection's
 	// Receive call.
-	// By default DefaultRedisReadTimeout used.
+	// By default, DefaultRedisReadTimeout used.
 	ReadTimeout time.Duration
 	// WriteTimeout is a timeout on write operations.
-	// By default DefaultRedisWriteTimeout used.
+	// By default, DefaultRedisWriteTimeout used.
 	WriteTimeout time.Duration
 	// ConnectTimeout is a timeout on connect operation.
-	// By default DefaultRedisConnectTimeout used.
+	// By default, DefaultRedisConnectTimeout used.
 	ConnectTimeout time.Duration
 
 	network string


### PR DESCRIPTION
An approach for https://github.com/grafana/grafana/pull/43145 where we need to maintain single stream throughout all Grafana nodes. We provide a way to force a stream epoch value from the application code. This allows using native Centrifuge mechanisms for watching position in stream.