### PR TITLE
Add server unsubscribes metric

### DIFF
--- a/_examples/compression_playground/readme.md
+++ b/_examples/compression_playground/readme.md
@@ -14,23 +14,23 @@ caught with WireShark filter:
 tcp.srcport == 8000 && websocket
 ```
 
-| Protocol                     | Compression | Delta     | Bytes sent | Percentage |
-|------------------------------|-------------|-----------|------------|------------|
-| JSON over JSON               | No          | No        | 40251      | 100.0      |
-| JSON over JSON               | Yes         | No        | 15669      | 38.93      |
-| JSON over JSON               | No          | Yes       | 6043       | 15.01      |
-| JSON over JSON               | Yes         | Yes       | 5360       | 13.32      |
-| JSON over Protobuf           | No          | No        | 39180      | 97.34      |
-| JSON over Protobuf           | Yes         | No        | 15542      | 38.61      |
-| JSON over Protobuf           | No          | Yes       | 4287       | 10.65      |
-| JSON over Protobuf           | Yes         | Yes       | 4126       | 10.25      |
-| Protobuf over Protobuf       | No          | No        | 16562      | 41.15      |
-| Protobuf over Protobuf       | Yes         | No        | 13115      | 32.58      |
-| Protobuf over Protobuf       | No          | Yes       | 4382       | 10.89      |
-| Protobuf over Protobuf       | Yes         | Yes       | 4473       | 11.11      |
-| JSON over JSON 200ms         | Yes         | Yes       | 2060       | 5.12       |
-| JSON over Protobuf 200ms     | Yes         | Yes       | 2008       | 4.99       |
-| Protobuf over Protobuf 200ms | Yes         | Yes       | 2315       | 5.75       |
+| Protocol                   | Compression | Delta      | Delay | Bytes sent | Percentage |
+|----------------------------|-------------|------------|-------|------------|-----------|
+| JSON over JSON             | No          | No         | 0     | 40251      | 100.0     |
+| JSON over JSON             | Yes         | No         | 0     | 15669      | 38.93     |
+| JSON over JSON             | No          | Yes        | 0     | 6043       | 15.01     |
+| JSON over JSON             | Yes         | Yes        | 0     | 5360       | 13.32     |
+| JSON over Protobuf         | No          | No         | 0     | 39180      | 97.34     |
+| JSON over Protobuf         | Yes         | No         | 0     | 15542      | 38.61     |
+| JSON over Protobuf         | No          | Yes        | 0     | 4287       | 10.65     |
+| JSON over Protobuf         | Yes         | Yes        | 0     | 4126       | 10.25     |
+| Protobuf over Protobuf     | No          | No         | 0     | 16562      | 41.15     |
+| Protobuf over Protobuf     | Yes         | No         | 0     | 13115      | 32.58     |
+| Protobuf over Protobuf     | No          | Yes        | 0     | 4382       | 10.89     |
+| Protobuf over Protobuf     | Yes         | Yes        | 0     | 4473       | 11.11     |
+| JSON over JSON             | Yes         | Yes        | 200ms | 2060       | 5.12      |
+| JSON over Protobuf         | Yes         | Yes        | 200ms | 2008       | 4.99      |
+| Protobuf over Protobuf     | Yes         | Yes        | 200ms | 2315       | 5.75      |
 
 Note: since we send JSON over Protobuf, the JSON size is the same as the JSON over JSON case.
 In this case Centrifugal protocol gives lower overhead, but the main part comes from the JSON payload size.

--- a/client.go
+++ b/client.go
@@ -708,6 +708,9 @@ func (c *Client) updatePresence() {
 		checkDelay := config.ClientChannelPositionCheckDelay
 		if checkDelay > 0 && !c.checkPosition(checkDelay, channel, channelContext) {
 			serverSide := channelHasFlag(channelContext.flags, flagServerSide)
+			if c.node.logger.enabled(LogLevelDebug) {
+				c.node.logger.log(newLogEntry(LogLevelDebug, "client insufficient state from periodic check", map[string]any{"channel": channel, "user": c.user, "client": c.uid}))
+			}
 			if c.isAsyncUnsubscribe(serverSide) {
 				go func(ch string) { c.handleAsyncUnsubscribe(ch, unsubscribeInsufficientState) }(channel)
 				continue
@@ -908,6 +911,7 @@ func (c *Client) sendUnsubscribe(ch string, unsub Unsubscribe) error {
 		return err
 	}
 	_ = c.transportEnqueue(replyData, ch, protocol.FrameTypePushUnsubscribe)
+	c.node.metrics.incServerUnsubscribe(unsub.Code)
 	return nil
 }
 


### PR DESCRIPTION
New metric:

```
prometheus.NewCounterVec(prometheus.CounterOpts{
	Namespace: metricsNamespace,
	Subsystem: "client",
	Name:      "num_server_unsubscribes",
	Help:      "Number of server initiated unsubscribes.",
}, []string{"code"})
```

Collected for each server-side unsubscribe push going to the client.