### PR TITLE
Refactor disconnects – avoid JSON in reason

### DIFF
--- a/_examples/chat_json/index.html
+++ b/_examples/chat_json/index.html
@@ -25,6 +25,7 @@
                     protocolVersion: 'v2',
                 });
                 // const centrifuge = new Centrifuge('http://localhost:8000/connection/sockjs', {
+                //     protocolVersion: 'v2',
                 //     sockjsTransports: [
                 //         "xhr-streaming",
                 //     ]
@@ -65,7 +66,7 @@
                 });
 
                 centrifuge.on('disconnect', function(ctx){
-                    drawText('Disconnected: ' + ctx.reason + (ctx.reconnect?", will try to reconnect":", won't try to reconnect"));
+                    drawText('Disconnected: ' + ctx.code + ' (' + ctx.reason + ')' + (ctx.reconnect?", will try to reconnect":", won't try to reconnect"));
                     input.setAttribute('disabled', 'true');
                 });
 

--- a/client.go
+++ b/client.go
@@ -358,11 +358,11 @@ func (c *Client) Connect(req ConnectRequest) {
 
 func (c *Client) getDisconnectPushReply(d *Disconnect) ([]byte, error) {
 	disconnect := &protocol.Disconnect{
-		Code:      d.Code,
-		Reason:    d.Reason,
-		Reconnect: d.Reconnect,
+		Code:   d.Code,
+		Reason: d.Reason,
 	}
 	if c.transport.ProtocolVersion() == ProtocolVersion1 {
+		disconnect.Reconnect = d.isReconnect()
 		pushBytes, err := protocol.EncodeDisconnectPush(c.transport.Protocol().toProto(), disconnect)
 		if err != nil {
 			return nil, err
@@ -835,7 +835,7 @@ func (c *Client) close(disconnect *Disconnect) error {
 	_ = c.transport.Close(disconnect)
 
 	if disconnect != nil && disconnect.Reason != "" {
-		c.node.logger.log(newLogEntry(LogLevelDebug, "closing client connection", map[string]interface{}{"client": c.uid, "user": c.user, "reason": disconnect.Reason, "reconnect": disconnect.Reconnect}))
+		c.node.logger.log(newLogEntry(LogLevelDebug, "closing client connection", map[string]interface{}{"client": c.uid, "user": c.user, "reason": disconnect.Reason}))
 	}
 	if disconnect != nil {
 		incServerDisconnect(disconnect.Code)

--- a/client.go
+++ b/client.go
@@ -363,7 +363,7 @@ func (c *Client) getDisconnectPushReply(d *Disconnect) ([]byte, error) {
 		Reconnect: d.Reconnect,
 	}
 	if c.transport.ProtocolVersion() == ProtocolVersion1 {
-		disconnect.Reconnect = d.isReconnect()
+		disconnect.Reconnect = d.isReconnect(ProtocolVersion1)
 		pushBytes, err := protocol.EncodeDisconnectPush(c.transport.Protocol().toProto(), disconnect)
 		if err != nil {
 			return nil, err

--- a/client.go
+++ b/client.go
@@ -358,8 +358,9 @@ func (c *Client) Connect(req ConnectRequest) {
 
 func (c *Client) getDisconnectPushReply(d *Disconnect) ([]byte, error) {
 	disconnect := &protocol.Disconnect{
-		Code:   d.Code,
-		Reason: d.Reason,
+		Code:      d.Code,
+		Reason:    d.Reason,
+		Reconnect: d.Reconnect,
 	}
 	if c.transport.ProtocolVersion() == ProtocolVersion1 {
 		disconnect.Reconnect = d.isReconnect()

--- a/disconnect.go
+++ b/disconnect.go
@@ -37,6 +37,9 @@ type Disconnect struct {
 	// Reason is a short description of disconnect code for humans.
 	Reason string `json:"reason"`
 
+	// Reconnect is only used for compatibility with ProtocolVersion1.
+	Reconnect bool `json:"reconnect"`
+
 	// These fields required for ProtocolVersion1 compatibility.
 	closeTextOnce   sync.Once
 	cachedCloseText string
@@ -56,6 +59,9 @@ func (d *Disconnect) Error() string {
 }
 
 func (d *Disconnect) isReconnect() bool {
+	if d.Reconnect {
+		return true
+	}
 	var reconnect = true
 	if (d.Code >= 3500 && d.Code < 3999) || (d.Code >= 4500 && d.Code <= 4999) {
 		reconnect = false
@@ -96,51 +102,60 @@ var (
 	// connection lost due to client not responding to ping from a server. Both
 	// scenarios are considered normal.
 	DisconnectNormal = &Disconnect{
-		Code:   3000,
-		Reason: "normal",
+		Code:      3000,
+		Reason:    "normal",
+		Reconnect: true,
 	}
 	// DisconnectShutdown sent when node is going to shut down.
 	DisconnectShutdown = &Disconnect{
-		Code:   3001,
-		Reason: "shutdown",
+		Code:      3001,
+		Reason:    "shutdown",
+		Reconnect: true,
 	}
 	// DisconnectServerError sent when internal error occurred on server.
 	DisconnectServerError = &Disconnect{
-		Code:   3004,
-		Reason: "internal server error",
+		Code:      3004,
+		Reason:    "internal server error",
+		Reconnect: true,
 	}
 	// DisconnectExpired sent when client connection expired.
 	DisconnectExpired = &Disconnect{
-		Code:   3005,
-		Reason: "expired",
+		Code:      3005,
+		Reason:    "expired",
+		Reconnect: true,
 	}
 	// DisconnectSubExpired sent when client subscription expired.
 	DisconnectSubExpired = &Disconnect{
-		Code:   3006,
-		Reason: "subscription expired",
+		Code:      3006,
+		Reason:    "subscription expired",
+		Reconnect: true,
 	}
 	// DisconnectSlow sent when client can't read messages fast enough.
 	DisconnectSlow = &Disconnect{
-		Code:   3008,
-		Reason: "slow",
+		Code:      3008,
+		Reason:    "slow",
+		Reconnect: true,
 	}
 	// DisconnectWriteError sent when an error occurred while writing to
 	// client connection.
 	DisconnectWriteError = &Disconnect{
-		Code:   3009,
-		Reason: "write error",
+		Code:      3009,
+		Reason:    "write error",
+		Reconnect: true,
 	}
 	// DisconnectInsufficientState sent when server detects wrong client
 	// position in channel Publication stream. Disconnect allows client
 	// to restore missed publications on reconnect.
 	DisconnectInsufficientState = &Disconnect{
-		Code:   3010,
-		Reason: "insufficient state",
+		Code:      3010,
+		Reason:    "insufficient state",
+		Reconnect: true,
 	}
 	// DisconnectForceReconnect sent when server disconnects connection.
 	DisconnectForceReconnect = &Disconnect{
-		Code:   3011,
-		Reason: "force reconnect",
+		Code:      3011,
+		Reason:    "force reconnect",
+		Reconnect: true,
 	}
 )
 

--- a/disconnect.go
+++ b/disconnect.go
@@ -7,48 +7,78 @@ import (
 	"sync"
 )
 
-// Disconnect allows configuring how client will be disconnected from server.
-// The important note that Disconnect serialized to JSON must be less than 127 bytes
-// due to WebSocket protocol limitations (because at moment we send Disconnect inside
-// reason field of WebSocket close handshake).
-// Note that due to performance reasons we cache Disconnect text representation
-// for Close Frame on first send to client so changing field values inside existing
-// Disconnect instance won't be reflected in WebSocket/Sockjs Close frames.
+// Disconnect allows configuring how client will be disconnected from a server.
+// A server can provide a Disconnect.Code and Disconnect.Reason to a client. Clients
+// can execute some custom logic based on a certain Disconnect.Code. Code is also
+// used for metric collection. Disconnect.Reason is optional and exists mostly for
+// human-readable description of returned code – i.e. for logging, debugging etc.
+//
+// The important note is that Disconnect.Reason must be less than 127 bytes
+// due to WebSocket protocol limitations.
+//
+// Codes have some rules which should be followed by a client connector implementation.
+// These rules described below.
+//
+// Codes in range 0-2999 should not be used by a Centrifuge library user. Those are
+// reserved for the client-side and transport specific needs. Codes in range >=5000
+// should not be used also. Those are reserved by Centrifuge.
+//
+// Client should reconnect upon receiving code in range 3000-3499, 4000-4499, >=5000.
+// For codes <3000 reconnect behavior can be adjusted for specific transport.
+//
+// Codes in range 3500-3999 and 4500-4999 are application terminal codes, no automatic
+// reconnect should be made by a client implementation.
+//
+// Library users supposed to use codes in range 4000-4999 for creating custom
+// disconnects.
 type Disconnect struct {
-	// Code is disconnect code.
+	// Code is a disconnect code.
 	Code uint32 `json:"code,omitempty"`
-	// Reason is a short description of disconnect.
+	// Reason is a short description of disconnect code for humans.
 	Reason string `json:"reason"`
-	// Reconnect gives client advice to reconnect after disconnect or not.
-	Reconnect bool `json:"reconnect"`
 
+	// These fields required for ProtocolVersion1 compatibility.
 	closeTextOnce   sync.Once
 	cachedCloseText string
 }
 
+// Make sure Disconnect implements error interface.
 var _ error = (*Disconnect)(nil)
 
 // String representation.
 func (d *Disconnect) String() string {
-	return fmt.Sprintf("code: %d, reason: %s, reconnect: %t", d.Code, d.Reason, d.Reconnect)
+	return fmt.Sprintf("code: %d, reason: %s", d.Code, d.Reason)
 }
 
 // Error representation.
 func (d *Disconnect) Error() string {
-	return fmt.Sprintf("disconnected: code: %d, reason: %s, reconnect: %t", d.Code, d.Reason, d.Reconnect)
+	return fmt.Sprintf("disconnected: code: %d, reason: %s", d.Code, d.Reason)
+}
+
+func (d *Disconnect) isReconnect() bool {
+	var reconnect = true
+	if (d.Code >= 3500 && d.Code < 3999) || (d.Code >= 4500 && d.Code <= 4999) {
+		reconnect = false
+	}
+	return reconnect
 }
 
 // CloseText allows building disconnect advice sent inside Close frame.
 // At moment, we don't encode Code here to not duplicate information
 // since it is sent separately as Code of WebSocket/SockJS Close Frame.
-func (d *Disconnect) CloseText() string {
+func (d *Disconnect) CloseText(protoVersion ProtocolVersion) string {
+	if protoVersion >= ProtocolVersion2 {
+		return d.Reason
+	}
+	// ProtocolVersion1 requires JSON with reconnect advice in reason text.
 	d.closeTextOnce.Do(func() {
 		buf := strings.Builder{}
 		buf.WriteString(`{"reason":`)
 		reason, _ := json.Marshal(d.Reason)
 		buf.Write(reason)
 		buf.WriteString(`,"reconnect":`)
-		if d.Reconnect {
+		var reconnect = d.isReconnect()
+		if reconnect {
 			buf.WriteString("true")
 		} else {
 			buf.WriteString("false")
@@ -59,106 +89,96 @@ func (d *Disconnect) CloseText() string {
 	return d.cachedCloseText
 }
 
-// Some predefined disconnect structures used by library internally. Though
-// it's always possible to create Disconnect with any field values on the fly.
-// Library users supposed to use codes in range 4000-4999 for custom disconnects.
+// Some predefined non-terminal disconnect structures used by
+// the library internally.
 var (
-	// DisconnectNormal is clean disconnect when client cleanly closed connection.
+	// DisconnectNormal is clean disconnect when client cleanly disconnected or
+	// connection lost due to client not responding to ping from a server. Both
+	// scenarios are considered normal.
 	DisconnectNormal = &Disconnect{
-		Code:      3000,
-		Reason:    "normal",
-		Reconnect: true,
+		Code:   3000,
+		Reason: "normal",
 	}
 	// DisconnectShutdown sent when node is going to shut down.
 	DisconnectShutdown = &Disconnect{
-		Code:      3001,
-		Reason:    "shutdown",
-		Reconnect: true,
-	}
-	// DisconnectInvalidToken sent when client came with invalid token.
-	DisconnectInvalidToken = &Disconnect{
-		Code:      3002,
-		Reason:    "invalid token",
-		Reconnect: false,
-	}
-	// DisconnectBadRequest sent when client uses malformed protocol
-	// frames or wrong order of commands.
-	DisconnectBadRequest = &Disconnect{
-		Code:      3003,
-		Reason:    "bad request",
-		Reconnect: false,
+		Code:   3001,
+		Reason: "shutdown",
 	}
 	// DisconnectServerError sent when internal error occurred on server.
 	DisconnectServerError = &Disconnect{
-		Code:      3004,
-		Reason:    "internal server error",
-		Reconnect: true,
+		Code:   3004,
+		Reason: "internal server error",
 	}
 	// DisconnectExpired sent when client connection expired.
 	DisconnectExpired = &Disconnect{
-		Code:      3005,
-		Reason:    "expired",
-		Reconnect: true,
+		Code:   3005,
+		Reason: "expired",
 	}
 	// DisconnectSubExpired sent when client subscription expired.
 	DisconnectSubExpired = &Disconnect{
-		Code:      3006,
-		Reason:    "subscription expired",
-		Reconnect: true,
-	}
-	// DisconnectStale sent to close connection that did not become
-	// authenticated in configured interval after dialing.
-	DisconnectStale = &Disconnect{
-		Code:      3007,
-		Reason:    "stale",
-		Reconnect: false,
+		Code:   3006,
+		Reason: "subscription expired",
 	}
 	// DisconnectSlow sent when client can't read messages fast enough.
 	DisconnectSlow = &Disconnect{
-		Code:      3008,
-		Reason:    "slow",
-		Reconnect: true,
+		Code:   3008,
+		Reason: "slow",
 	}
 	// DisconnectWriteError sent when an error occurred while writing to
 	// client connection.
 	DisconnectWriteError = &Disconnect{
-		Code:      3009,
-		Reason:    "write error",
-		Reconnect: true,
+		Code:   3009,
+		Reason: "write error",
 	}
 	// DisconnectInsufficientState sent when server detects wrong client
 	// position in channel Publication stream. Disconnect allows client
 	// to restore missed publications on reconnect.
 	DisconnectInsufficientState = &Disconnect{
-		Code:      3010,
-		Reason:    "insufficient state",
-		Reconnect: true,
+		Code:   3010,
+		Reason: "insufficient state",
 	}
 	// DisconnectForceReconnect sent when server disconnects connection.
 	DisconnectForceReconnect = &Disconnect{
-		Code:      3011,
-		Reason:    "force reconnect",
-		Reconnect: true,
+		Code:   3011,
+		Reason: "force reconnect",
+	}
+)
+
+// The codes below are built-in terminal codes.
+var (
+	// DisconnectInvalidToken sent when client came with invalid token.
+	DisconnectInvalidToken = &Disconnect{
+		Code:   3500,
+		Reason: "invalid token",
+	}
+	// DisconnectBadRequest sent when client uses malformed protocol
+	// frames or wrong order of commands.
+	DisconnectBadRequest = &Disconnect{
+		Code:   3501,
+		Reason: "bad request",
+	}
+	// DisconnectStale sent to close connection that did not become
+	// authenticated in configured interval after dialing.
+	DisconnectStale = &Disconnect{
+		Code:   3502,
+		Reason: "stale",
 	}
 	// DisconnectForceNoReconnect sent when server disconnects connection
 	// and asks it to not reconnect again.
 	DisconnectForceNoReconnect = &Disconnect{
-		Code:      3012,
-		Reason:    "force disconnect",
-		Reconnect: false,
+		Code:   3503,
+		Reason: "force disconnect",
 	}
 	// DisconnectConnectionLimit can be sent when client connection exceeds a
 	// configured connection limit (per user ID or due to other rule).
 	DisconnectConnectionLimit = &Disconnect{
-		Code:      3013,
-		Reason:    "connection limit",
-		Reconnect: false,
+		Code:   3504,
+		Reason: "connection limit",
 	}
 	// DisconnectChannelLimit can be sent when client connection exceeds a
 	// configured channel limit.
 	DisconnectChannelLimit = &Disconnect{
-		Code:      3013,
-		Reason:    "channel limit",
-		Reconnect: false,
+		Code:   3505,
+		Reason: "channel limit",
 	}
 )

--- a/disconnect_test.go
+++ b/disconnect_test.go
@@ -8,33 +8,33 @@ import (
 
 func TestDisconnect_CloseText(t *testing.T) {
 	d := DisconnectForceReconnect
-	closeText := d.CloseText()
+	closeText := d.CloseText(ProtocolVersion1)
 	require.Equal(t, `{"reason":"force reconnect","reconnect":true}`, closeText)
-	closeText = d.CloseText()
+	closeText = d.CloseText(ProtocolVersion1)
 	require.Equal(t, `{"reason":"force reconnect","reconnect":true}`, closeText)
 	d = DisconnectForceNoReconnect
-	closeText = d.CloseText()
+	closeText = d.CloseText(ProtocolVersion1)
 	require.Equal(t, `{"reason":"force disconnect","reconnect":false}`, closeText)
+	closeText = d.CloseText(ProtocolVersion2)
+	require.Equal(t, `force disconnect`, closeText)
 }
 
 func TestDisconnect_String(t *testing.T) {
 	d := Disconnect{
 		Code:            42,
 		Reason:          "reason",
-		Reconnect:       true,
 		cachedCloseText: "some information",
 	}
 	stringText := d.String()
-	require.Equal(t, "code: 42, reason: reason, reconnect: true", stringText)
+	require.Equal(t, "code: 42, reason: reason", stringText)
 }
 
 func TestDisconnect_Error(t *testing.T) {
 	d := Disconnect{
 		Code:            42,
 		Reason:          "reason",
-		Reconnect:       true,
 		cachedCloseText: "some information",
 	}
 	errorText := d.Error()
-	require.Equal(t, "disconnected: code: 42, reason: reason, reconnect: true", errorText)
+	require.Equal(t, "disconnected: code: 42, reason: reason", errorText)
 }

--- a/handler_sockjs.go
+++ b/handler_sockjs.go
@@ -279,5 +279,5 @@ func (t *sockjsTransport) Close(disconnect *Disconnect) error {
 	if disconnect == nil {
 		disconnect = DisconnectNormal
 	}
-	return t.session.Close(disconnect.Code, disconnect.CloseText())
+	return t.session.Close(disconnect.Code, disconnect.CloseText(t.ProtocolVersion()))
 }

--- a/handler_websocket.go
+++ b/handler_websocket.go
@@ -394,7 +394,7 @@ func (t *websocketTransport) Close(disconnect *Disconnect) error {
 	t.mu.Unlock()
 
 	if disconnect != nil {
-		msg := websocket.FormatCloseMessage(int(disconnect.Code), disconnect.CloseText())
+		msg := websocket.FormatCloseMessage(int(disconnect.Code), disconnect.CloseText(t.ProtocolVersion()))
 		err := t.conn.WriteControl(websocket.CloseMessage, msg, time.Now().Add(time.Second))
 		if err != nil {
 			return t.conn.Close()

--- a/hub_test.go
+++ b/hub_test.go
@@ -207,11 +207,13 @@ func TestHubDisconnect(t *testing.T) {
 
 	client.eventHub.disconnectHandler = func(e DisconnectEvent) {
 		defer wg.Done()
+		require.False(t, e.Disconnect.Reconnect)
 		require.Equal(t, DisconnectForceNoReconnect.Code, e.Disconnect.Code)
 	}
 
 	clientWithReconnect.eventHub.disconnectHandler = func(e DisconnectEvent) {
 		defer wg.Done()
+		require.True(t, e.Disconnect.Reconnect)
 		require.Equal(t, DisconnectForceReconnect.Code, e.Disconnect.Code)
 	}
 

--- a/hub_test.go
+++ b/hub_test.go
@@ -207,12 +207,12 @@ func TestHubDisconnect(t *testing.T) {
 
 	client.eventHub.disconnectHandler = func(e DisconnectEvent) {
 		defer wg.Done()
-		require.False(t, e.Disconnect.Reconnect)
+		require.Equal(t, DisconnectForceNoReconnect.Code, e.Disconnect.Code)
 	}
 
 	clientWithReconnect.eventHub.disconnectHandler = func(e DisconnectEvent) {
 		defer wg.Done()
-		require.True(t, e.Disconnect.Reconnect)
+		require.Equal(t, DisconnectForceReconnect.Code, e.Disconnect.Code)
 	}
 
 	// Disconnect not existed user.

--- a/node.go
+++ b/node.go
@@ -623,7 +623,7 @@ func (n *Node) handleControl(data []byte) error {
 			n.logger.log(newLogEntry(LogLevelError, "error decoding disconnect control params", map[string]interface{}{"error": err.Error()}))
 			return err
 		}
-		return n.hub.disconnect(cmd.User, &Disconnect{Code: cmd.Code, Reason: cmd.Reason, Reconnect: cmd.Reconnect}, cmd.Client, cmd.Whitelist)
+		return n.hub.disconnect(cmd.User, &Disconnect{Code: cmd.Code, Reason: cmd.Reason}, cmd.Client, cmd.Whitelist)
 	case controlpb.Command_SURVEY_REQUEST:
 		cmd, err := n.controlDecoder.DecodeSurveyRequest(params)
 		if err != nil {
@@ -928,7 +928,6 @@ func (n *Node) pubDisconnect(user string, disconnect *Disconnect, clientID strin
 		Whitelist: whitelist,
 		Code:      disconnect.Code,
 		Reason:    disconnect.Reason,
-		Reconnect: disconnect.Reconnect,
 		Client:    clientID,
 	}
 	params, _ := n.controlEncoder.EncodeDisconnect(protoDisconnect)

--- a/node.go
+++ b/node.go
@@ -623,7 +623,7 @@ func (n *Node) handleControl(data []byte) error {
 			n.logger.log(newLogEntry(LogLevelError, "error decoding disconnect control params", map[string]interface{}{"error": err.Error()}))
 			return err
 		}
-		return n.hub.disconnect(cmd.User, &Disconnect{Code: cmd.Code, Reason: cmd.Reason}, cmd.Client, cmd.Whitelist)
+		return n.hub.disconnect(cmd.User, &Disconnect{Code: cmd.Code, Reason: cmd.Reason, Reconnect: cmd.Reconnect}, cmd.Client, cmd.Whitelist)
 	case controlpb.Command_SURVEY_REQUEST:
 		cmd, err := n.controlDecoder.DecodeSurveyRequest(params)
 		if err != nil {
@@ -928,6 +928,7 @@ func (n *Node) pubDisconnect(user string, disconnect *Disconnect, clientID strin
 		Whitelist: whitelist,
 		Code:      disconnect.Code,
 		Reason:    disconnect.Reason,
+		Reconnect: disconnect.Reconnect,
 		Client:    clientID,
 	}
 	params, _ := n.controlEncoder.EncodeDisconnect(protoDisconnect)


### PR DESCRIPTION
Related #149 

New Disconnect behaviour described in detail in code comments. Copying from there:

```
Disconnect allows configuring how client will be disconnected from a server.
A server can provide a Disconnect.Code and Disconnect.Reason to a client. Clients
can execute some custom logic based on a certain Disconnect.Code. Code is also
used for metric collection. Disconnect.Reason is optional and exists mostly for
human-readable description of returned code – i.e. for logging, debugging etc.

The important note is that Disconnect.Reason must be less than 127 bytes
due to WebSocket protocol limitations.

Codes have some rules which should be followed by a client connector implementation.
These rules described below.

Codes in range 0-2999 should not be used by a Centrifuge library user. Those are
reserved for the client-side and transport specific needs. Codes in range >=5000
should not be used also. Those are reserved by Centrifuge.

Client should reconnect upon receiving code in range 3000-3499, 4000-4499, >=5000.
For codes <3000 reconnect behavior can be adjusted for specific transport.

Codes in range 3500-3999 and 4500-4999 are application terminal codes, no automatic
reconnect should be made by a client implementation.

Library users supposed to use codes in range 4000-4999 for creating custom
disconnects.
```

Some disconnect codes changed here to match new semantics, but since we never exposed codes to client's DisconnectContext it seems pretty safe. Reconnect field removed – but we still support building old-fashioned Reason for ProtocolVersion1.

Clients will need to expose code only for ProtocolVersion2.

For Centrifugo this will be a breaking change when custom Disconnects are used – but this should be possible to adopt fully on the backend side.

Eventually `Disconnect.CloseText(ProtocolVersion)` should be removed.