### PR TITLE
Disconnect clients in case of inappropriate protocol

### DIFF
--- a/client.go
+++ b/client.go
@@ -1245,6 +1245,7 @@ func (c *Client) writeEncodedPush(rep *protocol.Reply, rw *replyWriter) {
 		data, err = encoder.Encode(rep.Push)
 		if err != nil {
 			c.node.logger.log(newLogEntry(LogLevelError, "error encoding connect push", map[string]interface{}{"push": fmt.Sprintf("%v", rep.Push), "client": c.ID(), "user": c.UserID(), "error": err.Error()}))
+			go func() { _ = c.close(DisconnectInappropriateProtocol) }()
 			return
 		}
 	}
@@ -1272,6 +1273,7 @@ func (c *Client) writeEncodedCommandReply(method protocol.Command_MethodType, cm
 	replyData, err := replyEncoder.Encode(rep)
 	if err != nil {
 		c.node.logger.log(newLogEntry(LogLevelError, "error encoding reply", map[string]interface{}{"reply": fmt.Sprintf("%v", rep), "client": c.ID(), "user": c.UserID(), "error": err.Error()}))
+		go func() { _ = c.close(DisconnectInappropriateProtocol) }()
 		return
 	}
 	disconnect := c.messageWriter.enqueue(queue.Item{Data: replyData})

--- a/client_test.go
+++ b/client_test.go
@@ -31,6 +31,13 @@ func newTestConnectedClient(t *testing.T, n *Node, userID string) *Client {
 	return client
 }
 
+func newTestConnectedClientV2(t *testing.T, n *Node, userID string) *Client {
+	client := newTestClientV2(t, n, userID)
+	connectClientV2(t, client)
+	require.True(t, len(n.hub.UserConnections(userID)) > 0)
+	return client
+}
+
 func newTestConnectedClientWithTransport(t *testing.T, ctx context.Context, n *Node, transport Transport, userID string) *Client {
 	client := newTestClientCustomTransport(t, ctx, n, transport, userID)
 	if transport.ProtocolVersion() == ProtocolVersion1 {
@@ -45,6 +52,14 @@ func newTestConnectedClientWithTransport(t *testing.T, ctx context.Context, n *N
 func newTestSubscribedClient(t *testing.T, n *Node, userID, chanID string) *Client {
 	client := newTestConnectedClient(t, n, userID)
 	subscribeClient(t, client, chanID)
+	require.True(t, n.hub.NumSubscribers(chanID) > 0)
+	require.Contains(t, client.channels, chanID)
+	return client
+}
+
+func newTestSubscribedClientV2(t *testing.T, n *Node, userID, chanID string) *Client {
+	client := newTestConnectedClientV2(t, n, userID)
+	subscribeClientV2(t, client, chanID)
 	require.True(t, n.hub.NumSubscribers(chanID) > 0)
 	require.Contains(t, client.channels, chanID)
 	return client

--- a/disconnect.go
+++ b/disconnect.go
@@ -211,10 +211,12 @@ var (
 		Code:   3505,
 		Reason: "channel limit",
 	}
-	// DisconnectInsufficientProtocol can be issued when client connection format can not
-	// handle incoming payloads.
-	DisconnectInsufficientProtocol = Disconnect{
+	// DisconnectInappropriateProtocol can be issued when client connection format can not
+	// handle incoming data. For example, this happens when JSON-based clients receive
+	// binary data in a channel. This is usually an indicator of programmer error, JSON
+	// clients can not handle binary.
+	DisconnectInappropriateProtocol = Disconnect{
 		Code:   3506,
-		Reason: "insufficient protocol",
+		Reason: "inappropriate protocol",
 	}
 )

--- a/disconnect.go
+++ b/disconnect.go
@@ -211,4 +211,10 @@ var (
 		Code:   3505,
 		Reason: "channel limit",
 	}
+	// DisconnectInsufficientProtocol can be issued when client connection format can not
+	// handle incoming payloads.
+	DisconnectInsufficientProtocol = Disconnect{
+		Code:   3506,
+		Reason: "insufficient protocol",
+	}
 )


### PR DESCRIPTION
Currently we have a problem when publishing a binary message and having JSON-protocol connection – publications to channel do not work (return an error) in case of Memory engine (since broadcast is synchronous at the moment). In case of Redis engine there is a chance that only some connections will receive the data until we hit an encoding error (in Redis Engine case broadcast is asynchronous upon reading from PUB/SUB).

This is due to the fact that we can't serialize binary to JSON – so broadcasting obviously returns an error.  That's usually a programmer error, all connections should be Protobuf-based to properly work with binary. But this can also happen occasionally during migration from JSON to binary formats. So users come across weird behaviour here which can not be fixed easily (as clients continue reconnecting).

Here we are disconnecting clients which can not handle binary payload with `3506: inappropriate protocol` `Disconnect` instead of returning an error on publish. So valid connections will work, invalid connections will be disconnected.

Problem like this should usually be detected on development stage. We also log about such cases on WARN level (with the first observed client ID and user ID).

We also disconnect in cases when we can not serialize Reply or Unidirectional Push for single `Client`.

Probably this may be addressed in some alternative form – though do not have any good ideas at the moment.