### PR TITLE
Epoch control adjustments

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -2,6 +2,7 @@ package centrifuge
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -94,9 +95,17 @@ type PublishOptions struct {
 	ClientInfo *ClientInfo
 	// Meta is a custom meta information for the Publication.
 	Meta map[string]string
-	// Epoch if set instructs publish request to set an epoch for a stream. On new
-	// epoch stream will be reset.
-	Epoch string
+	// ExpectedEpoch if set instructs publish request to check an epoch for a stream.
+	ExpectedEpoch string
+}
+
+// PublishError may be returned by a Broker.Publish with a special ErrCode.
+type PublishError struct {
+	ErrCode uint64
+}
+
+func (p PublishError) Error() string {
+	return fmt.Sprintf("publish error with code %d", p.ErrCode)
 }
 
 // Broker is responsible for PUB/SUB mechanics.

--- a/broker.go
+++ b/broker.go
@@ -99,8 +99,16 @@ type PublishOptions struct {
 	ExpectedEpoch string
 }
 
+const (
+	// PublishErrorUnexpectedEpoch may be returned if stream already has different
+	// epoch than passed inside PublishOptions.ExpectedEpoch. In this case Publication
+	// is dropped by Broker.
+	PublishErrorUnexpectedEpoch uint64 = 1
+)
+
 // PublishError may be returned by a Broker.Publish with a special ErrCode.
 type PublishError struct {
+	// ErrCode for identifying the root cause of PublishError.
 	ErrCode uint64
 }
 

--- a/broker_memory.go
+++ b/broker_memory.go
@@ -244,7 +244,7 @@ func (h *historyHub) add(ch string, pub *Publication, opts PublishOptions) (Stre
 	h.Lock()
 	defer h.Unlock()
 
-	var index uint64
+	var offset uint64
 	var epoch string
 
 	expireAt := time.Now().Unix() + int64(opts.HistoryTTL.Seconds())
@@ -269,20 +269,22 @@ func (h *historyHub) add(ch string, pub *Publication, opts PublishOptions) (Stre
 
 	if stream, ok := h.streams[ch]; ok {
 		epoch = stream.Epoch()
-		if opts.Epoch != "" && opts.Epoch != epoch {
-			stream.Reset(opts.Epoch)
-			epoch = opts.Epoch
+		if opts.ExpectedEpoch != "" && opts.ExpectedEpoch != epoch {
+			return StreamPosition{}, PublishError{ErrCode: 1}
 		}
-		index, _ = stream.Add(pub, opts.HistorySize)
+		offset, _ = stream.Add(pub, opts.HistorySize)
 	} else {
-		stream := memstream.New(opts.Epoch)
+		if opts.ExpectedEpoch != "" {
+			return StreamPosition{}, PublishError{ErrCode: 1}
+		}
+		stream := memstream.New("")
 		epoch = stream.Epoch()
-		index, _ = stream.Add(pub, opts.HistorySize)
+		offset, _ = stream.Add(pub, opts.HistorySize)
 		h.streams[ch] = stream
 	}
-	pub.Offset = index
+	pub.Offset = offset
 
-	return StreamPosition{Offset: index, Epoch: epoch}, nil
+	return StreamPosition{Offset: offset, Epoch: epoch}, nil
 }
 
 // Lock must be held outside.

--- a/broker_memory.go
+++ b/broker_memory.go
@@ -270,12 +270,12 @@ func (h *historyHub) add(ch string, pub *Publication, opts PublishOptions) (Stre
 	if stream, ok := h.streams[ch]; ok {
 		epoch = stream.Epoch()
 		if opts.ExpectedEpoch != "" && opts.ExpectedEpoch != epoch {
-			return StreamPosition{}, PublishError{ErrCode: 1}
+			return StreamPosition{}, PublishError{ErrCode: PublishErrorUnexpectedEpoch}
 		}
 		offset, _ = stream.Add(pub, opts.HistorySize)
 	} else {
 		if opts.ExpectedEpoch != "" {
-			return StreamPosition{}, PublishError{ErrCode: 1}
+			return StreamPosition{}, PublishError{ErrCode: PublishErrorUnexpectedEpoch}
 		}
 		stream := memstream.New("")
 		epoch = stream.Epoch()

--- a/node.go
+++ b/node.go
@@ -1310,13 +1310,13 @@ func (n *Node) recoverHistory(ch string, since StreamPosition, epoch string) (Hi
 	if maxPublicationLimit > 0 {
 		limit = maxPublicationLimit
 	}
-	return n.History(ch, WithLimit(limit), WithSince(&since), WithHistoryEpoch(epoch))
+	return n.History(ch, WithLimit(limit), WithSince(&since), WithEpoch(epoch))
 }
 
 // streamTop returns current stream top StreamPosition for a channel.
 func (n *Node) streamTop(ch string, epoch string) (StreamPosition, error) {
 	incActionCount("history_stream_top")
-	historyResult, err := n.History(ch, WithHistoryEpoch(epoch))
+	historyResult, err := n.History(ch, WithEpoch(epoch))
 	if err != nil {
 		return StreamPosition{}, err
 	}

--- a/options.go
+++ b/options.go
@@ -27,13 +27,13 @@ func WithMeta(meta map[string]string) PublishOption {
 	}
 }
 
-// WithEpoch allows publishing with specified stream epoch – see PublishOptions.Epoch.
+// WithExpectedEpoch allows setting PublishOptions.ExpectedEpoch.
 // This API is EXPERIMENTAL and may be changed/removed in the future releases – please
 // consider discussing the use case with Centrifuge maintainer before using this. In most
 // cases you don't need to control Epoch from the outside.
-func WithEpoch(epoch string) PublishOption {
+func WithExpectedEpoch(epoch string) PublishOption {
 	return func(opts *PublishOptions) {
-		opts.Epoch = epoch
+		opts.ExpectedEpoch = epoch
 	}
 }
 
@@ -259,8 +259,8 @@ type HistoryOptions struct {
 	Limit int
 	// Reverse direction
 	Reverse bool
-	// Epoch if set instructs history request to set an epoch for a stream. On new
-	// epoch stream will be reset.
+	// Epoch if set instructs history request to set an epoch for a stream.
+	// On new epoch stream will be reset.
 	Epoch string
 }
 
@@ -291,11 +291,11 @@ func WithReverse(reverse bool) HistoryOption {
 	}
 }
 
-// WithHistoryEpoch allows setting HistoryOptions.Epoch option.
+// WithEpoch allows setting HistoryOptions.Epoch option.
 // This API is EXPERIMENTAL and may be changed/removed in the future releases – please
 // consider discussing the use case with Centrifuge maintainer before using this. In most
 // cases you don't need to control Epoch from the outside.
-func WithHistoryEpoch(epoch string) HistoryOption {
+func WithEpoch(epoch string) HistoryOption {
 	return func(opts *HistoryOptions) {
 		opts.Epoch = epoch
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -23,10 +23,10 @@ func TestWithMeta(t *testing.T) {
 }
 
 func TestWithEpoch(t *testing.T) {
-	opt := WithEpoch("test")
+	opt := WithExpectedEpoch("test")
 	opts := &PublishOptions{}
 	opt(opts)
-	require.Equal(t, "test", opts.Epoch)
+	require.Equal(t, "test", opts.ExpectedEpoch)
 }
 
 func TestSubscribeOptions(t *testing.T) {


### PR DESCRIPTION
Instead of modifying an epoch we return an error if we see unexpected epoch upon publish. This allows publisher to know that stream it was published too is not actual anymore. 