### PR TITLE
Reversed history fix for meta keys with epoch only

### DIFF
--- a/internal/redis_lua/broker_history_list.lua
+++ b/internal/redis_lua/broker_history_list.lua
@@ -14,6 +14,10 @@ if current_epoch == false then
   redis.call("hset", meta_key, "e", current_epoch, "s", "0")
 end
 
+if top_offset == false then
+  top_offset = 0
+end
+
 if meta_expire ~= '0' then
   redis.call("expire", meta_key, meta_expire)
 end

--- a/internal/redis_lua/broker_history_stream.lua
+++ b/internal/redis_lua/broker_history_stream.lua
@@ -16,6 +16,10 @@ if current_epoch == false then
   redis.call("hset", meta_key, "e", current_epoch, "s", "0")
 end
 
+if top_offset == false then
+  top_offset = 0
+end
+
 if meta_expire ~= '0' then
   redis.call("expire", meta_key, meta_expire)
 end


### PR DESCRIPTION
The fix in https://github.com/centrifugal/centrifuge/pull/328 found and eliminated the root cause of issue. But there is one more case we need to solve: handle meta hash keys without offset set - i.e. only with epoch. New versions do not create such keys, but they could be set by old versions.

Relates https://github.com/centrifugal/centrifugo/issues/732