### PR TITLE
Fix some data races

### DIFF
--- a/node.go
+++ b/node.go
@@ -1440,18 +1440,20 @@ func (r *nodeRegistry) get(uid string) (*controlpb.Node, bool) {
 func (r *nodeRegistry) add(info *controlpb.Node) bool {
 	var isNewNode bool
 	r.mu.Lock()
-	if node, ok := r.nodes[info.Uid]; ok {
+	if _, ok := r.nodes[info.Uid]; ok {
 		if info.Metrics != nil {
 			r.nodes[info.Uid] = info
 		} else {
-			node.Version = info.Version
-			node.NumChannels = info.NumChannels
-			node.NumClients = info.NumClients
-			node.NumUsers = info.NumUsers
-			node.NumSubs = info.NumSubs
-			node.Uptime = info.Uptime
-			node.Data = info.Data
-			r.nodes[info.Uid] = node
+			r.nodes[info.Uid] = &controlpb.Node{
+				Uid: info.Uid,
+				Version: info.Version,
+				NumChannels: info.NumChannels,
+				NumClients: info.NumClients,
+				NumUsers: info.NumUsers,
+				NumSubs: info.NumSubs,
+				Uptime: info.Uptime,
+				Data: info.Data,
+			}
 		}
 	} else {
 		r.nodes[info.Uid] = info

--- a/node.go
+++ b/node.go
@@ -1440,19 +1440,21 @@ func (r *nodeRegistry) get(uid string) (*controlpb.Node, bool) {
 func (r *nodeRegistry) add(info *controlpb.Node) bool {
 	var isNewNode bool
 	r.mu.Lock()
-	if _, ok := r.nodes[info.Uid]; ok {
+	if node, ok := r.nodes[info.Uid]; ok {
 		if info.Metrics != nil {
 			r.nodes[info.Uid] = info
 		} else {
 			r.nodes[info.Uid] = &controlpb.Node{
 				Uid: info.Uid,
+				Name: info.Name,
 				Version: info.Version,
-				NumChannels: info.NumChannels,
 				NumClients: info.NumClients,
 				NumUsers: info.NumUsers,
-				NumSubs: info.NumSubs,
+				NumChannels: info.NumChannels,
 				Uptime: info.Uptime,
 				Data: info.Data,
+				NumSubs: info.NumSubs,
+				Metrics: node.Metrics,
 			}
 		}
 	} else {

--- a/presence_redis_test.go
+++ b/presence_redis_test.go
@@ -5,6 +5,7 @@ package centrifuge
 import (
 	"context"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -137,12 +138,12 @@ func BenchmarkRedisPresence_ManyCh(b *testing.B) {
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	b.SetParallelism(128)
 	_ = e.AddPresence("channel", "uid", &ClientInfo{})
-	j := 0
+	j := int32(0)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			j++
-			channel := "channel" + strconv.Itoa(j%benchmarkNumDifferentChannels)
+			jj := atomic.AddInt32(&j, 1)
+			channel := "channel" + strconv.Itoa(int(jj)%benchmarkNumDifferentChannels)
 			_, err := e.Presence(channel)
 			if err != nil {
 				b.Fatal(err)


### PR DESCRIPTION
Found by running benchmark with race detector enabled:
```
==================
WARNING: DATA RACE
Write at 0x00c001358678 by goroutine 2940:
  github.com/centrifugal/centrifuge.(*nodeRegistry).add()
      /home/runner/work/centrifuge/centrifuge/node.go:1447 +0x23d
  github.com/centrifugal/centrifuge.(*Node).nodeCmd()
      /home/runner/work/centrifuge/centrifuge/node.go:1071 +0x65
  github.com/centrifugal/centrifuge.(*Node).pubNode()
      /home/runner/work/centrifuge/centrifuge/node.go:907 +0x892
  github.com/centrifugal/centrifuge.(*Node).nodeCmd()
      /home/runner/work/centrifuge/centrifuge/node.go:1074 +0x10f
  github.com/centrifugal/centrifuge.(*Node).handleControl()
      /home/runner/work/centrifuge/centrifuge/node.go:653 +0x992
  github.com/centrifugal/centrifuge.(*brokerEventHandler).HandleControl()
      /home/runner/work/centrifuge/centrifuge/node.go:1568 +0x6e
  github.com/centrifugal/centrifuge.(*RedisBroker).runControlPubSub.func4()
      /home/runner/work/centrifuge/centrifuge/broker_redis.go:916 +0x216

Previous read at 0x00c001358678 by goroutine 1866:
  github.com/centrifugal/centrifuge.(*Node).Info()
      /home/runner/work/centrifuge/centrifuge/node.go:604 +0x172
  github.com/centrifugal/centrifuge.waitAllNodes()
      /home/runner/work/centrifuge/centrifuge/broker_redis_test.go:893 +0x66
  github.com/centrifugal/centrifuge.BenchmarkRedisSurvey.func1()
      /home/runner/work/centrifuge/centrifuge/broker_redis_test.go:978 +0xb64
  testing.(*B).runN()
      /opt/hostedtoolcache/go/1.17.12/x64/src/testing/benchmark.go:192 +0x1e1
  testing.(*B).run1.func1()
      /opt/hostedtoolcache/go/1.17.12/x64/src/testing/benchmark.go:232 +0x78

Goroutine 2940 (running) created at:
  github.com/centrifugal/centrifuge.(*RedisBroker).runControlPubSub()
      /home/runner/work/centrifuge/centrifuge/broker_redis.go:906 +0x684
  github.com/centrifugal/centrifuge.(*RedisBroker).runShard.func4()
      /home/runner/work/centrifuge/centrifuge/broker_redis.go:375 +0x6e
  github.com/centrifugal/centrifuge.(*RedisBroker).runForever()
      /home/runner/work/centrifuge/centrifuge/broker_redis.go:338 +0xe2
  github.com/centrifugal/centrifuge.(*RedisBroker).runShard·dwrap·10()
      /home/runner/work/centrifuge/centrifuge/broker_redis.go:374 +0x47

Goroutine 1866 (running) created at:
  testing.(*B).run1()
      /opt/hostedtoolcache/go/1.17.12/x64/src/testing/benchmark.go:225 +0x173
  testing.(*B).Run()
      /opt/hostedtoolcache/go/1.17.12/x64/src/testing/benchmark.go:670 +0x82b
  github.com/centrifugal/centrifuge.BenchmarkRedisSurvey()
      /home/runner/work/centrifuge/centrifuge/broker_redis_test.go:[929](https://github.com/j178/centrifuge/runs/7702777745?check_suite_focus=true#step:5:930) +0x18f
  testing.(*B).runN()
      /opt/hostedtoolcache/go/1.17.12/x64/src/testing/benchmark.go:192 +0x1e1
  testing.(*B).run1.func1()
      /opt/hostedtoolcache/go/1.17.12/x64/src/testing/benchmark.go:232 +0x78
==================

==================
WARNING: DATA RACE
Read at 0x00c00186e948 by goroutine 2800:
  github.com/centrifugal/centrifuge.BenchmarkRedisSubscribe.func2()
      /home/runner/work/centrifuge/centrifuge/broker_redis_test.go:1116 +0x64
  testing.(*B).RunParallel.func1()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/benchmark.go:788 +0x1ad

Previous write at 0x00c00186e948 by goroutine 2958:
  github.com/centrifugal/centrifuge.BenchmarkRedisSubscribe.func2()
      /home/runner/work/centrifuge/centrifuge/broker_redis_test.go:1116 +0x76
  testing.(*B).RunParallel.func1()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/benchmark.go:788 +0x1ad

Goroutine 2800 (running) created at:
  testing.(*B).RunParallel()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/benchmark.go:781 +0x299
  github.com/centrifugal/centrifuge.BenchmarkRedisSubscribe()
      /home/runner/work/centrifuge/centrifuge/broker_redis_test.go:1114 +0x224
  testing.(*B).runN()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/benchmark.go:193 +0x1af
  testing.(*B).launch()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/benchmark.go:334 +0x335
  testing.(*B).doBench.func1()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/benchmark.go:284 +0x39

Goroutine 2958 (running) created at:
  testing.(*B).RunParallel()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/benchmark.go:781 +0x299
  github.com/centrifugal/centrifuge.BenchmarkRedisSubscribe()
      /home/runner/work/centrifuge/centrifuge/broker_redis_test.go:1114 +0x224
  testing.(*B).runN()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/benchmark.go:193 +0x1af
  testing.(*B).launch()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/benchmark.go:334 +0x335
  testing.(*B).doBench.func1()
      /opt/hostedtoolcache/go/1.18.4/x64/src/testing/benchmark.go:284 +0x39
==================
```