### PR TITLE
Reuse connection timer

### DIFF
--- a/client.go
+++ b/client.go
@@ -408,9 +408,9 @@ func (c *Client) onTimerOp() {
 		c.mu.Unlock()
 		return
 	}
-	timerOp := c.timerOp
+	op := c.timerOp
 	c.mu.Unlock()
-	switch timerOp {
+	switch op {
 	case timerOpStale:
 		c.closeStale()
 	case timerOpPresence:
@@ -456,7 +456,11 @@ func (c *Client) scheduleNextTimer() {
 	if needTimer {
 		c.timerOp = nextTimerOp
 		afterDuration := time.Duration(minEventTime-time.Now().UnixNano()) * time.Nanosecond
-		c.timer = time.AfterFunc(afterDuration, c.onTimerOp)
+		if c.timer != nil {
+			c.timer.Reset(afterDuration)
+		} else {
+			c.timer = time.AfterFunc(afterDuration, c.onTimerOp)
+		}
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	NodeInfoMetricsAggregateInterval time.Duration
 	// ClientPresenceUpdateInterval sets an interval how often connected
 	// clients update presence information.
-	// Zero value means 27 * time.Second.
+	// Zero value means 25 * time.Second.
 	ClientPresenceUpdateInterval time.Duration
 	// ClientExpiredCloseDelay is an extra time given to client to refresh
 	// its connection in the end of connection TTL. At moment only used for

--- a/node.go
+++ b/node.go
@@ -96,7 +96,7 @@ func New(c Config) (*Node, error) {
 		c.NodeInfoMetricsAggregateInterval = 60 * time.Second
 	}
 	if c.ClientPresenceUpdateInterval == 0 {
-		c.ClientPresenceUpdateInterval = 27 * time.Second
+		c.ClientPresenceUpdateInterval = 25 * time.Second
 	}
 	if c.ClientChannelPositionCheckDelay == 0 {
 		c.ClientChannelPositionCheckDelay = 40 * time.Second


### PR DESCRIPTION
Minor performance improvement – reset connection timer instead of allocating a new one each time.