### PR TITLE
Fix websocket v1 benchmarks

### DIFF
--- a/handler_websocket_test.go
+++ b/handler_websocket_test.go
@@ -637,6 +637,7 @@ func BenchmarkWsPubSubV1(b *testing.B) {
 	mux.Handle("/connection/websocket", testAuthMiddleware(NewWebsocketHandler(n, WebsocketConfig{
 		WriteBufferSize: 0,
 		ReadBufferSize:  0,
+		ProtocolVersion: ProtocolVersion1,
 	})))
 	server := httptest.NewServer(mux)
 	defer server.Close()
@@ -727,6 +728,7 @@ func BenchmarkWsConnectV1(b *testing.B) {
 
 	mux := http.NewServeMux()
 	mux.Handle("/connection/websocket", testAuthMiddleware(NewWebsocketHandler(n, WebsocketConfig{
+		ProtocolVersion: ProtocolVersion1,
 		WriteBufferSize: 0,
 		ReadBufferSize:  0,
 	})))
@@ -807,6 +809,7 @@ func BenchmarkWsCommandReplyV1(b *testing.B) {
 
 	mux := http.NewServeMux()
 	mux.Handle("/connection/websocket", testAuthMiddleware(NewWebsocketHandler(n, WebsocketConfig{
+		ProtocolVersion: ProtocolVersion1,
 		WriteBufferSize: 0,
 		ReadBufferSize:  0,
 	})))
@@ -889,7 +892,7 @@ func newRealConnJSONConnectV2(b testing.TB, url string) *websocket.Conn {
 	}
 	cmdBytes, _ := json.Marshal(cmd)
 
-	_ = conn.WriteMessage(websocket.TextMessage, cmdBytes)
+	require.NoError(b, conn.WriteMessage(websocket.TextMessage, cmdBytes))
 	_, _, err = conn.ReadMessage()
 	require.NoError(b, err)
 	return conn
@@ -913,7 +916,7 @@ func newRealConnProtobufConnectV2(b testing.TB, url string) *websocket.Conn {
 	buf.Write(bs[:n])
 	buf.Write(cmdBytes)
 
-	_ = conn.WriteMessage(websocket.BinaryMessage, buf.Bytes())
+	require.NoError(b, conn.WriteMessage(websocket.BinaryMessage, buf.Bytes()))
 	_, _, err = conn.ReadMessage()
 	require.NoError(b, err)
 	return conn
@@ -929,7 +932,7 @@ func newRealConnJSONV2(b testing.TB, channel string, url string) *websocket.Conn
 		},
 	}
 	cmdBytes, _ := json.Marshal(cmd)
-	_ = conn.WriteMessage(websocket.TextMessage, cmdBytes)
+	require.NoError(b, conn.WriteMessage(websocket.TextMessage, cmdBytes))
 	_, _, err := conn.ReadMessage()
 	require.NoError(b, err)
 	return conn


### PR DESCRIPTION
We need to set `ProtocolVersion` to `ProtocolVersion1` explicitly, since all handlers are now defaulting to `ProtocolVersion2`. Fix this error when running websocket benchmarks:
```
BenchmarkWsPubSubV1
BenchmarkWsPubSubV1/JSON
    handler_websocket_test.go:695: 
        	Error Trace:	handler_websocket_test.go:695
        	            				handler_websocket_test.go:366
        	            				handler_websocket_test.go:661
        	            				benchmark.go:193
        	            				benchmark.go:233
        	            				asm_amd64.s:1594
        	Error:      	Received unexpected error:
        	            	websocket: close 3502: stale
        	Test:       	BenchmarkWsPubSubV1/JSON
--- FAIL: BenchmarkWsPubSubV1/JSON
BenchmarkWsPubSubV1/PB
    handler_websocket_test.go:723: 
        	Error Trace:	handler_websocket_test.go:723
        	            				handler_websocket_test.go:385
        	            				handler_websocket_test.go:661
        	            				benchmark.go:193
        	            				benchmark.go:233
        	            				asm_amd64.s:1594
        	Error:      	Received unexpected error:
        	            	websocket: close 3502: stale
        	Test:       	BenchmarkWsPubSubV1/PB
--- FAIL: BenchmarkWsPubSubV1/PB
--- FAIL: BenchmarkWsPubSubV1
BenchmarkWsConnectV1
BenchmarkWsConnectV1/JSON
    handler_websocket_test.go:695: 
        	Error Trace:	handler_websocket_test.go:695
        	            				handler_websocket_test.go:756
        	            				benchmark.go:193
        	            				benchmark.go:233
        	            				asm_amd64.s:1594
        	Error:      	Received unexpected error:
        	            	websocket: close 3502: stale
        	Test:       	BenchmarkWsConnectV1/JSON
--- FAIL: BenchmarkWsConnectV1/JSON
BenchmarkWsConnectV1/PB
    handler_websocket_test.go:723: 
        	Error Trace:	handler_websocket_test.go:723
        	            				handler_websocket_test.go:756
        	            				benchmark.go:193
        	            				benchmark.go:233
        	            				asm_amd64.s:1594
        	Error:      	Received unexpected error:
        	            	websocket: close 3502: stale
        	Test:       	BenchmarkWsConnectV1/PB
--- FAIL: BenchmarkWsConnectV1/PB
--- FAIL: BenchmarkWsConnectV1
BenchmarkWsConnectV2
    handler_websocket_test.go:764: 
--- SKIP: BenchmarkWsConnectV2
BenchmarkWsCommandReplyV1
BenchmarkWsCommandReplyV1/JSON
    handler_websocket_test.go:695: 
        	Error Trace:	handler_websocket_test.go:695
        	            				handler_websocket_test.go:864
        	            				benchmark.go:193
        	            				benchmark.go:233
        	            				asm_amd64.s:1594
        	Error:      	Received unexpected error:
        	            	websocket: close 3502: stale
        	Test:       	BenchmarkWsCommandReplyV1/JSON
--- FAIL: BenchmarkWsCommandReplyV1/JSON
BenchmarkWsCommandReplyV1/PB
    handler_websocket_test.go:723: 
        	Error Trace:	handler_websocket_test.go:723
        	            				handler_websocket_test.go:864
        	            				benchmark.go:193
        	            				benchmark.go:233
        	            				asm_amd64.s:1594
        	Error:      	Received unexpected error:
        	            	websocket: close 3502: stale
        	Test:       	BenchmarkWsCommandReplyV1/PB
--- FAIL: BenchmarkWsCommandReplyV1/PB
--- FAIL: BenchmarkWsCommandReplyV1
```