### PR TITLE
Add nodeRegistry.size()

### DIFF
--- a/node.go
+++ b/node.go
@@ -299,7 +299,7 @@ func (n *Node) updateGauges() {
 	setNumUsers(float64(n.hub.NumUsers()))
 	setNumSubscriptions(float64(n.hub.NumSubscriptions()))
 	setNumChannels(float64(n.hub.NumChannels()))
-	setNumNodes(float64(len(n.nodes.list())))
+	setNumNodes(float64(n.nodes.size()))
 	version := n.config.Version
 	if version == "" {
 		version = "_"
@@ -482,7 +482,7 @@ func (n *Node) Survey(ctx context.Context, op string, data []byte, toNodeID stri
 	if toNodeID != "" {
 		numNodes = 1
 	} else {
-		numNodes = len(n.nodes.list())
+		numNodes = n.nodes.size()
 	}
 
 	n.surveyMu.Lock()
@@ -1421,6 +1421,13 @@ func (r *nodeRegistry) list() []*controlpb.Node {
 	}
 	r.mu.RUnlock()
 	return nodes
+}
+
+func (r *nodeRegistry) size() int {
+	r.mu.RLock()
+	size := len(r.nodes)
+	r.mu.RUnlock()
+	return size
 }
 
 func (r *nodeRegistry) get(uid string) (*controlpb.Node, bool) {

--- a/node_test.go
+++ b/node_test.go
@@ -248,6 +248,7 @@ func TestNode_shutdownCmd(t *testing.T) {
 	n := defaultNodeNoHandlers()
 	require.NoError(t, n.shutdownCmd(n.ID()))
 	require.True(t, len(n.nodes.list()) == 0)
+	require.True(t, n.nodes.size() == 0)
 }
 
 func TestClientEventHub(t *testing.T) {
@@ -265,6 +266,7 @@ func TestNodeRegistry(t *testing.T) {
 	registry.add(&nodeInfo1) // Make sure update works.
 	registry.add(&nodeInfo2)
 	require.Equal(t, 2, len(registry.list()))
+	require.Equal(t, 2, registry.size())
 	info, ok := registry.get("node1")
 	require.True(t, ok)
 	require.Equal(t, "node1", info.Uid)
@@ -273,6 +275,7 @@ func TestNodeRegistry(t *testing.T) {
 	registry.clean(time.Second)
 	// Current node info should still be in node registry - we never delete it.
 	require.Equal(t, 1, len(registry.list()))
+	require.Equal(t, 1, registry.size())
 }
 
 func TestNodeLogHandler(t *testing.T) {


### PR DESCRIPTION
`nodeRegistry.size()` returns the size of the registry, replaced two `len(nodeRegistry.nodes())` with `nodeRegistry.nodes()` to improve performance.