### PR TITLE
Shutdown nodes in tests

### DIFF
--- a/broker_memory_test.go
+++ b/broker_memory_test.go
@@ -34,6 +34,7 @@ func testPublicationData() []byte {
 
 func TestMemoryBrokerPublishHistory(t *testing.T) {
 	e := testMemoryBroker()
+	defer func() { _ = e.node.Shutdown(context.Background()) }()
 
 	require.NotEqual(t, nil, e.historyHub)
 
@@ -90,6 +91,7 @@ func TestMemoryBrokerPublishHistory(t *testing.T) {
 
 func TestMemoryEngineSubscribeUnsubscribe(t *testing.T) {
 	e := testMemoryBroker()
+	defer func() { _ = e.node.Shutdown(context.Background()) }()
 	require.NoError(t, e.Subscribe("channel"))
 	require.NoError(t, e.Unsubscribe("channel"))
 }
@@ -201,6 +203,7 @@ func TestMemoryHistoryHubMetaTTL(t *testing.T) {
 
 func TestMemoryBrokerRecover(t *testing.T) {
 	e := testMemoryBroker()
+	defer func() { _ = e.node.Shutdown(context.Background()) }()
 
 	for i := 0; i < 5; i++ {
 		_, err := e.Publish("channel", testPublicationData(), PublishOptions{HistorySize: 10, HistoryTTL: 2 * time.Second})
@@ -253,6 +256,8 @@ func TestMemoryBrokerRecover(t *testing.T) {
 
 func BenchmarkMemoryPublish_1Ch(b *testing.B) {
 	e := testMemoryBroker()
+	defer func() { _ = e.node.Shutdown(context.Background()) }()
+
 	rawData := protocol.Raw(`{"bench": true}`)
 	b.SetParallelism(128)
 	b.ResetTimer()
@@ -268,6 +273,8 @@ func BenchmarkMemoryPublish_1Ch(b *testing.B) {
 
 func BenchmarkMemoryPublish_History_1Ch(b *testing.B) {
 	e := testMemoryBroker()
+	defer func() { _ = e.node.Shutdown(context.Background()) }()
+
 	rawData := protocol.Raw(`{"bench": true}`)
 	chOpts := PublishOptions{HistorySize: 100, HistoryTTL: 60 * time.Second}
 	b.SetParallelism(128)
@@ -288,6 +295,8 @@ func BenchmarkMemoryPublish_History_1Ch(b *testing.B) {
 
 func BenchmarkMemoryHistory_1Ch(b *testing.B) {
 	e := testMemoryBroker()
+	defer func() { _ = e.node.Shutdown(context.Background()) }()
+
 	rawData := protocol.Raw("{}")
 	for i := 0; i < 4; i++ {
 		_, _ = e.Publish("channel", rawData, PublishOptions{HistorySize: 4, HistoryTTL: 300 * time.Second})
@@ -308,6 +317,8 @@ func BenchmarkMemoryHistory_1Ch(b *testing.B) {
 
 func BenchmarkMemoryRecover_1Ch(b *testing.B) {
 	e := testMemoryBroker()
+	defer func() { _ = e.node.Shutdown(context.Background()) }()
+
 	rawData := protocol.Raw("{}")
 	numMessages := 1000
 	numMissing := 5
@@ -521,6 +532,8 @@ outer:
 
 func TestMemoryBrokerHistoryIteration(t *testing.T) {
 	e := testMemoryBroker()
+	defer func() { _ = e.node.Shutdown(context.Background()) }()
+
 	it := historyIterationTest{10000, 100}
 	startPosition := it.prepareHistoryIteration(t, e.node)
 	it.testHistoryIteration(t, e.node, startPosition)
@@ -528,6 +541,8 @@ func TestMemoryBrokerHistoryIteration(t *testing.T) {
 
 func TestMemoryBrokerHistoryIterationReverse(t *testing.T) {
 	e := testMemoryBroker()
+	defer func() { _ = e.node.Shutdown(context.Background()) }()
+
 	it := historyIterationTest{10000, 100}
 	startPosition := it.prepareHistoryIteration(t, e.node)
 	it.testHistoryIterationReverse(t, e.node, startPosition)
@@ -535,6 +550,8 @@ func TestMemoryBrokerHistoryIterationReverse(t *testing.T) {
 
 func BenchmarkMemoryBrokerHistoryIteration(b *testing.B) {
 	e := testMemoryBroker()
+	defer func() { _ = e.node.Shutdown(context.Background()) }()
+
 	it := historyIterationTest{10000, 100}
 	startPosition := it.prepareHistoryIteration(b, e.node)
 	b.ResetTimer()

--- a/node_test.go
+++ b/node_test.go
@@ -246,6 +246,7 @@ func TestNode_Shutdown(t *testing.T) {
 func TestNode_shutdownCmd(t *testing.T) {
 	// Testing that shutdownCmd removes node from nodes registry.
 	n := defaultNodeNoHandlers()
+	defer func() { _ = n.Shutdown(context.Background()) }()
 	require.NoError(t, n.shutdownCmd(n.ID()))
 	require.True(t, len(n.nodes.list()) == 0)
 	require.True(t, n.nodes.size() == 0)
@@ -347,7 +348,7 @@ func TestNode_RunPubControlError(t *testing.T) {
 
 func TestNode_SetPresenceManager(t *testing.T) {
 	n, _ := New(Config{})
-	presenceManager := testMemoryPresenceManager()
+	presenceManager := testMemoryPresenceManager(t)
 	n.SetPresenceManager(presenceManager)
 	require.Equal(t, n.presenceManager, presenceManager)
 }


### PR DESCRIPTION
Add missing `node.Shutdown()` for some tests.