### PR TITLE
Avoid zero offset in meta hash keys

### DIFF
--- a/internal/redis_lua/broker_history_list.lua
+++ b/internal/redis_lua/broker_history_list.lua
@@ -11,7 +11,7 @@ local current_epoch, top_offset = stream_meta[1], stream_meta[2]
 if current_epoch == false then
   current_epoch = new_epoch_if_empty
   top_offset = 0
-  redis.call("hset", meta_key, "e", current_epoch, "s", "0")
+  redis.call("hset", meta_key, "e", current_epoch)
 end
 
 if top_offset == false then

--- a/internal/redis_lua/broker_history_stream.lua
+++ b/internal/redis_lua/broker_history_stream.lua
@@ -13,7 +13,7 @@ local current_epoch, top_offset = stream_meta[1], stream_meta[2]
 if current_epoch == false then
   current_epoch = new_epoch_if_empty
   top_offset = 0
-  redis.call("hset", meta_key, "e", current_epoch, "s", "0")
+  redis.call("hset", meta_key, "e", current_epoch)
 end
 
 if top_offset == false then


### PR DESCRIPTION
To save some memory for inactive channels.