### PR TITLE
Support app level ping in ProtocolVersion2

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,11 @@ func auth(h http.Handler) http.Handler {
 }
 
 func main() {
-	// We use default config here as a starting point. Default config
-	// contains reasonable values for available options.
-	cfg := centrifuge.DefaultConfig
-
 	// Node is the core object in Centrifuge library responsible for
 	// many useful things. For example Node allows publishing messages
-	// to channels with its Publish method.
-	node, err := centrifuge.New(cfg)
+	// into channels with its Publish method. Here we initialize Node
+	// with Config which has reasonable defaults for zero values.
+	node, err := centrifuge.New(centrifuge.Config{})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/_examples/chat_json/index.html
+++ b/_examples/chat_json/index.html
@@ -8,7 +8,7 @@
             .muted {color: #CCCCCC; font-size: 10px;}
         </style>
         <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
-        <script type="text/javascript" src="http://localhost:2000/centrifuge.js"></script>
+        <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/centrifugal/centrifuge-js@master/dist/centrifuge.min.js"></script>
         <script type="text/javascript">
             // helper functions to work with escaping html.
             const tagsToReplace = {'&': '&amp;', '<': '&lt;', '>': '&gt;'};
@@ -21,9 +21,7 @@
                 const input = document.getElementById("input");
                 const container = document.getElementById('messages');
 
-                const centrifuge = new Centrifuge('ws://localhost:8000/connection/websocket?cf_protocol_version=v2', {
-                    protocolVersion: 'v2',
-                });
+                const centrifuge = new Centrifuge('ws://localhost:8000/connection/websocket', {});
                 // const centrifuge = new Centrifuge('http://localhost:8000/connection/sockjs', {
                 //     sockjsTransports: [
                 //         "xhr-streaming",

--- a/_examples/chat_json/index.html
+++ b/_examples/chat_json/index.html
@@ -8,7 +8,7 @@
             .muted {color: #CCCCCC; font-size: 10px;}
         </style>
         <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
-        <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/centrifugal/centrifuge-js@master/dist/centrifuge.min.js"></script>
+        <script type="text/javascript" src="http://localhost:2000/centrifuge.js"></script>
         <script type="text/javascript">
             // helper functions to work with escaping html.
             const tagsToReplace = {'&': '&amp;', '<': '&lt;', '>': '&gt;'};
@@ -21,7 +21,9 @@
                 const input = document.getElementById("input");
                 const container = document.getElementById('messages');
 
-                const centrifuge = new Centrifuge('ws://localhost:8000/connection/websocket', {});
+                const centrifuge = new Centrifuge('ws://localhost:8000/connection/websocket?cf_protocol_version=v2', {
+                    protocolVersion: 'v2',
+                });
                 // const centrifuge = new Centrifuge('http://localhost:8000/connection/sockjs', {
                 //     sockjsTransports: [
                 //         "xhr-streaming",

--- a/_examples/chat_json/index.html
+++ b/_examples/chat_json/index.html
@@ -8,7 +8,7 @@
             .muted {color: #CCCCCC; font-size: 10px;}
         </style>
         <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
-        <script type="text/javascript" src="http://localhost:2000/centrifuge.js"></script>
+        <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/centrifugal/centrifuge-js@master/dist/centrifuge.min.js"></script>
         <script type="text/javascript">
             // helper functions to work with escaping html.
             const tagsToReplace = {'&': '&amp;', '<': '&lt;', '>': '&gt;'};
@@ -21,11 +21,8 @@
                 const input = document.getElementById("input");
                 const container = document.getElementById('messages');
 
-                const centrifuge = new Centrifuge('ws://localhost:8000/connection/websocket', {
-                    protocolVersion: 'v2',
-                });
+                const centrifuge = new Centrifuge('ws://localhost:8000/connection/websocket', {});
                 // const centrifuge = new Centrifuge('http://localhost:8000/connection/sockjs?cf_protocol_version=v2', {
-                //     protocolVersion: 'v2',
                 //     sockjsTransports: [
                 //         "xhr-polling",
                 //     ]

--- a/_examples/chat_json/index.html
+++ b/_examples/chat_json/index.html
@@ -8,7 +8,7 @@
             .muted {color: #CCCCCC; font-size: 10px;}
         </style>
         <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
-        <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/centrifugal/centrifuge-js@master/dist/centrifuge.min.js"></script>
+        <script type="text/javascript" src="http://localhost:2000/centrifuge.js"></script>
         <script type="text/javascript">
             // helper functions to work with escaping html.
             const tagsToReplace = {'&': '&amp;', '<': '&lt;', '>': '&gt;'};
@@ -21,10 +21,13 @@
                 const input = document.getElementById("input");
                 const container = document.getElementById('messages');
 
-                const centrifuge = new Centrifuge('ws://localhost:8000/connection/websocket', {});
-                // const centrifuge = new Centrifuge('http://localhost:8000/connection/sockjs', {
+                const centrifuge = new Centrifuge('ws://localhost:8000/connection/websocket', {
+                    protocolVersion: 'v2',
+                });
+                // const centrifuge = new Centrifuge('http://localhost:8000/connection/sockjs?cf_protocol_version=v2', {
+                //     protocolVersion: 'v2',
                 //     sockjsTransports: [
-                //         "xhr-streaming",
+                //         "xhr-polling",
                 //     ]
                 // });
 

--- a/_examples/chat_json/index.html
+++ b/_examples/chat_json/index.html
@@ -22,9 +22,9 @@
                 const container = document.getElementById('messages');
 
                 const centrifuge = new Centrifuge('ws://localhost:8000/connection/websocket', {});
-                // const centrifuge = new Centrifuge('http://localhost:8000/connection/sockjs?cf_protocol_version=v2', {
+                // const centrifuge = new Centrifuge('http://localhost:8000/connection/sockjs', {
                 //     sockjsTransports: [
-                //         "xhr-polling",
+                //         "xhr-streaming",
                 //     ]
                 // });
 

--- a/_examples/chat_json/main.go
+++ b/_examples/chat_json/main.go
@@ -3,12 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 	"time"
 
@@ -61,12 +59,10 @@ func channelSubscribeAllowed(channel string) bool {
 }
 
 func main() {
-	cfg := centrifuge.DefaultConfig
-
-	cfg.LogLevel = centrifuge.LogLevelInfo
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelInfo,
+		LogHandler: handleLog,
+	})
 
 	// Override default broker which does not use HistoryMetaTTL.
 	broker, _ := centrifuge.NewMemoryBroker(node, centrifuge.MemoryBrokerConfig{
@@ -89,24 +85,24 @@ func main() {
 		transport := client.Transport()
 		log.Printf("user %s connected via %s with protocol: %s", client.UserID(), transport.Name(), transport.Protocol())
 
-		// Event handler should not block, so start separate goroutine to
-		// periodically send messages to client.
-		go func() {
-			for {
-				select {
-				case <-client.Context().Done():
-					return
-				case <-time.After(5 * time.Second):
-					err := client.Send([]byte(`{"time": "` + strconv.FormatInt(time.Now().Unix(), 10) + `"}`))
-					if err != nil {
-						if err == io.EOF {
-							return
-						}
-						log.Printf("error sending message: %s", err)
-					}
-				}
-			}
-		}()
+		//// Event handler should not block, so start separate goroutine to
+		//// periodically send messages to client.
+		//go func() {
+		//	for {
+		//		select {
+		//		case <-client.Context().Done():
+		//			return
+		//		case <-time.After(5 * time.Second):
+		//			err := client.Send([]byte(`{"time": "` + strconv.FormatInt(time.Now().Unix(), 10) + `"}`))
+		//			if err != nil {
+		//				if err == io.EOF {
+		//					return
+		//				}
+		//				log.Printf("error sending message: %s", err)
+		//			}
+		//		}
+		//	}
+		//}()
 
 		client.OnAlive(func() {
 			log.Printf("user %s connection is still active", client.UserID())
@@ -193,47 +189,52 @@ func main() {
 		log.Fatal(err)
 	}
 
-	go func() {
-		// Publish personal notifications for user 42 periodically.
-		i := 1
-		for {
-			_, err := node.Publish(
-				"#42",
-				[]byte(`{"personal": "`+strconv.Itoa(i)+`"}`),
-				centrifuge.WithHistory(300, time.Minute),
-			)
-			if err != nil {
-				log.Printf("error publishing to personal channel: %s", err)
-			}
-			i++
-			time.Sleep(5000 * time.Millisecond)
-		}
-	}()
-
-	go func() {
-		// Publish to channel periodically.
-		i := 1
-		for {
-			_, err := node.Publish(
-				"chat:index",
-				[]byte(`{"input": "Publish from server `+strconv.Itoa(i)+`"}`),
-				centrifuge.WithHistory(300, time.Minute),
-			)
-			if err != nil {
-				log.Printf("error publishing to channel: %s", err)
-			}
-			i++
-			time.Sleep(10000 * time.Millisecond)
-		}
-	}()
+	//go func() {
+	//	// Publish personal notifications for user 42 periodically.
+	//	i := 1
+	//	for {
+	//		_, err := node.Publish(
+	//			"#42",
+	//			[]byte(`{"personal": "`+strconv.Itoa(i)+`"}`),
+	//			centrifuge.WithHistory(300, time.Minute),
+	//		)
+	//		if err != nil {
+	//			log.Printf("error publishing to personal channel: %s", err)
+	//		}
+	//		i++
+	//		time.Sleep(5000 * time.Millisecond)
+	//	}
+	//}()
+	//
+	//go func() {
+	//	// Publish to channel periodically.
+	//	i := 1
+	//	for {
+	//		_, err := node.Publish(
+	//			"chat:index",
+	//			[]byte(`{"input": "Publish from server `+strconv.Itoa(i)+`"}`),
+	//			centrifuge.WithHistory(300, time.Minute),
+	//		)
+	//		if err != nil {
+	//			log.Printf("error publishing to channel: %s", err)
+	//		}
+	//		i++
+	//		time.Sleep(10000 * time.Millisecond)
+	//	}
+	//}()
 
 	websocketHandler := centrifuge.NewWebsocketHandler(node, centrifuge.WebsocketConfig{
+		ProtocolVersion:    centrifuge.ProtocolVersion2,
 		ReadBufferSize:     1024,
 		UseWriteBufferPool: true,
+		CheckOrigin: func(r *http.Request) bool {
+			return true
+		},
 	})
 	http.Handle("/connection/websocket", authMiddleware(websocketHandler))
 
 	sockjsHandler := centrifuge.NewSockjsHandler(node, centrifuge.SockjsConfig{
+		ProtocolVersion:          centrifuge.ProtocolVersion2,
 		URL:                      "https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js",
 		HandlerPrefix:            "/connection/sockjs",
 		WebsocketReadBufferSize:  1024,

--- a/_examples/chat_json/main.go
+++ b/_examples/chat_json/main.go
@@ -228,9 +228,6 @@ func main() {
 	websocketHandler := centrifuge.NewWebsocketHandler(node, centrifuge.WebsocketConfig{
 		ReadBufferSize:     1024,
 		UseWriteBufferPool: true,
-		CheckOrigin: func(r *http.Request) bool {
-			return true
-		},
 	})
 	http.Handle("/connection/websocket", authMiddleware(websocketHandler))
 

--- a/_examples/chat_oauth2/main.go
+++ b/_examples/chat_oauth2/main.go
@@ -97,7 +97,7 @@ func authMiddleware(h http.Handler) http.Handler {
 }
 
 func createCentrifugeNode() (*centrifuge.Node, error) {
-	node, err := centrifuge.New(centrifuge.DefaultConfig)
+	node, err := centrifuge.New(centrifuge.Config{})
 	if err != nil {
 		return nil, err
 	}

--- a/_examples/chat_protobuf/index.html
+++ b/_examples/chat_protobuf/index.html
@@ -9,7 +9,7 @@
         </style>
         <script src="https://unpkg.com/text-encoding@0.6.4/lib/encoding-indexes.js"></script>
         <script src="https://unpkg.com/text-encoding@0.6.4/lib/encoding.js"></script>
-        <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/centrifugal/centrifuge-js@master/dist/centrifuge.protobuf.min.js"></script>
+        <script type="text/javascript" src="http://localhost:2000/centrifuge.protobuf.js"></script>
         <script type="text/javascript">
             // helper functions to work with escaping html.
             const tagsToReplace = {'&': '&amp;', '<': '&lt;', '>': '&gt;'};
@@ -23,7 +23,8 @@
                 const container = document.getElementById('messages');
 
                 const centrifuge = new Centrifuge('ws://localhost:8000/connection/websocket', {
-                    protocol: 'protobuf' // Note we are setting protobuf protocol here!
+                    protocol: 'protobuf', // Note we are setting protobuf protocol here!
+                    protocolVersion: 'v2',
                 });
 
                 // bind listeners on centrifuge object instance events.

--- a/_examples/chat_protobuf/index.html
+++ b/_examples/chat_protobuf/index.html
@@ -9,7 +9,7 @@
         </style>
         <script src="https://unpkg.com/text-encoding@0.6.4/lib/encoding-indexes.js"></script>
         <script src="https://unpkg.com/text-encoding@0.6.4/lib/encoding.js"></script>
-        <script type="text/javascript" src="http://localhost:2000/centrifuge.protobuf.js"></script>
+        <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/centrifugal/centrifuge-js@master/dist/centrifuge.min.js"></script>
         <script type="text/javascript">
             // helper functions to work with escaping html.
             const tagsToReplace = {'&': '&amp;', '<': '&lt;', '>': '&gt;'};

--- a/_examples/chat_protobuf/index.html
+++ b/_examples/chat_protobuf/index.html
@@ -9,7 +9,7 @@
         </style>
         <script src="https://unpkg.com/text-encoding@0.6.4/lib/encoding-indexes.js"></script>
         <script src="https://unpkg.com/text-encoding@0.6.4/lib/encoding.js"></script>
-        <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/centrifugal/centrifuge-js@master/dist/centrifuge.min.js"></script>
+        <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/centrifugal/centrifuge-js@master/dist/centrifuge.protobuf.min.js"></script>
         <script type="text/javascript">
             // helper functions to work with escaping html.
             const tagsToReplace = {'&': '&amp;', '<': '&lt;', '>': '&gt;'};
@@ -24,7 +24,6 @@
 
                 const centrifuge = new Centrifuge('ws://localhost:8000/connection/websocket', {
                     protocol: 'protobuf', // Note we are setting protobuf protocol here!
-                    protocolVersion: 'v2',
                 });
 
                 // bind listeners on centrifuge object instance events.

--- a/_examples/chat_protobuf/main.go
+++ b/_examples/chat_protobuf/main.go
@@ -45,12 +45,10 @@ func waitExitSignal(n *centrifuge.Node) {
 }
 
 func main() {
-	cfg := centrifuge.DefaultConfig
-
-	cfg.LogLevel = centrifuge.LogLevelDebug
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelDebug,
+		LogHandler: handleLog,
+	})
 
 	node.OnConnecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
 		return centrifuge.ConnectReply{
@@ -113,7 +111,11 @@ func main() {
 		log.Fatal(err)
 	}
 
-	http.Handle("/connection/websocket", authMiddleware(centrifuge.NewWebsocketHandler(node, centrifuge.WebsocketConfig{})))
+	http.Handle("/connection/websocket", authMiddleware(centrifuge.NewWebsocketHandler(node, centrifuge.WebsocketConfig{
+		ProtocolVersion: centrifuge.ProtocolVersion2,
+		PingInterval:    5 * time.Second,
+		PongTimeout:     3 * time.Second,
+	})))
 	http.Handle("/", http.FileServer(http.Dir("./")))
 
 	go func() {

--- a/_examples/chat_protobuf/main.go
+++ b/_examples/chat_protobuf/main.go
@@ -111,9 +111,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	http.Handle("/connection/websocket", authMiddleware(centrifuge.NewWebsocketHandler(node, centrifuge.WebsocketConfig{
-		ProtocolVersion: centrifuge.ProtocolVersion2,
-	})))
+	http.Handle("/connection/websocket", authMiddleware(centrifuge.NewWebsocketHandler(node, centrifuge.WebsocketConfig{})))
 	http.Handle("/", http.FileServer(http.Dir("./")))
 
 	go func() {

--- a/_examples/chat_protobuf/main.go
+++ b/_examples/chat_protobuf/main.go
@@ -113,8 +113,6 @@ func main() {
 
 	http.Handle("/connection/websocket", authMiddleware(centrifuge.NewWebsocketHandler(node, centrifuge.WebsocketConfig{
 		ProtocolVersion: centrifuge.ProtocolVersion2,
-		PingInterval:    5 * time.Second,
-		PongTimeout:     3 * time.Second,
 	})))
 	http.Handle("/", http.FileServer(http.Dir("./")))
 

--- a/_examples/concurrency/main.go
+++ b/_examples/concurrency/main.go
@@ -42,12 +42,10 @@ func waitExitSignal(n *centrifuge.Node) {
 }
 
 func main() {
-	cfg := centrifuge.DefaultConfig
-
-	cfg.LogLevel = centrifuge.LogLevelInfo
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelDebug,
+		LogHandler: handleLog,
+	})
 
 	broker, _ := centrifuge.NewMemoryBroker(node, centrifuge.MemoryBrokerConfig{
 		HistoryMetaTTL: 120 * time.Second,

--- a/_examples/custom_broker_nats/main.go
+++ b/_examples/custom_broker_nats/main.go
@@ -51,11 +51,10 @@ func waitExitSignal(n *centrifuge.Node) {
 func main() {
 	flag.Parse()
 
-	cfg := centrifuge.DefaultConfig
-	cfg.LogLevel = centrifuge.LogLevelDebug
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelDebug,
+		LogHandler: handleLog,
+	})
 
 	node.OnConnect(func(client *centrifuge.Client) {
 		transport := client.Transport()

--- a/_examples/custom_engine_tarantool/main.go
+++ b/_examples/custom_engine_tarantool/main.go
@@ -59,11 +59,10 @@ func waitExitSignal(n *centrifuge.Node) {
 func main() {
 	flag.Parse()
 
-	cfg := centrifuge.DefaultConfig
-	cfg.LogLevel = centrifuge.LogLevelDebug
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelDebug,
+		LogHandler: handleLog,
+	})
 
 	node.OnConnect(func(client *centrifuge.Client) {
 		transport := client.Transport()

--- a/_examples/custom_engine_tarantool/tntengine/broker_test.go
+++ b/_examples/custom_engine_tarantool/tntengine/broker_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func newTestTarantoolEngine(tb testing.TB) (*Broker, *PresenceManager) {
-	n, _ := centrifuge.New(centrifuge.DefaultConfig)
+	n, _ := centrifuge.New(centrifuge.Config{})
 	var shards []*Shard
 	for _, port := range []string{"3301"} {
 		shard, err := NewShard(ShardConfig{Addresses: []string{"127.0.0.1:" + port}})
@@ -81,7 +81,7 @@ func TestTarantoolClientSubscribeRecover(t *testing.T) {
 }
 
 func nodeWithTarantoolBroker(tb testing.TB) *centrifuge.Node {
-	c := centrifuge.DefaultConfig
+	c := centrifuge.Config{}
 	return nodeWithTarantoolBrokerWithConfig(tb, c)
 }
 

--- a/_examples/custom_token/main.go
+++ b/_examples/custom_token/main.go
@@ -32,15 +32,12 @@ func waitExitSignal(n *centrifuge.Node) {
 }
 
 func main() {
-	cfg := centrifuge.DefaultConfig
-
-	cfg.LogLevel = centrifuge.LogLevelInfo
-	cfg.LogHandler = handleLog
-
-	// Better to keep default in production. Here we just speeding up things a bit.
-	cfg.ClientExpiredCloseDelay = 5 * time.Second
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelDebug,
+		LogHandler: handleLog,
+		// Better to keep default in production. Here we are just speeding up things a bit.
+		ClientExpiredCloseDelay: 5 * time.Second,
+	})
 
 	broker, _ := centrifuge.NewMemoryBroker(node, centrifuge.MemoryBrokerConfig{
 		HistoryMetaTTL: 120 * time.Second,

--- a/_examples/custom_ws_gobwas/main.go
+++ b/_examples/custom_ws_gobwas/main.go
@@ -46,12 +46,10 @@ func waitExitSignal(n *centrifuge.Node) {
 func main() {
 	flag.Parse()
 
-	cfg := centrifuge.DefaultConfig
-
-	cfg.LogLevel = centrifuge.LogLevelDebug
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelDebug,
+		LogHandler: handleLog,
+	})
 
 	node.OnConnecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
 		return centrifuge.ConnectReply{

--- a/_examples/custom_ws_gobwas/transport.go
+++ b/_examples/custom_ws_gobwas/transport.go
@@ -55,6 +55,11 @@ func (t *customWebsocketTransport) DisabledPushFlags() uint64 {
 	return centrifuge.PushFlagDisconnect
 }
 
+// AppLevelPing not implemented here, example only works over ProtocolVersion1.
+func (t *customWebsocketTransport) AppLevelPing() centrifuge.AppLevelPing {
+	return centrifuge.AppLevelPing{}
+}
+
 func (t *customWebsocketTransport) read() ([]byte, bool, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -131,7 +136,7 @@ func (t *customWebsocketTransport) Close(disconnect *centrifuge.Disconnect) erro
 	t.mu.Unlock()
 
 	if disconnect != nil {
-		data := ws.NewCloseFrameBody(ws.StatusCode(disconnect.Code), disconnect.CloseText())
+		data := ws.NewCloseFrameBody(ws.StatusCode(disconnect.Code), disconnect.CloseText(t.ProtocolVersion()))
 		_ = wsutil.WriteServerMessage(t.conn, ws.OpClose, data)
 		return t.conn.Close()
 	}

--- a/_examples/custom_ws_nhooyr/main.go
+++ b/_examples/custom_ws_nhooyr/main.go
@@ -55,11 +55,10 @@ func waitExitSignal(n *centrifuge.Node) {
 }
 
 func main() {
-	cfg := centrifuge.DefaultConfig
-	cfg.LogLevel = centrifuge.LogLevelInfo
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelInfo,
+		LogHandler: handleLog,
+	})
 
 	node.OnConnecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
 		return centrifuge.ConnectReply{
@@ -217,6 +216,11 @@ func (t *customWebsocketTransport) DisabledPushFlags() uint64 {
 	return centrifuge.PushFlagDisconnect
 }
 
+// AppLevelPing not implemented here, example only works over ProtocolVersion1.
+func (t *customWebsocketTransport) AppLevelPing() centrifuge.AppLevelPing {
+	return centrifuge.AppLevelPing{}
+}
+
 // Write ...
 func (t *customWebsocketTransport) Write(message []byte) error {
 	select {
@@ -277,7 +281,7 @@ func (t *customWebsocketTransport) Close(disconnect *centrifuge.Disconnect) erro
 	t.mu.Unlock()
 
 	if disconnect != nil {
-		return t.conn.Close(websocket.StatusCode(disconnect.Code), disconnect.CloseText())
+		return t.conn.Close(websocket.StatusCode(disconnect.Code), disconnect.CloseText(t.ProtocolVersion()))
 	}
 	return t.conn.Close(websocket.StatusNormalClosure, "")
 }

--- a/_examples/gin_auth/main.go
+++ b/_examples/gin_auth/main.go
@@ -90,11 +90,10 @@ func authMiddleware(h http.Handler) http.Handler {
 }
 
 func main() {
-	cfg := centrifuge.DefaultConfig
-	cfg.LogLevel = centrifuge.LogLevelDebug
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelDebug,
+		LogHandler: handleLog,
+	})
 
 	node.OnConnecting(func(ctx context.Context, event centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
 		// Let's include user email into connect reply, so we can display user name in chat.

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -7,7 +7,7 @@ replace github.com/centrifugal/centrifuge => ../
 require (
 	github.com/FZambia/tarantool v0.2.2
 	github.com/centrifugal/centrifuge v0.8.2
-	github.com/centrifugal/protocol v0.8.3-0.20220207171307-8a5d230cacfc
+	github.com/centrifugal/protocol v0.8.3
 	github.com/cristalhq/jwt/v3 v3.0.0
 	github.com/dchest/uniuri v0.0.0-20200228104902-7aecb25e1fe5
 	github.com/gin-contrib/sessions v0.0.3

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -7,7 +7,7 @@ replace github.com/centrifugal/centrifuge => ../
 require (
 	github.com/FZambia/tarantool v0.2.2
 	github.com/centrifugal/centrifuge v0.8.2
-	github.com/centrifugal/protocol v0.8.1
+	github.com/centrifugal/protocol v0.8.2
 	github.com/cristalhq/jwt/v3 v3.0.0
 	github.com/dchest/uniuri v0.0.0-20200228104902-7aecb25e1fe5
 	github.com/gin-contrib/sessions v0.0.3

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -7,7 +7,7 @@ replace github.com/centrifugal/centrifuge => ../
 require (
 	github.com/FZambia/tarantool v0.2.2
 	github.com/centrifugal/centrifuge v0.8.2
-	github.com/centrifugal/protocol v0.8.2
+	github.com/centrifugal/protocol v0.8.3-0.20220207171307-8a5d230cacfc
 	github.com/cristalhq/jwt/v3 v3.0.0
 	github.com/dchest/uniuri v0.0.0-20200228104902-7aecb25e1fe5
 	github.com/gin-contrib/sessions v0.0.3

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -20,8 +20,8 @@ github.com/boj/redistore v0.0.0-20180917114910-cd5dcc76aeff/go.mod h1:+RTT1BOk5P
 github.com/bradfitz/gomemcache v0.0.0-20190329173943-551aad21a668/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/bradleypeabody/gorilla-sessions-memcache v0.0.0-20181103040241-659414f458e1/go.mod h1:dkChI7Tbtx7H1Tj7TqGSZMOeGpMP5gLHtjroHd4agiI=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/centrifugal/protocol v0.8.1 h1:XvcdqgC7cFM+wovmmAN2XMeK5HiTftKl+7Y0ZoJ50FE=
-github.com/centrifugal/protocol v0.8.1/go.mod h1:cJo0/BuXglhPfg0fgSgTXvBZ7y+9rdg4+nPbIDOVmlA=
+github.com/centrifugal/protocol v0.8.2 h1:5dXWRPklLhwWJV2VkPpN2oR57OHLd2LBaI7gfDBJNuo=
+github.com/centrifugal/protocol v0.8.2/go.mod h1:cJo0/BuXglhPfg0fgSgTXvBZ7y+9rdg4+nPbIDOVmlA=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -20,8 +20,8 @@ github.com/boj/redistore v0.0.0-20180917114910-cd5dcc76aeff/go.mod h1:+RTT1BOk5P
 github.com/bradfitz/gomemcache v0.0.0-20190329173943-551aad21a668/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/bradleypeabody/gorilla-sessions-memcache v0.0.0-20181103040241-659414f458e1/go.mod h1:dkChI7Tbtx7H1Tj7TqGSZMOeGpMP5gLHtjroHd4agiI=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/centrifugal/protocol v0.8.2 h1:5dXWRPklLhwWJV2VkPpN2oR57OHLd2LBaI7gfDBJNuo=
-github.com/centrifugal/protocol v0.8.2/go.mod h1:cJo0/BuXglhPfg0fgSgTXvBZ7y+9rdg4+nPbIDOVmlA=
+github.com/centrifugal/protocol v0.8.3-0.20220207171307-8a5d230cacfc h1:1Wtxm7jxxf+DpdeVbBPyd2/PoS0xAa93B6RXlFVMObw=
+github.com/centrifugal/protocol v0.8.3-0.20220207171307-8a5d230cacfc/go.mod h1:cJo0/BuXglhPfg0fgSgTXvBZ7y+9rdg4+nPbIDOVmlA=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -20,8 +20,8 @@ github.com/boj/redistore v0.0.0-20180917114910-cd5dcc76aeff/go.mod h1:+RTT1BOk5P
 github.com/bradfitz/gomemcache v0.0.0-20190329173943-551aad21a668/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/bradleypeabody/gorilla-sessions-memcache v0.0.0-20181103040241-659414f458e1/go.mod h1:dkChI7Tbtx7H1Tj7TqGSZMOeGpMP5gLHtjroHd4agiI=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/centrifugal/protocol v0.8.3-0.20220207171307-8a5d230cacfc h1:1Wtxm7jxxf+DpdeVbBPyd2/PoS0xAa93B6RXlFVMObw=
-github.com/centrifugal/protocol v0.8.3-0.20220207171307-8a5d230cacfc/go.mod h1:cJo0/BuXglhPfg0fgSgTXvBZ7y+9rdg4+nPbIDOVmlA=
+github.com/centrifugal/protocol v0.8.3 h1:0Xg8kbNp3LHOJZaIRsbyjriX6e4/AiCPSbUSHmpp7Zc=
+github.com/centrifugal/protocol v0.8.3/go.mod h1:cJo0/BuXglhPfg0fgSgTXvBZ7y+9rdg4+nPbIDOVmlA=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/_examples/history_pagination/main.go
+++ b/_examples/history_pagination/main.go
@@ -61,12 +61,10 @@ func channelSubscribeAllowed(channel string) bool {
 }
 
 func main() {
-	cfg := centrifuge.DefaultConfig
-
-	cfg.LogLevel = centrifuge.LogLevelInfo
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelDebug,
+		LogHandler: handleLog,
+	})
 
 	broker, _ := centrifuge.NewMemoryBroker(node, centrifuge.MemoryBrokerConfig{
 		HistoryMetaTTL: 120 * time.Second,

--- a/_examples/jwt_token/main.go
+++ b/_examples/jwt_token/main.go
@@ -45,11 +45,10 @@ func channelSubscribeAllowed(channel string) bool {
 }
 
 func main() {
-	cfg := centrifuge.DefaultConfig
-	cfg.LogLevel = centrifuge.LogLevelInfo
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelDebug,
+		LogHandler: handleLog,
+	})
 
 	broker, _ := centrifuge.NewMemoryBroker(node, centrifuge.MemoryBrokerConfig{
 		HistoryMetaTTL: 120 * time.Second,

--- a/_examples/single_connection/main.go
+++ b/_examples/single_connection/main.go
@@ -42,11 +42,10 @@ func waitExitSignal(n *centrifuge.Node) {
 }
 
 func main() {
-	cfg := centrifuge.DefaultConfig
-	cfg.LogLevel = centrifuge.LogLevelInfo
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelDebug,
+		LogHandler: handleLog,
+	})
 
 	node.OnConnecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
 		cred, _ := centrifuge.GetCredentials(ctx)

--- a/_examples/survey/main.go
+++ b/_examples/survey/main.go
@@ -94,11 +94,10 @@ func respondChannelsSurvey(node *centrifuge.Node) centrifuge.SurveyReply {
 func main() {
 	flag.Parse()
 
-	cfg := centrifuge.DefaultConfig
-	cfg.LogLevel = centrifuge.LogLevelDebug
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelDebug,
+		LogHandler: handleLog,
+	})
 
 	node.OnSurvey(func(event centrifuge.SurveyEvent, cb centrifuge.SurveyCallback) {
 		switch event.Op {

--- a/_examples/unidirectional_fetch_stream/main.go
+++ b/_examples/unidirectional_fetch_stream/main.go
@@ -59,11 +59,10 @@ var exampleChannel = "unidirectional"
 func main() {
 	flag.Parse()
 
-	cfg := centrifuge.DefaultConfig
-	cfg.LogLevel = centrifuge.LogLevelDebug
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelDebug,
+		LogHandler: handleLog,
+	})
 
 	if *redis {
 		redisShardConfigs := []centrifuge.RedisShardConfig{
@@ -298,6 +297,11 @@ func (t *streamTransport) Unidirectional() bool {
 // DisabledPushFlags ...
 func (t *streamTransport) DisabledPushFlags() uint64 {
 	return 0
+}
+
+// AppLevelPing not implemented here, example only works over ProtocolVersion1.
+func (t *streamTransport) AppLevelPing() centrifuge.AppLevelPing {
+	return centrifuge.AppLevelPing{}
 }
 
 func (t *streamTransport) Write(message []byte) error {

--- a/_examples/unidirectional_grpc/main.go
+++ b/_examples/unidirectional_grpc/main.go
@@ -194,6 +194,11 @@ func (t *grpcTransport) DisabledPushFlags() uint64 {
 	return 0
 }
 
+// AppLevelPing not implemented here, example only works over ProtocolVersion1.
+func (t *grpcTransport) AppLevelPing() centrifuge.AppLevelPing {
+	return centrifuge.AppLevelPing{}
+}
+
 func (t *grpcTransport) Write(message []byte) error {
 	return t.WriteMany(message)
 }
@@ -235,11 +240,10 @@ var exampleChannel = "unidirectional"
 func main() {
 	flag.Parse()
 
-	cfg := centrifuge.DefaultConfig
-	cfg.LogLevel = centrifuge.LogLevelDebug
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelDebug,
+		LogHandler: handleLog,
+	})
 
 	if *redis {
 		redisShardConfigs := []centrifuge.RedisShardConfig{

--- a/_examples/unidirectional_sse/main.go
+++ b/_examples/unidirectional_sse/main.go
@@ -55,11 +55,10 @@ var exampleChannel = "unidirectional"
 func main() {
 	flag.Parse()
 
-	cfg := centrifuge.DefaultConfig
-	cfg.LogLevel = centrifuge.LogLevelDebug
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelDebug,
+		LogHandler: handleLog,
+	})
 
 	if *redis {
 		redisShardConfigs := []centrifuge.RedisShardConfig{
@@ -280,6 +279,11 @@ func (t *eventsourceTransport) Unidirectional() bool {
 // DisabledPushFlags ...
 func (t *eventsourceTransport) DisabledPushFlags() uint64 {
 	return 0
+}
+
+// AppLevelPing not implemented here, example only works over ProtocolVersion1.
+func (t *eventsourceTransport) AppLevelPing() centrifuge.AppLevelPing {
+	return centrifuge.AppLevelPing{}
 }
 
 func (t *eventsourceTransport) Write(message []byte) error {

--- a/_examples/unidirectional_ws/main.go
+++ b/_examples/unidirectional_ws/main.go
@@ -61,11 +61,10 @@ var exampleChannel = "unidirectional"
 func main() {
 	flag.Parse()
 
-	cfg := centrifuge.DefaultConfig
-	cfg.LogLevel = centrifuge.LogLevelDebug
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelDebug,
+		LogHandler: handleLog,
+	})
 
 	if *redis {
 		redisShardConfigs := []centrifuge.RedisShardConfig{
@@ -271,6 +270,11 @@ func (t *websocketTransport) DisabledPushFlags() uint64 {
 	return 0
 }
 
+// AppLevelPing not implemented here, example only works over ProtocolVersion1.
+func (t *websocketTransport) AppLevelPing() centrifuge.AppLevelPing {
+	return centrifuge.AppLevelPing{}
+}
+
 func (t *websocketTransport) writeData(data []byte) error {
 	if t.opts.compressionMinSize > 0 {
 		t.conn.EnableWriteCompression(len(data) > t.opts.compressionMinSize)
@@ -301,7 +305,6 @@ func (t *websocketTransport) Write(message []byte) error {
 	return t.WriteMany(message)
 }
 
-// Write data to transport.
 func (t *websocketTransport) WriteMany(messages ...[]byte) error {
 	select {
 	case <-t.closeCh:

--- a/_examples/user_subscribe_unsubscribe/main.go
+++ b/_examples/user_subscribe_unsubscribe/main.go
@@ -49,11 +49,10 @@ func waitExitSignal(n *centrifuge.Node) {
 func main() {
 	flag.Parse()
 
-	cfg := centrifuge.DefaultConfig
-	cfg.LogLevel = centrifuge.LogLevelDebug
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelDebug,
+		LogHandler: handleLog,
+	})
 
 	node.OnConnecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
 		return centrifuge.ConnectReply{

--- a/_examples/worms/main.go
+++ b/_examples/worms/main.go
@@ -46,11 +46,10 @@ func waitExitSignal(n *centrifuge.Node) {
 }
 
 func main() {
-	cfg := centrifuge.DefaultConfig
-	cfg.LogLevel = centrifuge.LogLevelDebug
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelDebug,
+		LogHandler: handleLog,
+	})
 
 	node.OnConnecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
 		return centrifuge.ConnectReply{

--- a/_examples/ws_benchmarks/benchmark_gobwas/main.go
+++ b/_examples/ws_benchmarks/benchmark_gobwas/main.go
@@ -48,11 +48,10 @@ func main() {
 
 	flag.Parse()
 
-	cfg := centrifuge.DefaultConfig
-	cfg.LogLevel = centrifuge.LogLevelError
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelError,
+		LogHandler: handleLog,
+	})
 
 	node.OnConnecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
 		return centrifuge.ConnectReply{

--- a/_examples/ws_benchmarks/benchmark_gobwas/transport.go
+++ b/_examples/ws_benchmarks/benchmark_gobwas/transport.go
@@ -48,9 +48,13 @@ func (t *customWebsocketTransport) DisabledPushFlags() uint64 {
 	return centrifuge.PushFlagDisconnect
 }
 
-// Version of protocol.
 func (t *customWebsocketTransport) ProtocolVersion() centrifuge.ProtocolVersion {
 	return centrifuge.ProtocolVersion1
+}
+
+// AppLevelPing not implemented here, example only works over ProtocolVersion1.
+func (t *customWebsocketTransport) AppLevelPing() centrifuge.AppLevelPing {
+	return centrifuge.AppLevelPing{}
 }
 
 func (t *customWebsocketTransport) read() ([]byte, bool, error) {
@@ -129,7 +133,7 @@ func (t *customWebsocketTransport) Close(disconnect *centrifuge.Disconnect) erro
 	t.mu.Unlock()
 
 	if disconnect != nil {
-		data := ws.NewCloseFrameBody(ws.StatusCode(disconnect.Code), disconnect.CloseText())
+		data := ws.NewCloseFrameBody(ws.StatusCode(disconnect.Code), disconnect.CloseText(t.ProtocolVersion()))
 		_ = wsutil.WriteServerMessage(t.conn, ws.OpClose, data)
 		return t.conn.Close()
 	}

--- a/_examples/ws_benchmarks/benchmark_gorilla/main.go
+++ b/_examples/ws_benchmarks/benchmark_gorilla/main.go
@@ -36,11 +36,10 @@ func waitExitSignal(n *centrifuge.Node) {
 func main() {
 	log.Printf("NumCPU: %d", runtime.NumCPU())
 
-	cfg := centrifuge.DefaultConfig
-	cfg.LogLevel = centrifuge.LogLevelError
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelError,
+		LogHandler: handleLog,
+	})
 
 	if os.Getenv("CENTRIFUGE_BROKER") == "redis" {
 		redisShardConfigs := []centrifuge.RedisShardConfig{

--- a/_examples/ws_benchmarks/benchmark_nhooyr/main.go
+++ b/_examples/ws_benchmarks/benchmark_nhooyr/main.go
@@ -74,6 +74,10 @@ func (t *customWebsocketTransport) Protocol() centrifuge.ProtocolType {
 	return t.protoType
 }
 
+func (t *customWebsocketTransport) ProtocolVersion() centrifuge.ProtocolVersion {
+	return centrifuge.ProtocolVersion1
+}
+
 // Unidirectional returns whether transport is unidirectional.
 func (t *customWebsocketTransport) Unidirectional() bool {
 	return false
@@ -84,9 +88,9 @@ func (t *customWebsocketTransport) DisabledPushFlags() uint64 {
 	return centrifuge.PushFlagDisconnect
 }
 
-// Version of protocol.
-func (t *customWebsocketTransport) ProtocolVersion() centrifuge.ProtocolVersion {
-	return centrifuge.ProtocolVersion1
+// AppLevelPing not implemented here, example only works over ProtocolVersion1.
+func (t *customWebsocketTransport) AppLevelPing() centrifuge.AppLevelPing {
+	return centrifuge.AppLevelPing{}
 }
 
 // Write ...
@@ -206,11 +210,10 @@ func (s *customWebsocketHandler) ServeHTTP(rw http.ResponseWriter, r *http.Reque
 func main() {
 	log.Printf("NumCPU: %d", runtime.NumCPU())
 
-	cfg := centrifuge.DefaultConfig
-	cfg.LogLevel = centrifuge.LogLevelError
-	cfg.LogHandler = handleLog
-
-	node, _ := centrifuge.New(cfg)
+	node, _ := centrifuge.New(centrifuge.Config{
+		LogLevel:   centrifuge.LogLevelError,
+		LogHandler: handleLog,
+	})
 
 	node.OnConnecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
 		return centrifuge.ConnectReply{

--- a/broker_memory_test.go
+++ b/broker_memory_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 func testMemoryBroker() *MemoryBroker {
-	conf := DefaultConfig
-	conf.LogLevel = LogLevelDebug
-	conf.LogHandler = func(entry LogEntry) {}
-	n, _ := New(conf)
+	n, _ := New(Config{
+		LogLevel:   LogLevelDebug,
+		LogHandler: func(entry LogEntry) {},
+	})
 	e, _ := NewMemoryBroker(n, MemoryBrokerConfig{})
 	n.SetBroker(e)
 	err := n.Run()

--- a/broker_redis_test.go
+++ b/broker_redis_test.go
@@ -35,10 +35,10 @@ func newTestRedisBroker(tb testing.TB, n *Node, useStreams bool, useCluster bool
 }
 
 func testNode(tb testing.TB) *Node {
-	conf := DefaultConfig
-	conf.LogLevel = LogLevelDebug
-	conf.LogHandler = func(entry LogEntry) {}
-	node, err := New(conf)
+	node, err := New(Config{
+		LogLevel:   LogLevelDebug,
+		LogHandler: func(entry LogEntry) {},
+	})
 	require.NoError(tb, err)
 	return node
 }
@@ -684,7 +684,7 @@ func TestRedisExtractPushData(t *testing.T) {
 func TestNode_OnSurvey_TwoNodes(t *testing.T) {
 	redisConf := testRedisConf()
 
-	node1, _ := New(DefaultConfig)
+	node1, _ := New(Config{})
 
 	s, err := NewRedisShard(node1, redisConf)
 	require.NoError(t, err)
@@ -708,7 +708,7 @@ func TestNode_OnSurvey_TwoNodes(t *testing.T) {
 		})
 	})
 
-	node2, _ := New(DefaultConfig)
+	node2, _ := New(Config{})
 
 	s2, err := NewRedisShard(node2, redisConf)
 	require.NoError(t, err)
@@ -747,7 +747,7 @@ func TestNode_OnSurvey_TwoNodes(t *testing.T) {
 func TestNode_OnNotification_TwoNodes(t *testing.T) {
 	redisConf := testRedisConf()
 
-	node1, _ := New(DefaultConfig)
+	node1, _ := New(Config{})
 
 	s, err := NewRedisShard(node1, redisConf)
 	require.NoError(t, err)
@@ -772,7 +772,7 @@ func TestNode_OnNotification_TwoNodes(t *testing.T) {
 		close(ch1)
 	})
 
-	node2, _ := New(DefaultConfig)
+	node2, _ := New(Config{})
 
 	s2, err := NewRedisShard(node2, redisConf)
 	require.NoError(t, err)
@@ -813,7 +813,7 @@ func TestNode_OnNotification_TwoNodes(t *testing.T) {
 func TestRedisPubSubTwoNodes(t *testing.T) {
 	redisConf := testRedisConf()
 
-	node1, _ := New(DefaultConfig)
+	node1, _ := New(Config{})
 
 	s, err := NewRedisShard(node1, redisConf)
 	require.NoError(t, err)
@@ -847,7 +847,7 @@ func TestRedisPubSubTwoNodes(t *testing.T) {
 	_ = e1.Run(brokerEventHandler)
 	require.NoError(t, e1.Subscribe("test"))
 
-	node2, _ := New(DefaultConfig)
+	node2, _ := New(Config{})
 	s2, err := NewRedisShard(node2, redisConf)
 	require.NoError(t, err)
 
@@ -932,7 +932,7 @@ func BenchmarkRedisSurvey(b *testing.B) {
 			data := make([]byte, tt.DataSize)
 
 			for i := 0; i < tt.NumOtherNodes; i++ {
-				node, _ := New(DefaultConfig)
+				node, _ := New(Config{})
 				s, err := NewRedisShard(node, redisConf)
 				if err != nil {
 					b.Fatal(err)
@@ -952,7 +952,7 @@ func BenchmarkRedisSurvey(b *testing.B) {
 				})
 			}
 
-			node, _ := New(DefaultConfig)
+			node, _ := New(Config{})
 			s, err := NewRedisShard(node, redisConf)
 			if err != nil {
 				b.Fatal(err)
@@ -1168,8 +1168,7 @@ func BenchmarkRedisRecover_1Ch(b *testing.B) {
 }
 
 func nodeWithRedisBroker(tb testing.TB, useStreams bool, useCluster bool) *Node {
-	c := DefaultConfig
-	n, err := New(c)
+	n, err := New(Config{})
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/client.go
+++ b/client.go
@@ -2300,8 +2300,14 @@ func (c *Client) connectCmd(req *protocol.ConnectRequest, cmd *protocol.Command,
 		Ttl:     ttl,
 	}
 
-	if c.transport.ProtocolVersion() > ProtocolVersion1 && c.transport.AppLevelPing().PingInterval > 0 {
-		res.Ping = uint32(c.transport.AppLevelPing().PingInterval.Seconds())
+	if c.transport.ProtocolVersion() > ProtocolVersion1 {
+		appLevelPing := c.transport.AppLevelPing()
+		if appLevelPing.PingInterval > 0 {
+			res.Ping = uint32(c.transport.AppLevelPing().PingInterval.Seconds())
+		}
+		if !c.transport.Unidirectional() && appLevelPing.PongTimeout > 0 {
+			res.Pong = true
+		}
 	}
 
 	// Client successfully connected.

--- a/client_test.go
+++ b/client_test.go
@@ -209,6 +209,7 @@ func TestClientV2TimerSchedule(t *testing.T) {
 }
 
 func TestClientV2DisconnectNoPong(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	done := make(chan struct{})
@@ -232,6 +233,7 @@ func TestClientV2DisconnectNoPong(t *testing.T) {
 }
 
 func TestClientV2PingPong(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	done := make(chan struct{})
@@ -494,6 +496,7 @@ func TestClientSubscribe(t *testing.T) {
 }
 
 func TestClientSubscribeBrokerErrorOnSubscribe(t *testing.T) {
+	t.Parallel()
 	broker := NewTestBroker()
 	broker.errorOnSubscribe = true
 	node := nodeWithBroker(broker)
@@ -528,6 +531,7 @@ func TestClientSubscribeBrokerErrorOnSubscribe(t *testing.T) {
 }
 
 func TestClientSubscribeBrokerErrorOnStreamTop(t *testing.T) {
+	t.Parallel()
 	broker := NewTestBroker()
 	broker.errorOnHistory = true
 	node := nodeWithBroker(broker)
@@ -596,6 +600,7 @@ func TestClientSubscribeUnrecoverablePosition(t *testing.T) {
 }
 
 func TestClientSubscribePositionedError(t *testing.T) {
+	t.Parallel()
 	broker := NewTestBroker()
 	broker.errorOnHistory = true
 	node := nodeWithBroker(broker)
@@ -660,6 +665,7 @@ func TestClientSubscribePositioned(t *testing.T) {
 }
 
 func TestClientSubscribeBrokerErrorOnRecoverHistory(t *testing.T) {
+	t.Parallel()
 	broker := NewTestBroker()
 	broker.errorOnHistory = true
 	node := nodeWithBroker(broker)
@@ -695,6 +701,7 @@ func TestClientSubscribeBrokerErrorOnRecoverHistory(t *testing.T) {
 }
 
 func testUnexpectedOffsetEpoch(t *testing.T, offset uint64, epoch string) {
+	t.Parallel()
 	broker := NewTestBroker()
 	node := nodeWithBroker(broker)
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -787,6 +794,7 @@ func TestClientSubscribeValidateErrors(t *testing.T) {
 }
 
 func TestClientSubscribeReceivePublication(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	transport := newTestTransport(func() {})
@@ -825,6 +833,7 @@ func TestClientSubscribeReceivePublication(t *testing.T) {
 }
 
 func TestClientSubscribeReceivePublicationWithOffset(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -915,6 +924,7 @@ type testContextKey int
 var keyTest testContextKey = 1
 
 func TestConnectingReply(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -950,6 +960,7 @@ func TestConnectingReply(t *testing.T) {
 }
 
 func TestServerSideSubscriptions(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		Name           string
 		Unidirectional bool
@@ -1037,6 +1048,7 @@ func TestServerSideSubscriptions(t *testing.T) {
 }
 
 func TestClientRefresh(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1140,6 +1152,7 @@ func TestClientRefresh(t *testing.T) {
 }
 
 func TestClientRefreshExpireAtInThePast(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1253,6 +1266,7 @@ func getJSONEncodedParams(t testing.TB, request interface{}) []byte {
 }
 
 func TestClientUnsubscribeClientSide(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1296,6 +1310,7 @@ func TestClientUnsubscribeClientSide(t *testing.T) {
 }
 
 func TestClientUnsubscribeServerSide(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	client := newTestClient(t, node, "42")
@@ -1331,6 +1346,7 @@ func TestClientUnsubscribeServerSide(t *testing.T) {
 }
 
 func TestClientAliveHandler(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1518,6 +1534,7 @@ type testClientMessage struct {
 }
 
 func TestClientPublishHandler(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2080,6 +2097,7 @@ func TestClientHistoryNotAvailable(t *testing.T) {
 }
 
 func TestClientCloseUnauthenticated(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2097,6 +2115,7 @@ func TestClientCloseUnauthenticated(t *testing.T) {
 }
 
 func TestClientHandleUnidirectional(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2127,6 +2146,7 @@ func TestExtractUnidirectionalDisconnect(t *testing.T) {
 }
 
 func TestClientHandleEmptyData(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2145,6 +2165,7 @@ func TestClientHandleEmptyData(t *testing.T) {
 }
 
 func TestClientHandleBrokenData(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2159,6 +2180,7 @@ func TestClientHandleBrokenData(t *testing.T) {
 }
 
 func TestClientHandleCommandNotAuthenticated(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2193,6 +2215,7 @@ func TestClientHandleUnknownMethod(t *testing.T) {
 }
 
 func TestClientHandleCommandWithBrokenParams(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() {
 		_ = node.Shutdown(context.Background())
@@ -2315,6 +2338,7 @@ func TestClientHandleCommandWithBrokenParams(t *testing.T) {
 }
 
 func TestClientOnAlive(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	node.config.ClientPresenceUpdateInterval = time.Second
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -2341,6 +2365,7 @@ func TestClientOnAlive(t *testing.T) {
 }
 
 func TestClientHandleCommandWithoutID(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2373,6 +2398,7 @@ func TestToClientError(t *testing.T) {
 }
 
 func TestClientAlreadyAuthenticated(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2393,6 +2419,7 @@ func TestClientAlreadyAuthenticated(t *testing.T) {
 }
 
 func TestClientCloseExpired(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2469,6 +2496,7 @@ func TestClientPresenceUpdate(t *testing.T) {
 }
 
 func TestClientSubExpired(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2712,6 +2740,7 @@ func TestClientSideRefresh(t *testing.T) {
 }
 
 func TestServerSideRefresh(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2760,6 +2789,7 @@ func TestServerSideRefresh(t *testing.T) {
 }
 
 func TestServerSideRefreshDisconnect(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2811,6 +2841,7 @@ func TestServerSideRefreshDisconnect(t *testing.T) {
 }
 
 func TestServerSideRefreshCustomError(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2986,6 +3017,7 @@ func TestClientSideSubRefreshUnexpected(t *testing.T) {
 }
 
 func TestCloseNoRace(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -3151,6 +3183,7 @@ func errLogLevel(err error) LogLevel {
 }
 
 func TestClientTransportWriteError(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		Name               string
 		Error              error

--- a/config.go
+++ b/config.go
@@ -6,7 +6,7 @@ import (
 
 // Config contains Node configuration options.
 type Config struct {
-	// Version of server – will be sent to a client on connection establishment
+	// Version of server – if set will be sent to a client on connection establishment
 	// phase in reply to connect command from a client.
 	Version string
 	// Name is a unique name of the current server Node. Name used as human-readable
@@ -18,33 +18,41 @@ type Config struct {
 	LogHandler LogHandler
 	// NodeInfoMetricsAggregateInterval sets interval for automatic metrics
 	// aggregation. It's not reasonable to have it less than one second.
+	// Zero value means 60 * time.Second.
 	NodeInfoMetricsAggregateInterval time.Duration
 	// ClientPresenceUpdateInterval sets an interval how often connected
 	// clients update presence information.
+	// Zero value means 27 * time.Second.
 	ClientPresenceUpdateInterval time.Duration
 	// ClientExpiredCloseDelay is an extra time given to client to refresh
 	// its connection in the end of connection TTL. At moment only used for
 	// a client-side refresh workflow.
+	// Zero value means 25 * time.Second.
 	ClientExpiredCloseDelay time.Duration
 	// ClientExpiredSubCloseDelay is an extra time given to client to
 	// refresh its expiring subscription in the end of subscription TTL.
 	// At the moment only used for a client-side subscription refresh workflow.
+	// Zero value means 25 * time.Second.
 	ClientExpiredSubCloseDelay time.Duration
 	// ClientStaleCloseDelay is a timeout after which connection will be
 	// closed if still not authenticated (i.e. no valid connect command
 	// received yet).
+	// Zero value means 25 * time.Second.
 	ClientStaleCloseDelay time.Duration
 	// ClientChannelPositionCheckDelay defines minimal time from previous
 	// client position check in channel. If client does not pass check it will
 	// be disconnected with DisconnectInsufficientState.
+	// Zero value means 40 * time.Second.
 	ClientChannelPositionCheckDelay time.Duration
 	// ClientQueueMaxSize is a maximum size of client's message queue in bytes.
 	// After this queue size exceeded Centrifuge closes client's connection.
+	// Zero value means 1048576 bytes (1MB).
 	ClientQueueMaxSize int
 	// ClientChannelLimit sets upper limit of client-side channels each client
 	// can subscribe to. Client-side subscriptions attempts will get an ErrorLimitExceeded
 	// in subscribe reply. Server-side subscriptions above limit will result into
 	// DisconnectChannelLimit.
+	// Zero value means 128.
 	ClientChannelLimit int
 	// UserConnectionLimit limits number of client connections to single Node
 	// from user with the same ID. Zero value means unlimited. Anonymous users
@@ -52,6 +60,7 @@ type Config struct {
 	UserConnectionLimit int
 	// ChannelMaxLength is the maximum length of a channel name. This is only checked
 	// for client-side subscription requests.
+	// Zero value means 255.
 	ChannelMaxLength int
 	// MetricsNamespace is a Prometheus metrics namespace to use for internal metrics.
 	// If not set then the default namespace name `centrifuge` will be used.
@@ -83,14 +92,5 @@ const (
 )
 
 // DefaultConfig is Config initialized with default values for all fields.
-var DefaultConfig = Config{
-	NodeInfoMetricsAggregateInterval: 60 * time.Second,
-	ClientPresenceUpdateInterval:     25 * time.Second,
-	ClientExpiredCloseDelay:          25 * time.Second,
-	ClientExpiredSubCloseDelay:       25 * time.Second,
-	ClientStaleCloseDelay:            25 * time.Second,
-	ClientChannelPositionCheckDelay:  40 * time.Second,
-	ClientQueueMaxSize:               10485760, // 10MB by default.
-	ClientChannelLimit:               128,
-	ChannelMaxLength:                 255,
-}
+// Deprecated, use Config struct directly – it now uses reasonable zero values.
+var DefaultConfig = Config{}

--- a/disconnect.go
+++ b/disconnect.go
@@ -38,6 +38,7 @@ type Disconnect struct {
 	Reason string `json:"reason"`
 
 	// Reconnect is only used for compatibility with ProtocolVersion1.
+	// Ignore this field if all your clients are using ProtocolVersion2.
 	Reconnect bool `json:"reconnect"`
 
 	// These fields required for ProtocolVersion1 compatibility.
@@ -102,44 +103,44 @@ var (
 		Reason:    "normal",
 		Reconnect: true,
 	}
-	// DisconnectShutdown sent when node is going to shut down.
+	// DisconnectShutdown issued when node is going to shut down.
 	DisconnectShutdown = &Disconnect{
 		Code:      3001,
 		Reason:    "shutdown",
 		Reconnect: true,
 	}
-	// DisconnectServerError sent when internal error occurred on server.
+	// DisconnectServerError issued when internal error occurred on server.
 	DisconnectServerError = &Disconnect{
 		Code:      3004,
 		Reason:    "internal server error",
 		Reconnect: true,
 	}
-	// DisconnectExpired sent when client connection expired.
+	// DisconnectExpired issued when client connection expired.
 	DisconnectExpired = &Disconnect{
 		Code:      3005,
 		Reason:    "expired",
 		Reconnect: true,
 	}
-	// DisconnectSubExpired sent when client subscription expired.
+	// DisconnectSubExpired issued when client subscription expired.
 	DisconnectSubExpired = &Disconnect{
 		Code:      3006,
 		Reason:    "subscription expired",
 		Reconnect: true,
 	}
-	// DisconnectSlow sent when client can't read messages fast enough.
+	// DisconnectSlow issued when client can't read messages fast enough.
 	DisconnectSlow = &Disconnect{
 		Code:      3008,
 		Reason:    "slow",
 		Reconnect: true,
 	}
-	// DisconnectWriteError sent when an error occurred while writing to
+	// DisconnectWriteError issued when an error occurred while writing to
 	// client connection.
 	DisconnectWriteError = &Disconnect{
 		Code:      3009,
 		Reason:    "write error",
 		Reconnect: true,
 	}
-	// DisconnectInsufficientState sent when server detects wrong client
+	// DisconnectInsufficientState issued when server detects wrong client
 	// position in channel Publication stream. Disconnect allows client
 	// to restore missed publications on reconnect.
 	DisconnectInsufficientState = &Disconnect{
@@ -147,46 +148,54 @@ var (
 		Reason:    "insufficient state",
 		Reconnect: true,
 	}
-	// DisconnectForceReconnect sent when server disconnects connection.
+	// DisconnectForceReconnect issued when server disconnects connection.
 	DisconnectForceReconnect = &Disconnect{
 		Code:      3011,
 		Reason:    "force reconnect",
+		Reconnect: true,
+	}
+	// DisconnectNoPong may be issued when server disconnects bidirectional
+	// connection due to no pong received to application-level server-to-client
+	// pings in a configured time.
+	DisconnectNoPong = &Disconnect{
+		Code:      3012,
+		Reason:    "no pong",
 		Reconnect: true,
 	}
 )
 
 // The codes below are built-in terminal codes.
 var (
-	// DisconnectInvalidToken sent when client came with invalid token.
+	// DisconnectInvalidToken issued when client came with invalid token.
 	DisconnectInvalidToken = &Disconnect{
 		Code:   3500,
 		Reason: "invalid token",
 	}
-	// DisconnectBadRequest sent when client uses malformed protocol
+	// DisconnectBadRequest issued when client uses malformed protocol
 	// frames or wrong order of commands.
 	DisconnectBadRequest = &Disconnect{
 		Code:   3501,
 		Reason: "bad request",
 	}
-	// DisconnectStale sent to close connection that did not become
+	// DisconnectStale issued to close connection that did not become
 	// authenticated in configured interval after dialing.
 	DisconnectStale = &Disconnect{
 		Code:   3502,
 		Reason: "stale",
 	}
-	// DisconnectForceNoReconnect sent when server disconnects connection
+	// DisconnectForceNoReconnect issued when server disconnects connection
 	// and asks it to not reconnect again.
 	DisconnectForceNoReconnect = &Disconnect{
 		Code:   3503,
 		Reason: "force disconnect",
 	}
-	// DisconnectConnectionLimit can be sent when client connection exceeds a
+	// DisconnectConnectionLimit can be issued when client connection exceeds a
 	// configured connection limit (per user ID or due to other rule).
 	DisconnectConnectionLimit = &Disconnect{
 		Code:   3504,
 		Reason: "connection limit",
 	}
-	// DisconnectChannelLimit can be sent when client connection exceeds a
+	// DisconnectChannelLimit can be issued when client connection exceeds a
 	// configured channel limit.
 	DisconnectChannelLimit = &Disconnect{
 		Code:   3505,

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/FZambia/eagle v0.0.1
 	github.com/FZambia/sentinel v1.1.0
-	github.com/centrifugal/protocol v0.8.1
+	github.com/centrifugal/protocol v0.8.2
 	github.com/gomodule/redigo v1.8.5
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.4.2

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/FZambia/eagle v0.0.1
 	github.com/FZambia/sentinel v1.1.0
-	github.com/centrifugal/protocol v0.8.3-0.20220207171307-8a5d230cacfc
+	github.com/centrifugal/protocol v0.8.3
 	github.com/gomodule/redigo v1.8.5
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.4.2

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/FZambia/eagle v0.0.1
 	github.com/FZambia/sentinel v1.1.0
-	github.com/centrifugal/protocol v0.8.2
+	github.com/centrifugal/protocol v0.8.3-0.20220207171307-8a5d230cacfc
 	github.com/gomodule/redigo v1.8.5
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/centrifugal/protocol v0.8.1 h1:XvcdqgC7cFM+wovmmAN2XMeK5HiTftKl+7Y0ZoJ50FE=
-github.com/centrifugal/protocol v0.8.1/go.mod h1:cJo0/BuXglhPfg0fgSgTXvBZ7y+9rdg4+nPbIDOVmlA=
+github.com/centrifugal/protocol v0.8.2 h1:5dXWRPklLhwWJV2VkPpN2oR57OHLd2LBaI7gfDBJNuo=
+github.com/centrifugal/protocol v0.8.2/go.mod h1:cJo0/BuXglhPfg0fgSgTXvBZ7y+9rdg4+nPbIDOVmlA=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/centrifugal/protocol v0.8.2 h1:5dXWRPklLhwWJV2VkPpN2oR57OHLd2LBaI7gfDBJNuo=
-github.com/centrifugal/protocol v0.8.2/go.mod h1:cJo0/BuXglhPfg0fgSgTXvBZ7y+9rdg4+nPbIDOVmlA=
+github.com/centrifugal/protocol v0.8.3-0.20220207171307-8a5d230cacfc h1:1Wtxm7jxxf+DpdeVbBPyd2/PoS0xAa93B6RXlFVMObw=
+github.com/centrifugal/protocol v0.8.3-0.20220207171307-8a5d230cacfc/go.mod h1:cJo0/BuXglhPfg0fgSgTXvBZ7y+9rdg4+nPbIDOVmlA=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/centrifugal/protocol v0.8.3-0.20220207171307-8a5d230cacfc h1:1Wtxm7jxxf+DpdeVbBPyd2/PoS0xAa93B6RXlFVMObw=
-github.com/centrifugal/protocol v0.8.3-0.20220207171307-8a5d230cacfc/go.mod h1:cJo0/BuXglhPfg0fgSgTXvBZ7y+9rdg4+nPbIDOVmlA=
+github.com/centrifugal/protocol v0.8.3 h1:0Xg8kbNp3LHOJZaIRsbyjriX6e4/AiCPSbUSHmpp7Zc=
+github.com/centrifugal/protocol v0.8.3/go.mod h1:cJo0/BuXglhPfg0fgSgTXvBZ7y+9rdg4+nPbIDOVmlA=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/handler_sockjs.go
+++ b/handler_sockjs.go
@@ -56,12 +56,15 @@ type SockjsConfig struct {
 	WebsocketWriteTimeout time.Duration
 
 	// AppLevelPingInterval tells how often to issue application-level server-to-client pings.
-	// For zero value 25 secs will be used. To disable sending app-level pings in ProtocolVersion2
-	// use -1.
+	// AppLevelPingInterval is only used for clients with ProtocolVersion2.
+	// AppLevelPingInterval is EXPERIMENTAL and is a subject to change.
+	// For zero value 25 secs will be used. To disable app-level pings use -1.
 	AppLevelPingInterval time.Duration
-	// AppLevelPongTimeout sets time for application-level pong check after issuing ping.
-	// AppLevelPongTimeout must be less than AppLevelPingInterval. For zero value 10 secs
-	// will be used. To disable pong checks use -1.
+	// AppLevelPongTimeout sets time for application-level pong check after issuing
+	// ping. AppLevelPongTimeout must be less than AppLevelPingInterval.
+	// AppLevelPongTimeout is only used for clients with ProtocolVersion2.
+	// AppLevelPongTimeout is EXPERIMENTAL and is a subject to change.
+	// For zero value AppLevelPingInterval / 3 will be used. To disable pong checks use -1.
 	AppLevelPongTimeout time.Duration
 }
 
@@ -195,7 +198,7 @@ func (s *SockjsHandler) handleSession(protoVersion ProtocolVersion, sess sockjs.
 		if pongTimeout < 0 {
 			pongTimeout = 0
 		} else if pongTimeout == 0 {
-			pongTimeout = 10 * time.Second
+			pongTimeout = pingInterval / 3
 		}
 	}
 

--- a/handler_sockjs_test.go
+++ b/handler_sockjs_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/centrifugal/protocol"
-
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 )
@@ -236,22 +235,10 @@ func TestSockjsHandlerURLParams(t *testing.T) {
 	url := "ws" + server.URL[4:]
 
 	// Connect with invalid protocol version.
-	conn, resp, err := websocket.DefaultDialer.Dial(url+"/connection/sockjs/220/fi0988475/websocket?cf_protocol_version=v3", nil)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
-	require.NotNil(t, conn)
-	defer func() { _ = conn.Close() }()
-	_, msg, err := conn.ReadMessage()
-	require.NoError(t, err)
-	require.Equal(t, "o", string(msg))
-	_, msg, err = conn.ReadMessage()
-	require.NoError(t, err)
-	require.Equal(t, "c[3501,\"bad request\"]", string(msg))
-	_, _, err = conn.ReadMessage()
+	_, _, err := websocket.DefaultDialer.Dial(url+"/connection/sockjs/220/fi0988475/websocket?cf_protocol_version=v3", nil)
 	require.Error(t, err)
 
-	conn, resp, err = websocket.DefaultDialer.Dial(url+"/connection/sockjs/220/fi0988475/websocket?cf_protocol_version=v2", nil)
+	conn, resp, err := websocket.DefaultDialer.Dial(url+"/connection/sockjs/220/fi0988475/websocket?cf_protocol_version=v2", nil)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)

--- a/handler_websocket.go
+++ b/handler_websocket.go
@@ -67,7 +67,7 @@ type WebsocketConfig struct {
 	// with ProtocolVersion1.
 	PingInterval time.Duration
 	// PongTimeout sets the time to wait for pong messages from the client.
-	// By default, DefaultWebsocketPongTimeout is used. Only used for clients
+	// By default, PingInterval / 3 is used. Only used for clients
 	// with ProtocolVersion1.
 	PongTimeout time.Duration
 
@@ -171,7 +171,7 @@ func (s *WebsocketHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		pongTimeout  time.Duration
 	)
 
-	appLevelPing := protoVersion >= ProtocolVersion1 && s.config.AppLevelPingInterval >= 0
+	appLevelPing := protoVersion > ProtocolVersion1 && s.config.AppLevelPingInterval >= 0
 
 	if !appLevelPing {
 		pingInterval = s.config.PingInterval
@@ -180,7 +180,7 @@ func (s *WebsocketHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		}
 		pongTimeout = s.config.PongTimeout
 		if pongTimeout == 0 {
-			pongTimeout = 10 * time.Second
+			pongTimeout = pingInterval / 3
 		}
 	} else {
 		pingInterval = s.config.AppLevelPingInterval

--- a/handler_websocket.go
+++ b/handler_websocket.go
@@ -377,8 +377,8 @@ func (t *websocketTransport) DisabledPushFlags() uint64 {
 // AppLevelPing ...
 func (t *websocketTransport) AppLevelPing() AppLevelPing {
 	return AppLevelPing{
-		PingInterval: 25 * time.Second,
-		PongTimeout:  10 * time.Second,
+		PingInterval: t.opts.pingInterval,
+		PongTimeout:  t.opts.pongTimeout,
 	}
 }
 

--- a/hub_test.go
+++ b/hub_test.go
@@ -25,6 +25,8 @@ type testTransport struct {
 	protocolVersion   ProtocolVersion
 	writeErr          error
 	writeErrorContent string
+	pingInterval      time.Duration
+	pongTimeout       time.Duration
 }
 
 func newTestTransport(cancelFn func()) *testTransport {
@@ -34,6 +36,8 @@ func newTestTransport(cancelFn func()) *testTransport {
 		closeCh:         make(chan struct{}),
 		unidirectional:  false,
 		protocolVersion: ProtocolVersion1,
+		pingInterval:    10 * time.Second,
+		pongTimeout:     3 * time.Second,
 	}
 }
 
@@ -51,6 +55,11 @@ func (t *testTransport) setUnidirectional(uni bool) {
 
 func (t *testTransport) setSink(sink chan []byte) {
 	t.sink = sink
+}
+
+func (t *testTransport) setPing(pingInterval, pongTimeout time.Duration) {
+	t.pingInterval = pingInterval
+	t.pongTimeout = pongTimeout
 }
 
 func (t *testTransport) Write(message []byte) error {
@@ -116,8 +125,8 @@ func (t *testTransport) DisabledPushFlags() uint64 {
 
 func (t *testTransport) AppLevelPing() AppLevelPing {
 	return AppLevelPing{
-		PingInterval: 10 * time.Second,
-		PongTimeout:  4 * time.Second,
+		PingInterval: t.pingInterval,
+		PongTimeout:  t.pongTimeout,
 	}
 }
 

--- a/hub_test.go
+++ b/hub_test.go
@@ -114,6 +114,13 @@ func (t *testTransport) DisabledPushFlags() uint64 {
 	return PushFlagDisconnect
 }
 
+func (t *testTransport) AppLevelPing() AppLevelPing {
+	return AppLevelPing{
+		PingInterval: 10 * time.Second,
+		PongTimeout:  4 * time.Second,
+	}
+}
+
 func (t *testTransport) Close(disconnect *Disconnect) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/node.go
+++ b/node.go
@@ -88,6 +88,31 @@ const (
 
 // New creates Node with provided Config.
 func New(c Config) (*Node, error) {
+	if c.NodeInfoMetricsAggregateInterval == 0 {
+		c.NodeInfoMetricsAggregateInterval = 60 * time.Second
+	}
+	if c.ClientPresenceUpdateInterval == 0 {
+		c.ClientPresenceUpdateInterval = 27 * time.Second
+	}
+	if c.ClientExpiredCloseDelay == 0 {
+		c.ClientExpiredCloseDelay = 25 * time.Second
+	}
+	if c.ClientExpiredSubCloseDelay == 0 {
+		c.ClientExpiredSubCloseDelay = 25 * time.Second
+	}
+	if c.ClientStaleCloseDelay == 0 {
+		c.ClientStaleCloseDelay = 25 * time.Second
+	}
+	if c.ClientQueueMaxSize == 0 {
+		c.ClientQueueMaxSize = 1048576 // 1MB by default.
+	}
+	if c.ClientChannelLimit == 0 {
+		c.ClientChannelLimit = 128
+	}
+	if c.ChannelMaxLength == 0 {
+		c.ChannelMaxLength = 255
+	}
+
 	uid := uuid.Must(uuid.NewRandom()).String()
 
 	subLocks := make(map[int]*sync.Mutex, numSubLocks)

--- a/options.go
+++ b/options.go
@@ -40,7 +40,7 @@ type SubscribeOptions struct {
 	JoinLeave bool
 	// When position is on client will additionally sync its position inside
 	// a stream to prevent message loss. Make sure you are enabling Position in channels
-	// that maintain Publication history stream. When Position is on  Centrifuge will
+	// that maintain Publication history stream. When Position is on Centrifuge will
 	// include StreamPosition information to subscribe response - for a client to be able
 	// to manually track its position inside a stream.
 	Position bool

--- a/presence_memory_test.go
+++ b/presence_memory_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func testMemoryPresenceManager() *MemoryPresenceManager {
-	conf := DefaultConfig
-	conf.LogLevel = LogLevelDebug
-	conf.LogHandler = func(entry LogEntry) {}
-	n, _ := New(conf)
+	n, _ := New(Config{
+		LogLevel:   LogLevelDebug,
+		LogHandler: func(entry LogEntry) {},
+	})
 	m, _ := NewMemoryPresenceManager(n, MemoryPresenceManagerConfig{})
 	return m
 }

--- a/transport.go
+++ b/transport.go
@@ -92,13 +92,11 @@ type Transport interface {
 	TransportInfo
 	// Write should write single push data into a connection. Every byte slice
 	// here is a single Reply (or Push for unidirectional transport) encoded
-	// according transport ProtocolType. For ProtocolVersion2 this can also
-	// be an empty slice which describes an application-level ping message.
+	// according transport ProtocolType.
 	Write([]byte) error
 	// WriteMany should write data into a connection. Every byte slice here is a
 	// single Reply (or Push for unidirectional transport) encoded according
-	// transport ProtocolType. For ProtocolVersion2 this can also be an empty
-	// slice which describes an application-level ping message.
+	// transport ProtocolType.
 	// The reason why we have both Write and WriteMany here is to have a path
 	// without extra allocations for massive broadcasts (since variadic args cause
 	// allocation).


### PR DESCRIPTION
This pull request introduces application-level ping. Currently:

* for WebSocket we send pings from server to client and from client to server to detect broken connections.
* for SockJS we send SockJS heartbeats without pong from client.

With application-level ping we will be able to only send pings from server to client. Bidirectional client should respond with pong. Ping and pong are just empty Replies in this case.

Server --- PING (`{}`) --> CLIENT --- OPTIONAL PONG (`{}`) ---> Server.

So both WebSocket and SockJS will work in similar way. Client receives server ping seconds in connect result (`ping` field) and can set a timer to detect broken connection if no ping received from a server in configured timeout/delay.

This should have a positive effect on the server CPU resource utilization for WebSocket transport since we eliminate pings from client to server thus reducing number of messages travelling. On local 20k idle clients I observed ~30% CPU drop using new ping mechanics.

New mechanics used only for ProtocolVersion2.

For unidirectional transports app-level pings will allow using same unified format for all pings throughout different transports, fix `websocat` problems (don't like empty non-JSON strings).

This pr also refactors Config and deprecates using `DefaultConfig`.