### PR TITLE
Maintain user mapping in Redis to speed up presence stats significantly

### DIFF
--- a/_examples/custom_engine_tarantool/tntengine/presence.go
+++ b/_examples/custom_engine_tarantool/tntengine/presence.go
@@ -174,7 +174,7 @@ type removePresenceRequest struct {
 	ClientID string
 }
 
-func (m PresenceManager) RemovePresence(ch string, clientID string) error {
+func (m PresenceManager) RemovePresence(ch string, clientID string, _ string) error {
 	s := consistentShard(ch, m.shards)
 	_, err := s.Exec(tarantool.Call("centrifuge.remove_presence", removePresenceRequest{Channel: ch, ClientID: clientID}))
 	return err

--- a/client.go
+++ b/client.go
@@ -3063,7 +3063,7 @@ func (c *Client) unsubscribe(channel string, unsubscribe Unsubscribe, disconnect
 	c.mu.Unlock()
 
 	if channelHasFlag(chCtx.flags, flagEmitPresence) && channelHasFlag(chCtx.flags, flagSubscribed) {
-		err := c.node.removePresence(channel, c.uid)
+		err := c.node.removePresence(channel, c.uid, c.user)
 		if err != nil {
 			c.node.logger.log(newLogEntry(LogLevelError, "error removing channel presence", map[string]any{"channel": channel, "user": c.user, "client": c.uid, "error": err.Error()}))
 		}

--- a/internal/redis_lua/presence_add.lua
+++ b/internal/redis_lua/presence_add.lua
@@ -1,11 +1,32 @@
 -- Add/update presence information.
--- KEYS[1] - presence set key
+-- KEYS[1] - presence zset key
 -- KEYS[2] - presence hash key
+-- KEYS[3] - per-user zset key
+-- KEYS[4] - per-user hash key
 -- ARGV[1] - key expire seconds
 -- ARGV[2] - expire at for set member
 -- ARGV[3] - client ID
 -- ARGV[4] - info payload
+-- ARGV[5] - user ID
+-- ARGV[6] - enable user mapping "0" or "1"
+
+-- Check if client ID is new.
+local isNewClient = false
+if ARGV[6] ~= '0' then
+  isNewClient = redis.call("hexists", KEYS[2], ARGV[3]) == 0
+end
+
+-- Add per-client presence.
 redis.call("zadd", KEYS[1], ARGV[2], ARGV[3])
 redis.call("hset", KEYS[2], ARGV[3], ARGV[4])
 redis.call("expire", KEYS[1], ARGV[1])
 redis.call("expire", KEYS[2], ARGV[1])
+
+-- Add per-user information.
+if ARGV[6] ~= '0' then
+    redis.call("zadd", KEYS[3], ARGV[2], ARGV[5])
+    redis.call("expire", KEYS[3], ARGV[1])
+    if isNewClient then
+        redis.call("hincrby", KEYS[4], ARGV[5], 1)
+    end
+end

--- a/internal/redis_lua/presence_add.lua
+++ b/internal/redis_lua/presence_add.lua
@@ -29,4 +29,5 @@ if ARGV[6] ~= '0' then
     if isNewClient then
         redis.call("hincrby", KEYS[4], ARGV[5], 1)
     end
+    redis.call("expire", KEYS[4], ARGV[1])
 end

--- a/internal/redis_lua/presence_rem.lua
+++ b/internal/redis_lua/presence_rem.lua
@@ -1,6 +1,27 @@
 -- Remove client presence.
 -- KEYS[1] - presence set key
 -- KEYS[2] - presence hash key
+-- KEYS[3] - per-user zset key
+-- KEYS[4] - per-user hash key
 -- ARGV[1] - client ID
+-- ARGV[2] - user ID
+-- ARGV[3] - enable user mapping "0" or "1"
+
+local clientExists = false
+if ARGV[3] ~= '0' then
+    -- Check if client ID exists in hash.
+    clientExists = redis.call("hexists", KEYS[2], ARGV[1]) == 1
+end
+
 redis.call("hdel", KEYS[2], ARGV[1])
 redis.call("zrem", KEYS[1], ARGV[1])
+
+if ARGV[3] ~= '0' and clientExists then
+    local connectionsCount = redis.call("hincrby", KEYS[4], ARGV[2], -1)
+    -- If the number of connections for this user is zero, remove the user
+    -- from the sorted set and clean hash.
+    if connectionsCount <= 0 then
+        redis.call("zrem", KEYS[3], ARGV[2])
+        redis.call("hdel", KEYS[4], ARGV[2])
+    end
+end

--- a/internal/redis_lua/presence_stats_get.lua
+++ b/internal/redis_lua/presence_stats_get.lua
@@ -1,0 +1,26 @@
+-- Get presence stats information.
+-- KEYS[1] - presence set key
+-- KEYS[2] - presence hash key
+-- KEYS[3] - per-user zset key
+-- KEYS[4] - per-user hash key
+-- ARGV[1] - current timestamp in seconds
+local expired = redis.call("zrangebyscore", KEYS[1], "0", ARGV[1])
+if #expired > 0 then
+  for num = 1, #expired do
+    redis.call("hdel", KEYS[2], expired[num])
+  end
+  redis.call("zremrangebyscore", KEYS[1], "0", ARGV[1])
+end
+
+local userExpired = redis.call("zrangebyscore", KEYS[3], "0", ARGV[1])
+if #userExpired > 0 then
+  for num = 1, #userExpired do
+    redis.call("hdel", KEYS[4], userExpired[num])
+  end
+  redis.call("zremrangebyscore", KEYS[3], "0", ARGV[1])
+end
+
+local clientCount = redis.call("hlen", KEYS[2])
+local userCount = redis.call("hlen", KEYS[4])
+
+return {clientCount, userCount}

--- a/node.go
+++ b/node.go
@@ -1129,12 +1129,12 @@ func (n *Node) addPresence(ch string, uid string, info *ClientInfo) error {
 }
 
 // removePresence proxies presence removing to PresenceManager.
-func (n *Node) removePresence(ch string, uid string) error {
+func (n *Node) removePresence(ch string, clientID string, userID string) error {
 	if n.presenceManager == nil {
 		return nil
 	}
 	n.metrics.incActionCount("remove_presence")
-	return n.presenceManager.RemovePresence(ch, uid)
+	return n.presenceManager.RemovePresence(ch, clientID, userID)
 }
 
 var (

--- a/node_test.go
+++ b/node_test.go
@@ -123,7 +123,7 @@ func (e *TestPresenceManager) AddPresence(_ string, _ string, _ *ClientInfo) err
 	return nil
 }
 
-func (e *TestPresenceManager) RemovePresence(_ string, _ string) error {
+func (e *TestPresenceManager) RemovePresence(_ string, _ string, _ string) error {
 	if e.errorOnRemovePresence {
 		return errors.New("boom")
 	}
@@ -309,8 +309,8 @@ func TestNode_SetBroker(t *testing.T) {
 func TestNode_SetPresenceManager_NilPresenceManager(t *testing.T) {
 	n, _ := New(Config{})
 	n.SetPresenceManager(nil)
-	require.NoError(t, n.addPresence("test", "uid", nil))
-	require.NoError(t, n.removePresence("test", "uid"))
+	require.NoError(t, n.addPresence("test", "uid", &ClientInfo{}))
+	require.NoError(t, n.removePresence("test", "uid", ""))
 	_, err := n.Presence("test")
 	require.Equal(t, ErrorNotAvailable, err)
 	_, err = n.PresenceStats("test")

--- a/presence.go
+++ b/presence.go
@@ -23,5 +23,5 @@ type PresenceManager interface {
 	AddPresence(ch string, clientID string, info *ClientInfo) error
 	// RemovePresence removes presence information for connection
 	// with specified identifier.
-	RemovePresence(ch string, clientID string) error
+	RemovePresence(ch string, clientID string, userID string) error
 }

--- a/presence.go
+++ b/presence.go
@@ -22,6 +22,6 @@ type PresenceManager interface {
 	// (touched) after some configured time interval.
 	AddPresence(ch string, clientID string, info *ClientInfo) error
 	// RemovePresence removes presence information for connection
-	// with specified identifier.
+	// with specified client and user identifiers.
 	RemovePresence(ch string, clientID string, userID string) error
 }

--- a/presence_memory.go
+++ b/presence_memory.go
@@ -42,8 +42,8 @@ func (m *MemoryPresenceManager) AddPresence(ch string, uid string, info *ClientI
 }
 
 // RemovePresence - see PresenceManager interface description.
-func (m *MemoryPresenceManager) RemovePresence(ch string, uid string) error {
-	return m.presenceHub.remove(ch, uid)
+func (m *MemoryPresenceManager) RemovePresence(ch string, clientID string, _ string) error {
+	return m.presenceHub.remove(ch, clientID)
 }
 
 // Presence - see PresenceManager interface description.

--- a/presence_memory_test.go
+++ b/presence_memory_test.go
@@ -26,7 +26,7 @@ func TestNewMemoryPresenceManager_RemovePresence(t *testing.T) {
 	p, err := m.Presence("channel")
 	require.NoError(t, err)
 	require.Equal(t, 1, len(p))
-	require.NoError(t, m.RemovePresence("channel", "uid"))
+	require.NoError(t, m.RemovePresence("channel", "uid", ""))
 	p, err = m.Presence("channel")
 	require.NoError(t, err)
 	require.Equal(t, 0, len(p))

--- a/presence_redis_test.go
+++ b/presence_redis_test.go
@@ -186,7 +186,6 @@ func TestRedisPresenceManagerWithUserMapping(t *testing.T) {
 }
 
 func TestRedisPresenceManagerWithUserMappingExpire(t *testing.T) {
-	t.Skip()
 	t.Parallel()
 	for _, tt := range redisPresenceTests {
 		t.Run(tt.Name, func(t *testing.T) {

--- a/presence_redis_test.go
+++ b/presence_redis_test.go
@@ -31,9 +31,11 @@ func NewTestRedisPresenceManagerWithPrefix(tb testing.TB, n *Node, prefix string
 	s, err := NewRedisShard(n, redisConf)
 	require.NoError(tb, err)
 	pm, err := NewRedisPresenceManager(n, RedisPresenceManagerConfig{
-		Prefix:            prefix,
-		Shards:            []*RedisShard{s},
-		EnableUserMapping: userMapping,
+		Prefix: prefix,
+		Shards: []*RedisShard{s},
+		EnableUserMapping: func(_ string) bool {
+			return userMapping
+		},
 	})
 	if err != nil {
 		tb.Fatal(err)
@@ -54,9 +56,11 @@ func NewTestRedisPresenceManagerClusterWithPrefix(tb testing.TB, n *Node, prefix
 	s, err := NewRedisShard(n, redisConf)
 	require.NoError(tb, err)
 	pm, err := NewRedisPresenceManager(n, RedisPresenceManagerConfig{
-		Prefix:            prefix,
-		Shards:            []*RedisShard{s},
-		EnableUserMapping: userMapping,
+		Prefix: prefix,
+		Shards: []*RedisShard{s},
+		EnableUserMapping: func(_ string) bool {
+			return userMapping
+		},
 	})
 	if err != nil {
 		tb.Fatal(err)

--- a/presence_redis_test.go
+++ b/presence_redis_test.go
@@ -311,6 +311,7 @@ func BenchmarkRedisPresenceStatsWithMapping(b *testing.B) {
 				b.Fatal(err)
 			}
 			require.Equal(b, s.NumClients, numClients)
+			require.Equal(b, s.NumUsers, numClients)
 		}
 	})
 }

--- a/presence_redis_test.go
+++ b/presence_redis_test.go
@@ -211,11 +211,21 @@ func TestRedisPresenceManagerWithUserMappingExpire(t *testing.T) {
 				ClientID: "uid-3",
 				UserID:   "2",
 			}))
+			// anonymous user, different conn
+			require.NoError(t, pm.AddPresence("channel", "uid-4", &ClientInfo{
+				ClientID: "uid-4",
+				UserID:   "",
+			}))
+			// anonymous user, different conn
+			require.NoError(t, pm.AddPresence("channel", "uid-5", &ClientInfo{
+				ClientID: "uid-5",
+				UserID:   "",
+			}))
 
 			stats, err := pm.PresenceStats("channel")
 			require.NoError(t, err)
-			require.Equal(t, 3, stats.NumClients)
-			require.Equal(t, 2, stats.NumUsers)
+			require.Equal(t, 5, stats.NumClients)
+			require.Equal(t, 3, stats.NumUsers)
 
 			timer := time.NewTimer(2 * time.Second)
 		LOOP:

--- a/presence_redis_test.go
+++ b/presence_redis_test.go
@@ -5,6 +5,7 @@ package centrifuge
 import (
 	"context"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -12,11 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestRedisPresenceManager(tb testing.TB, n *Node, useCluster bool) *RedisPresenceManager {
+func newTestRedisPresenceManager(tb testing.TB, n *Node, useCluster bool, userMapping bool) *RedisPresenceManager {
 	if useCluster {
-		return NewTestRedisPresenceManagerClusterWithPrefix(tb, n, getUniquePrefix())
+		return NewTestRedisPresenceManagerClusterWithPrefix(tb, n, getUniquePrefix(), userMapping)
 	}
-	return NewTestRedisPresenceManagerWithPrefix(tb, n, getUniquePrefix())
+	return NewTestRedisPresenceManagerWithPrefix(tb, n, getUniquePrefix(), userMapping)
 }
 
 func stopRedisPresenceManager(pm *RedisPresenceManager) {
@@ -25,13 +26,14 @@ func stopRedisPresenceManager(pm *RedisPresenceManager) {
 	}
 }
 
-func NewTestRedisPresenceManagerWithPrefix(tb testing.TB, n *Node, prefix string) *RedisPresenceManager {
+func NewTestRedisPresenceManagerWithPrefix(tb testing.TB, n *Node, prefix string, userMapping bool) *RedisPresenceManager {
 	redisConf := testRedisConf()
 	s, err := NewRedisShard(n, redisConf)
 	require.NoError(tb, err)
 	pm, err := NewRedisPresenceManager(n, RedisPresenceManagerConfig{
-		Prefix: prefix,
-		Shards: []*RedisShard{s},
+		Prefix:            prefix,
+		Shards:            []*RedisShard{s},
+		EnableUserMapping: userMapping,
 	})
 	if err != nil {
 		tb.Fatal(err)
@@ -44,7 +46,7 @@ func NewTestRedisPresenceManagerWithPrefix(tb testing.TB, n *Node, prefix string
 	return pm
 }
 
-func NewTestRedisPresenceManagerClusterWithPrefix(tb testing.TB, n *Node, prefix string) *RedisPresenceManager {
+func NewTestRedisPresenceManagerClusterWithPrefix(tb testing.TB, n *Node, prefix string, userMapping bool) *RedisPresenceManager {
 	redisConf := RedisShardConfig{
 		ClusterAddresses: []string{"localhost:7000", "localhost:7001", "localhost:7002"},
 		IOTimeout:        10 * time.Second,
@@ -52,8 +54,9 @@ func NewTestRedisPresenceManagerClusterWithPrefix(tb testing.TB, n *Node, prefix
 	s, err := NewRedisShard(n, redisConf)
 	require.NoError(tb, err)
 	pm, err := NewRedisPresenceManager(n, RedisPresenceManagerConfig{
-		Prefix: prefix,
-		Shards: []*RedisShard{s},
+		Prefix:            prefix,
+		Shards:            []*RedisShard{s},
+		EnableUserMapping: userMapping,
 	})
 	if err != nil {
 		tb.Fatal(err)
@@ -78,7 +81,7 @@ func TestRedisPresenceManager(t *testing.T) {
 	for _, tt := range redisPresenceTests {
 		t.Run(tt.Name, func(t *testing.T) {
 			node := testNode(t)
-			pm := newTestRedisPresenceManager(t, node, tt.UseCluster)
+			pm := newTestRedisPresenceManager(t, node, tt.UseCluster, false)
 			defer func() { _ = node.Shutdown(context.Background()) }()
 			defer stopRedisPresenceManager(pm)
 
@@ -94,7 +97,7 @@ func TestRedisPresenceManager(t *testing.T) {
 			require.Equal(t, 1, s.NumUsers)
 			require.Equal(t, 1, s.NumClients)
 
-			err = pm.RemovePresence("channel", "uid")
+			err = pm.RemovePresence("channel", "uid", "")
 			require.NoError(t, err)
 
 			p, err = pm.Presence("channel")
@@ -104,11 +107,85 @@ func TestRedisPresenceManager(t *testing.T) {
 	}
 }
 
+func TestRedisPresenceManagerWithUserMapping(t *testing.T) {
+	for _, tt := range redisPresenceTests {
+		t.Run(tt.Name, func(t *testing.T) {
+			node := testNode(t)
+			pm := newTestRedisPresenceManager(t, node, tt.UseCluster, true)
+			defer func() { _ = node.Shutdown(context.Background()) }()
+			defer stopRedisPresenceManager(pm)
+
+			// adding presence for the first time.
+			require.NoError(t, pm.AddPresence("channel", "uid", &ClientInfo{
+				ClientID: "uid",
+				UserID:   "1",
+			}))
+
+			// same conn, same user.
+			require.NoError(t, pm.AddPresence("channel", "uid", &ClientInfo{
+				ClientID: "uid",
+				UserID:   "1",
+			}))
+
+			stats, err := pm.PresenceStats("channel")
+			require.NoError(t, err)
+			require.Equal(t, 1, stats.NumClients)
+			require.Equal(t, 1, stats.NumUsers)
+
+			// same user, different conn
+			require.NoError(t, pm.AddPresence("channel", "uid-2", &ClientInfo{
+				ClientID: "uid-2",
+				UserID:   "1",
+			}))
+
+			stats, err = pm.PresenceStats("channel")
+			require.NoError(t, err)
+			require.Equal(t, 2, stats.NumClients)
+			require.Equal(t, 1, stats.NumUsers)
+
+			// different user, different conn
+			require.NoError(t, pm.AddPresence("channel", "uid-3", &ClientInfo{
+				ClientID: "uid-3",
+				UserID:   "2",
+			}))
+
+			stats, err = pm.PresenceStats("channel")
+			require.NoError(t, err)
+			require.Equal(t, 3, stats.NumClients)
+			require.Equal(t, 2, stats.NumUsers)
+
+			err = pm.RemovePresence("channel", "uid", "1")
+			require.NoError(t, err)
+
+			stats, err = pm.PresenceStats("channel")
+			require.NoError(t, err)
+			require.Equal(t, 2, stats.NumClients)
+			require.Equal(t, 2, stats.NumUsers)
+
+			err = pm.RemovePresence("channel", "uid-2", "1")
+			require.NoError(t, err)
+
+			stats, err = pm.PresenceStats("channel")
+			require.NoError(t, err)
+			require.Equal(t, 1, stats.NumClients)
+			require.Equal(t, 1, stats.NumUsers)
+
+			err = pm.RemovePresence("channel", "uid-3", "2")
+			require.NoError(t, err)
+
+			stats, err = pm.PresenceStats("channel")
+			require.NoError(t, err)
+			require.Equal(t, 0, stats.NumClients)
+			require.Equal(t, 0, stats.NumUsers)
+		})
+	}
+}
+
 func BenchmarkRedisAddPresence_1Ch(b *testing.B) {
 	for _, tt := range benchRedisTests {
 		b.Run(tt.Name, func(b *testing.B) {
 			node := benchNode(b)
-			pm := newTestRedisPresenceManager(b, node, tt.UseCluster)
+			pm := newTestRedisPresenceManager(b, node, tt.UseCluster, false)
 			defer func() { _ = node.Shutdown(context.Background()) }()
 			defer stopRedisPresenceManager(pm)
 			b.SetParallelism(getBenchParallelism())
@@ -129,7 +206,7 @@ func BenchmarkRedisAddPresence_ManyCh(b *testing.B) {
 	for _, tt := range benchRedisTests {
 		b.Run(tt.Name, func(b *testing.B) {
 			node := benchNode(b)
-			pm := newTestRedisPresenceManager(b, node, tt.UseCluster)
+			pm := newTestRedisPresenceManager(b, node, tt.UseCluster, false)
 			defer func() { _ = node.Shutdown(context.Background()) }()
 			defer stopRedisPresenceManager(pm)
 			b.SetParallelism(getBenchParallelism())
@@ -153,7 +230,7 @@ func BenchmarkRedisPresence_1Ch(b *testing.B) {
 	for _, tt := range benchRedisTests {
 		b.Run(tt.Name, func(b *testing.B) {
 			node := benchNode(b)
-			pm := newTestRedisPresenceManager(b, node, tt.UseCluster)
+			pm := newTestRedisPresenceManager(b, node, tt.UseCluster, false)
 			defer func() { _ = node.Shutdown(context.Background()) }()
 			defer stopRedisPresenceManager(pm)
 			b.SetParallelism(getBenchParallelism())
@@ -175,7 +252,7 @@ func BenchmarkRedisPresence_ManyCh(b *testing.B) {
 	for _, tt := range benchRedisTests {
 		b.Run(tt.Name, func(b *testing.B) {
 			node := benchNode(b)
-			pm := newTestRedisPresenceManager(b, node, tt.UseCluster)
+			pm := newTestRedisPresenceManager(b, node, tt.UseCluster, false)
 			defer func() { _ = node.Shutdown(context.Background()) }()
 			defer stopRedisPresenceManager(pm)
 			b.SetParallelism(getBenchParallelism())
@@ -194,4 +271,46 @@ func BenchmarkRedisPresence_ManyCh(b *testing.B) {
 			})
 		})
 	}
+}
+
+func BenchmarkRedisPresenceStatsWithMapping(b *testing.B) {
+	node := benchNode(b)
+	pm := newTestRedisPresenceManager(b, node, false, true)
+	defer func() { _ = node.Shutdown(context.Background()) }()
+	defer stopRedisPresenceManager(pm)
+	b.SetParallelism(getBenchParallelism())
+
+	sem := make(chan struct{}, 100)
+	numClients := 100_000
+
+	var wg sync.WaitGroup
+	wg.Add(numClients)
+	for i := 0; i < numClients; i++ {
+		sem <- struct{}{}
+		i := i
+		go func() {
+			defer wg.Done()
+			defer func() {
+				<-sem
+			}()
+			clientID := "uid" + strconv.Itoa(i)
+			userID := "user" + strconv.Itoa(i)
+			_ = pm.AddPresence("channel", "uid"+strconv.Itoa(i), &ClientInfo{
+				ClientID: clientID,
+				UserID:   userID,
+			})
+		}()
+	}
+	wg.Wait()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			s, err := pm.PresenceStats("channel")
+			if err != nil {
+				b.Fatal(err)
+			}
+			require.Equal(b, s.NumClients, numClients)
+		}
+	})
 }


### PR DESCRIPTION
Related https://github.com/centrifugal/centrifugo/issues/750

For channel with 100k subscribers this changes the performance of presence stats from 15 ops/sec to 200000 ops/sec on my local machine.

Using a separate option here (`EnableUserMapping` in `RedisPresenceManagerConfig`) since storing user info in Redis means using additional structures => increases memory usage on Redis side.