### PR TITLE
Improve subscribe throughput upon increased latency

### DIFF
--- a/_examples/redis_broker_presence/main.go
+++ b/_examples/redis_broker_presence/main.go
@@ -161,7 +161,7 @@ func main() {
 					centrifuge.WithHistory(10, time.Minute),
 				)
 				if err != nil {
-					log.Println(err.Error())
+					log.Printf("error publishing: %v", err)
 				}
 				_, err = node.History("chat:" + strconv.Itoa(i))
 				if err != nil {

--- a/broker_redis.go
+++ b/broker_redis.go
@@ -701,7 +701,7 @@ func (b *RedisBroker) runPubSub(s *shardWrapper, eventHandler BrokerEventHandler
 	go func() {
 		wg.Wait()
 		if len(channels) > 0 && b.node.LogEnabled(LogLevelDebug) {
-			b.node.Log(NewLogEntry(LogLevelError, "resubscribed to channels", map[string]interface{}{"elapsed": fmt.Sprintf("%s", time.Since(started)), "numChannels": len(channels)}))
+			b.node.Log(NewLogEntry(LogLevelError, "resubscribed to channels", map[string]interface{}{"elapsed": time.Since(started).String(), "numChannels": len(channels)}))
 		}
 		select {
 		case <-done:

--- a/broker_redis.go
+++ b/broker_redis.go
@@ -638,7 +638,12 @@ func (b *RedisBroker) runPubSub(s *shardWrapper, eventHandler BrokerEventHandler
 		},
 	})
 
-	err := conn.Do(context.Background(), conn.B().Subscribe().Channel(shardChannel).Build()).Error()
+	var err error
+	if useShardedPubSub {
+		err = conn.Do(context.Background(), conn.B().Ssubscribe().Channel(shardChannel).Build()).Error()
+	} else {
+		err = conn.Do(context.Background(), conn.B().Subscribe().Channel(shardChannel).Build()).Error()
+	}
 	if err != nil {
 		startOnce(err)
 		b.node.Log(NewLogEntry(LogLevelError, "pub/sub error", map[string]interface{}{"error": err.Error()}))

--- a/broker_redis.go
+++ b/broker_redis.go
@@ -458,8 +458,6 @@ func (b *RedisBroker) runForever(fn func()) {
 }
 
 func (b *RedisBroker) runShard(s *shardWrapper, h BrokerEventHandler) error {
-	var controlPubSubStartOnce sync.Once
-
 	go b.runForever(func() {
 		select {
 		case <-b.closeCh:
@@ -467,7 +465,7 @@ func (b *RedisBroker) runShard(s *shardWrapper, h BrokerEventHandler) error {
 		default:
 		}
 		b.runControlPubSub(s.shard, h, func(err error) {
-			controlPubSubStartOnce.Do(func() {
+			s.controlPubSubStart.once.Do(func() {
 				s.controlPubSubStart.errCh <- err
 			})
 		})

--- a/broker_redis_test.go
+++ b/broker_redis_test.go
@@ -1552,6 +1552,8 @@ func BenchmarkPubSubThroughput(b *testing.B) {
 			})
 			defer stopRedisBroker(b1)
 
+			node1.SetBroker(b1)
+
 			numChannels := 1024
 			pubCh := make(chan struct{}, 1024)
 			brokerEventHandler := &testBrokerEventHandler{

--- a/broker_redis_test.go
+++ b/broker_redis_test.go
@@ -1,4 +1,5 @@
 //go:build integration
+// +build integration
 
 package centrifuge
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/igm/sockjs-go/v3 v3.0.2
 	github.com/prometheus/client_golang v1.14.0
-	github.com/rueian/rueidis v0.0.89
+	github.com/rueian/rueidis v0.0.90
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/sync v0.1.0
 	google.golang.org/protobuf v1.28.1

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rueian/rueidis v0.0.89 h1:Q2TbuNXMJ2d2NegQ47uOoGOGPZLQwRuL0oX/dAlCh6k=
-github.com/rueian/rueidis v0.0.89/go.mod h1:LiKWMM/QnILwRfDZIhSIXi4vQqZ/UZy4+/aNkSCt8XA=
+github.com/rueian/rueidis v0.0.90 h1:zuTFPvouPmO4FojrWg2p47XhiFcJ5Ux/cQu37ZRIdVs=
+github.com/rueian/rueidis v0.0.90/go.mod h1:LiKWMM/QnILwRfDZIhSIXi4vQqZ/UZy4+/aNkSCt8XA=
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/asm v1.1.4 h1:Q/FKBtrgnmDc0YMrurLROqG9mXE6Ndn276EtDnoWtMM=
 github.com/segmentio/asm v1.1.4/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=

--- a/redis_shard.go
+++ b/redis_shard.go
@@ -21,7 +21,7 @@ type (
 )
 
 const (
-	defaultRedisIOTimeout      = 3 * time.Second
+	defaultRedisIOTimeout      = 4 * time.Second
 	defaultRedisConnectTimeout = time.Second
 )
 


### PR DESCRIPTION
I noticed that when adding latency subscribe throughput decreases in the new Redis Broker implementation in master branch merged recently, this PR removes intermediate channel between subscribe call and command execution. This improves subscribe throughput as latency grows.

Still need to spend some time validating the approach here.