### PR TITLE
Close Redis Broker and PresenceManager on Node shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,3 +269,20 @@ cfg := centrifuge.DefaultConfig
 cfg.LogLevel = centrifuge.LogLevelDebug
 cfg.LogHandler = handleLog
 ```
+
+### For contributors
+
+#### Running integration tests locally
+
+To run integration tests over Redis, Redis + Sentinel, Redis Cluster:
+
+```
+docker compose up
+go test -tags integration ./...
+```
+
+To clean up container state:
+
+```
+docker compose down -v
+```

--- a/broker_redis.go
+++ b/broker_redis.go
@@ -318,7 +318,11 @@ func (b *RedisBroker) Run(h BrokerEventHandler) error {
 func (b *RedisBroker) Close(_ context.Context) error {
 	b.closeOnce.Do(func() {
 		close(b.closeCh)
+		for _, s := range b.shards {
+			_ = s.pool.Close()
+		}
 	})
+
 	return nil
 }
 

--- a/broker_redis.go
+++ b/broker_redis.go
@@ -769,15 +769,10 @@ func (b *RedisBroker) runPubSub(s *RedisShard, eventHandler BrokerEventHandler) 
 		}(workerCh)
 	}
 
-	err := conn.Subscribe(b.pingChannel)
-	if err != nil {
-		b.node.Log(NewLogEntry(LogLevelError, "control channel subscribe error", map[string]interface{}{"error": err.Error()}))
-		return
-	}
-
 	go func() {
 		channels := b.node.Hub().Channels()
-		chIDs := make([]channelID, 0, len(channels)/len(b.shards))
+		chIDs := make([]channelID, 0, len(channels)/len(b.shards)+1)
+		chIDs = append(chIDs, channelID(b.pingChannel))
 		for _, ch := range channels {
 			if b.getShard(ch) == s {
 				chIDs = append(chIDs, b.messageChannelID(ch))

--- a/broker_redis.go
+++ b/broker_redis.go
@@ -1020,7 +1020,6 @@ func (b *RedisBroker) runPubSubPing(s *RedisShard) {
 		case <-b.closeCh:
 			return
 		case <-pingTicker.C:
-			<-pingTicker.C
 			// Publish periodically to maintain PUB/SUB connection alive and allow
 			// PUB/SUB connection to close early if no data received for a period of time.
 			conn := s.pool.Get()

--- a/broker_redis.go
+++ b/broker_redis.go
@@ -318,9 +318,6 @@ func (b *RedisBroker) Run(h BrokerEventHandler) error {
 func (b *RedisBroker) Close(_ context.Context) error {
 	b.closeOnce.Do(func() {
 		close(b.closeCh)
-		for _, s := range b.shards {
-			s.close()
-		}
 	})
 	return nil
 }

--- a/broker_redis_test.go
+++ b/broker_redis_test.go
@@ -930,6 +930,8 @@ func BenchmarkRedisSurvey(b *testing.B) {
 			redisConf := testRedisConf()
 			data := make([]byte, tt.DataSize)
 
+			var nodes []*Node
+
 			for i := 0; i < tt.NumOtherNodes; i++ {
 				node, _ := New(Config{})
 				s, err := NewRedisShard(node, redisConf)
@@ -942,6 +944,7 @@ func BenchmarkRedisSurvey(b *testing.B) {
 				})
 				node.SetBroker(broker)
 				_ = node.Run()
+				nodes = append(nodes, node)
 
 				node.OnSurvey(func(event SurveyEvent, callback SurveyCallback) {
 					callback(SurveyReply{
@@ -962,6 +965,7 @@ func BenchmarkRedisSurvey(b *testing.B) {
 			})
 			node.SetBroker(broker)
 			_ = node.Run()
+			nodes = append(nodes, node)
 
 			node.OnSurvey(func(event SurveyEvent, callback SurveyCallback) {
 				callback(SurveyReply{
@@ -982,6 +986,9 @@ func BenchmarkRedisSurvey(b *testing.B) {
 				}
 			})
 			b.StopTimer()
+			for _, n := range nodes {
+				_ = n.Shutdown(context.Background())
+			}
 		})
 	}
 }

--- a/broker_redis_test.go
+++ b/broker_redis_test.go
@@ -159,6 +159,7 @@ func TestRedisBroker(t *testing.T) {
 	for _, tt := range redisTests {
 		t.Run(tt.Name, func(t *testing.T) {
 			node := testNode(t)
+
 			e := newTestRedisBroker(t, node, tt.UseStreams, tt.UseCluster)
 			defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -342,7 +343,7 @@ func TestRedisBrokerSubscribeUnsubscribe(t *testing.T) {
 		// Redis PUBSUB CHANNELS command looks like eventual consistent, so sometimes
 		// it returns wrong results, sleeping for a while helps in such situations.
 		// See https://gist.github.com/FZambia/80a5241e06b4662f7fe89cfaf24072c3
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(2000 * time.Millisecond)
 		channels, err := pubSubChannels(t, e)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(channels), fmt.Sprintf("%#v", channels))
@@ -352,7 +353,7 @@ func TestRedisBrokerSubscribeUnsubscribe(t *testing.T) {
 	channels, err = pubSubChannels(t, e)
 	require.NoError(t, err)
 	if len(channels) != 0 {
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(2000 * time.Millisecond)
 		channels, _ := pubSubChannels(t, e)
 		require.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
 	}
@@ -373,7 +374,7 @@ func TestRedisBrokerSubscribeUnsubscribe(t *testing.T) {
 	require.NoError(t, err)
 
 	if len(channels) != 0 {
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(2000 * time.Millisecond)
 		channels, _ := pubSubChannels(t, e)
 		require.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
 	}
@@ -391,7 +392,7 @@ func TestRedisBrokerSubscribeUnsubscribe(t *testing.T) {
 	channels, err = pubSubChannels(t, e)
 	require.Equal(t, nil, err)
 	if len(channels) != 0 {
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(2000 * time.Millisecond)
 		channels, err := pubSubChannels(t, e)
 		require.NoError(t, err)
 		require.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
@@ -405,7 +406,7 @@ func TestRedisBrokerSubscribeUnsubscribe(t *testing.T) {
 	channels, err = pubSubChannels(t, e)
 	require.NoError(t, err)
 	if len(channels) != 0 {
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(2000 * time.Millisecond)
 		channels, _ := pubSubChannels(t, e)
 		require.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
 	}
@@ -419,7 +420,7 @@ func TestRedisBrokerSubscribeUnsubscribe(t *testing.T) {
 		channels, err = pubSubChannels(t, e)
 		require.NoError(t, err)
 		if len(channels) != 0 {
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(2000 * time.Millisecond)
 			channels, err := pubSubChannels(t, e)
 			require.NoError(t, err)
 			require.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
@@ -438,7 +439,7 @@ func TestRedisBrokerSubscribeUnsubscribe(t *testing.T) {
 	channels, err = pubSubChannels(t, e)
 	require.NoError(t, err)
 	if len(channels) != 100 {
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(2000 * time.Millisecond)
 		channels, err := pubSubChannels(t, e)
 		require.NoError(t, err)
 		require.Equal(t, 100, len(channels), fmt.Sprintf("%#v", channels))
@@ -456,7 +457,7 @@ func TestRedisBrokerSubscribeUnsubscribe(t *testing.T) {
 	channels, err = pubSubChannels(t, e)
 	require.NoError(t, err)
 	if len(channels) != 0 {
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(2000 * time.Millisecond)
 		channels, _ := pubSubChannels(t, e)
 		require.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
 	}
@@ -480,7 +481,7 @@ func TestRedisBrokerSubscribeUnsubscribe(t *testing.T) {
 	channels, err = pubSubChannels(t, e)
 	require.NoError(t, err)
 	if len(channels) != 0 {
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(2000 * time.Millisecond)
 		channels, err := pubSubChannels(t, e)
 		require.NoError(t, err)
 		require.Equal(t, 0, len(channels), fmt.Sprintf("%#v", channels))
@@ -1262,7 +1263,7 @@ func TestRedisHistoryIteration(t *testing.T) {
 			node := testNode(t)
 			e := newTestRedisBroker(t, node, tt.UseStreams, tt.UseCluster)
 			defer func() { _ = node.Shutdown(context.Background()) }()
-			it := historyIterationTest{10000, 100}
+			it := historyIterationTest{100, 5}
 			startPosition := it.prepareHistoryIteration(t, e.node)
 			it.testHistoryIteration(t, e.node, startPosition)
 		})
@@ -1278,7 +1279,7 @@ func TestRedisHistoryIterationReverse(t *testing.T) {
 			node := testNode(t)
 			e := newTestRedisBroker(t, node, tt.UseStreams, tt.UseCluster)
 			defer func() { _ = node.Shutdown(context.Background()) }()
-			it := historyIterationTest{10000, 100}
+			it := historyIterationTest{100, 5}
 			startPosition := it.prepareHistoryIteration(t, e.node)
 			it.testHistoryIterationReverse(t, e.node, startPosition)
 		})

--- a/client.go
+++ b/client.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"sync"
 	"time"
 
 	"github.com/centrifugal/centrifuge/internal/queue"
 	"github.com/centrifugal/centrifuge/internal/recovery"
+	"github.com/centrifugal/centrifuge/internal/saferand"
 
 	"github.com/centrifugal/protocol"
 	"github.com/google/uuid"
@@ -22,12 +22,12 @@ var protobufPingReply []byte
 var jsonPingPush = []byte(`{}`)
 var protobufPingPush []byte
 
-var randSource *rand.Rand
+var randSource *saferand.Rand
 
 func init() {
 	protobufPingReply, _ = protocol.DefaultProtobufReplyEncoder.Encode(&protocol.Reply{})
 	protobufPingPush, _ = protocol.DefaultProtobufPushEncoder.Encode(&protocol.Push{})
-	randSource = rand.New(rand.NewSource(time.Now().UnixNano()))
+	randSource = saferand.New(time.Now().UnixNano())
 }
 
 // clientEventHub allows dealing with client event handlers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.8"
+
+services:
+  redis:
+    image: redis:7.0.2-alpine
+    ports:
+      - "6379:6379"
+  sentinel:
+    image: redis:7.0.2-alpine
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        redis-server --save "" --appendonly no --port 6380 &
+        echo "sentinel monitor mymaster 127.0.0.1 6380 2\n" > sentinel.conf
+        redis-server sentinel.conf --sentinel
+    ports:
+      - "6380:6380"
+      - "26379:26379"
+  cluster:
+    image: redis:7.0.2-alpine
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        redis-server --port 7000 --save "" --appendonly no --cluster-enabled yes --cluster-config-file 7000.conf &
+        redis-server --port 7001 --save "" --appendonly no --cluster-enabled yes --cluster-config-file 7001.conf &
+        redis-server --port 7002 --save "" --appendonly no --cluster-enabled yes --cluster-config-file 7002.conf &
+        while ! redis-cli --cluster create 127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 --cluster-yes; do sleep 1; done
+        wait
+    ports:
+      - "7000:7000"
+      - "7001:7001"
+      - "7002:7002"

--- a/internal/memstream/stream.go
+++ b/internal/memstream/stream.go
@@ -2,11 +2,12 @@ package memstream
 
 import (
 	"container/list"
-	"math/rand"
 	"time"
+
+	"github.com/centrifugal/centrifuge/internal/saferand"
 )
 
-var random = rand.New(rand.NewSource(time.Now().UnixNano()))
+var random = saferand.New(time.Now().UnixNano())
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 

--- a/internal/saferand/rand.go
+++ b/internal/saferand/rand.go
@@ -1,0 +1,34 @@
+package saferand
+
+import (
+	"math/rand"
+	"sync"
+)
+
+// Rand is a concurrency-safe source of pseudo-random numbers. The Go
+// stdlib's math/rand.Source is not concurrency-safe. The global source in
+// math/rand would be concurrency safe (due to its internal use of
+// lockedSource), but it is prone to inter-package interference with the PRNG
+// state.
+type Rand struct {
+	mu sync.Mutex
+	r  *rand.Rand
+}
+
+func New(seed int64) *Rand {
+	return &Rand{r: rand.New(rand.NewSource(seed))}
+}
+
+func (sr *Rand) Int63n(n int64) int64 {
+	sr.mu.Lock()
+	v := sr.r.Int63n(n)
+	sr.mu.Unlock()
+	return v
+}
+
+func (sr *Rand) Intn(n int) int {
+	sr.mu.Lock()
+	v := sr.r.Intn(n)
+	sr.mu.Unlock()
+	return v
+}

--- a/internal/saferand/rand_test.go
+++ b/internal/saferand/rand_test.go
@@ -1,0 +1,18 @@
+package saferand
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRand_Int63n(t *testing.T) {
+	r := New(time.Now().Unix())
+	require.True(t, r.Int63n(200)+1 > 0)
+}
+
+func TestRand_Intn(t *testing.T) {
+	r := New(time.Now().Unix())
+	require.True(t, r.Intn(200)+1 > 0)
+}

--- a/presence_redis.go
+++ b/presence_redis.go
@@ -132,9 +132,6 @@ func NewRedisPresenceManager(n *Node, config RedisPresenceManagerConfig) (*Redis
 func (m *RedisPresenceManager) Close(_ context.Context) error {
 	m.closeOnce.Do(func() {
 		close(m.closeCh)
-		for _, s := range m.shards {
-			s.close()
-		}
 	})
 	return nil
 }

--- a/presence_redis.go
+++ b/presence_redis.go
@@ -1,6 +1,7 @@
 package centrifuge
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -122,6 +123,13 @@ func NewRedisPresenceManager(n *Node, config RedisPresenceManagerConfig) (*Redis
 	}
 
 	return m, nil
+}
+
+func (m *RedisPresenceManager) Close(_ context.Context) error {
+	for _, s := range m.shards {
+		s.close()
+	}
+	return nil
 }
 
 func (m *RedisPresenceManager) getShard(channel string) *RedisShard {

--- a/redis_shard.go
+++ b/redis_shard.go
@@ -230,7 +230,7 @@ type dataRequest struct {
 	clusterKey string
 }
 
-func (s *RedisShard) close() {
+func (s *RedisShard) Close() {
 	s.closeOnce.Do(func() {
 		close(s.closeCh)
 		_ = s.pool.Close()

--- a/redis_shard.go
+++ b/redis_shard.go
@@ -24,8 +24,8 @@ type (
 	channelID string
 )
 
-var errRedisOpTimeout = errors.New("operation timed out")
-var errRedisClosed = errors.New("closed")
+var errRedisOpTimeout = errors.New("redis: operation timed out")
+var errRedisClosed = errors.New("redis: closed")
 
 const (
 	DefaultRedisReadTimeout    = time.Second

--- a/redis_shard.go
+++ b/redis_shard.go
@@ -40,6 +40,7 @@ const (
 
 type redisConnPool interface {
 	Get() redis.Conn
+	Close() error
 }
 
 type RedisShard struct {


### PR DESCRIPTION
This closes all the running goroutines of Redis Broker on Node Shutdown. This should also fix our Survey tests when those are launched with count > 1. 