### PR TITLE
Command read handler

### DIFF
--- a/client.go
+++ b/client.go
@@ -415,18 +415,21 @@ func hasFlag(flags, flag uint64) bool {
 	return flags&flag != 0
 }
 
+func (c *Client) issueCommandReadEvent(cmd *protocol.Command) {
+	if c.node.clientEvents.commandReadHandler != nil {
+		c.node.clientEvents.commandReadHandler(c, CommandReadEvent{
+			Command: cmd,
+		})
+	}
+}
+
 func (c *Client) unidirectionalConnect(connectRequest *protocol.ConnectRequest) error {
 	_, err := c.connectCmd(connectRequest, nil, time.Time{}, true, nil)
 	if err != nil {
+		c.issueCommandReadEvent(&protocol.Command{Connect: connectRequest})
 		return err
 	}
-	if c.node.clientEvents.commandReadHandler != nil {
-		c.node.clientEvents.commandReadHandler(c, CommandReadEvent{
-			Command: &protocol.Command{
-				Connect: connectRequest,
-			},
-		})
-	}
+	c.issueCommandReadEvent(&protocol.Command{Connect: connectRequest})
 	c.triggerConnect()
 	c.scheduleOnConnectTimers()
 	return nil
@@ -1135,11 +1138,11 @@ func (c *Client) HandleCommand(cmd *protocol.Command) bool {
 	}
 
 	var commandReadIssued bool
-	if c.node.clientEvents.commandReadHandler != nil {
+	if c.authenticated && c.node.clientEvents.commandReadHandler != nil {
 		// For authenticated clients we issue CommandReadEvent before processing
-		// the command. For non-authenticated – after processing - since this seems
-		// the only way to properly capture command in per-user tracing.
-		c.node.clientEvents.commandReadHandler(c, CommandReadEvent{Command: cmd})
+		// the command. For non-authenticated – after processing - as this seems
+		// the only way to properly capture connect command in per-user tracing.
+		c.issueCommandReadEvent(cmd)
 		commandReadIssued = true
 	}
 
@@ -1148,7 +1151,7 @@ func (c *Client) HandleCommand(cmd *protocol.Command) bool {
 	if !commandReadIssued && c.node.clientEvents.commandReadHandler != nil {
 		// This is required to capture connect command for non-authenticated
 		// clients in per-user tracing.
-		c.node.clientEvents.commandReadHandler(c, CommandReadEvent{Command: cmd})
+		c.issueCommandReadEvent(cmd)
 	}
 
 	select {

--- a/events.go
+++ b/events.go
@@ -2,6 +2,8 @@ package centrifuge
 
 import (
 	"context"
+
+	"github.com/centrifugal/protocol"
 )
 
 // ConnectEvent contains fields related to connecting event (when a server
@@ -373,3 +375,9 @@ type TransportWriteEvent struct {
 // false from a handler. The main purpose of this handler is not a message
 // filtering based on data content but rather tracing stuff.
 type TransportWriteHandler func(*Client, TransportWriteEvent) bool
+
+type CommandReadEvent struct {
+	Command *protocol.Command
+}
+
+type CommandReadHandler func(*Client, CommandReadEvent)

--- a/events.go
+++ b/events.go
@@ -376,8 +376,15 @@ type TransportWriteEvent struct {
 // filtering based on data content but rather tracing stuff.
 type TransportWriteHandler func(*Client, TransportWriteEvent) bool
 
+// CommandReadEvent contains protocol.Command processed by Client.
 type CommandReadEvent struct {
 	Command *protocol.Command
 }
 
+// CommandReadHandler allows setting a callback which will be called after
+// Client processed a protocol.Command. This exists mostly for real-time connection
+// tracing purposes. Theoretically CommandReadHandler may be called after the
+// corresponding Reply written to connection and TransportWriteHandler called. But
+// for tracing purposes this seems tolerable as commands and replies may be matched
+// by id.
 type CommandReadHandler func(*Client, CommandReadEvent)

--- a/node.go
+++ b/node.go
@@ -1518,6 +1518,7 @@ type eventHub struct {
 	connectingHandler     ConnectingHandler
 	connectHandler        ConnectHandler
 	transportWriteHandler TransportWriteHandler
+	commandReadHandler    CommandReadHandler
 }
 
 // OnConnecting allows setting ConnectingHandler.
@@ -1538,6 +1539,11 @@ func (n *Node) OnConnect(handler ConnectHandler) {
 // OnTransportWrite allows setting TransportWriteHandler. This should be done before Node.Run called.
 func (n *Node) OnTransportWrite(handler TransportWriteHandler) {
 	n.clientEvents.transportWriteHandler = handler
+}
+
+// OnCommandRead allows setting CommandReadHandler. This should be done before Node.Run called.
+func (n *Node) OnCommandRead(handler CommandReadHandler) {
+	n.clientEvents.commandReadHandler = handler
 }
 
 type brokerEventHandler struct {


### PR DESCRIPTION
Add `Node.OnCommandRead` API which allows setting callback called upon processing Command received from client connection. The purpose is mostly real-time tracing. 

This is required to improve per-user tracing in [Centrifugo PRO](https://centrifugal.dev/docs/pro/tracing) – changes introduced here allow to catch commands sent by user and display entire content of those.