### PR TITLE
Use docker-compose, update test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,39 +17,33 @@ jobs:
           version: v1.45.2
           args: --timeout 3m0s
   build:
-    name: Test with Go ${{ matrix.go-version }}
+    name: Test with Go ${{ matrix.go-version }} Redis ${{ matrix.redis-version }}
     runs-on: ubuntu-latest
     # Prevent duplicate builds on internal PRs.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
-        go-version: [1.17, 1.18]
-        redis-version: [6]
+        go-version: [1.17, 1.18, 1.19]
+        redis-version: [6, 7]
     steps:
       - name: Install Go stable version
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Start single Redis
-        uses: supercharge/redis-github-action@1.1.0
-        with:
-          redis-version: ${{ matrix.redis-version }}
-
-      - name: Start Redis Cluster
-        run: docker run -d -e "IP=0.0.0.0" -p 7000-7006:7000-7006 grokzen/redis-cluster:latest
-
-      - name: Start Redis with Sentinel
-        run: docker run -d -p 26379:26379 joshula/redis-sentinel:latest --sentinel announce-ip 1.2.3.4 --sentinel announce-port 26379
+      - name: Start redis
+        env:
+          REDIS_VERSION: ${{ matrix.redis-version }}
+        run: docker compose up -d --wait
 
       - name: Test
         run: go test -v -race -tags integration -coverprofile=coverage.out $(go list ./... | grep -v /_examples/)
 
       - name: Upload code coverage to codecov
         if: matrix.go-version == '1.18'
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.out

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,11 @@ version: "3.8"
 
 services:
   redis:
-    image: redis:7.0.2-alpine
+    image: redis:${REDIS_VERSION:-7}-alpine
     ports:
       - "6379:6379"
   sentinel:
-    image: redis:7.0.2-alpine
+    image: redis:${REDIS_VERSION:-7}-alpine
     entrypoint:
       - /bin/sh
       - -c
@@ -18,7 +18,7 @@ services:
       - "6380:6380"
       - "26379:26379"
   cluster:
-    image: redis:7.0.2-alpine
+    image: redis:${REDIS_VERSION:-7}-alpine
     entrypoint:
       - /bin/sh
       - -c


### PR DESCRIPTION
## What this PR did
- Add Go 1.19 and Redis 7 to the test matrix
- Use docker-compose to run the redis server
- Update some github-actions