### PR TITLE
Option to mark positioned clients with insufficient state if publication lag exceeds threshold

### DIFF
--- a/_examples/document_sync/index.html
+++ b/_examples/document_sync/index.html
@@ -31,8 +31,8 @@
                     document += update.increment
                     return document
                 },
-                compareVersion: (publication, currentVersion) => {
-                    const newVersion = publication.data.version;
+                compareVersion: (currentVersion, update) => {
+                    const newVersion = update.version;
                     return newVersion > currentVersion ? newVersion : null;
                 },
                 onChange: (document) => {

--- a/_examples/document_sync/main.go
+++ b/_examples/document_sync/main.go
@@ -15,6 +15,7 @@ import (
 	_ "net/http/pprof"
 
 	"github.com/centrifugal/centrifuge"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // Counter is a document we sync here. Returned when loading full state.
@@ -135,6 +136,7 @@ func main() {
 
 	http.Handle("/connection/websocket", authMiddleware(centrifuge.NewWebsocketHandler(node, centrifuge.WebsocketConfig{})))
 	http.HandleFunc("/api/counter", getCounterHandler)
+	http.Handle("/metrics", promhttp.Handler())
 	http.Handle("/", http.FileServer(http.Dir("./")))
 
 	counter = Counter{Version: 0, Value: 0}

--- a/_examples/document_sync/main.go
+++ b/_examples/document_sync/main.go
@@ -80,27 +80,6 @@ func main() {
 		LogHandler: handleLog,
 	})
 
-	redisShardConfigs := []centrifuge.RedisShardConfig{
-		{Address: "localhost:6379"},
-	}
-	var redisShards []*centrifuge.RedisShard
-	for _, redisConf := range redisShardConfigs {
-		redisShard, err := centrifuge.NewRedisShard(node, redisConf)
-		if err != nil {
-			log.Fatal(err)
-		}
-		redisShards = append(redisShards, redisShard)
-	}
-
-	broker, err := centrifuge.NewRedisBroker(node, centrifuge.RedisBrokerConfig{
-		// And configure a couple of shards to use.
-		Shards: redisShards,
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	node.SetBroker(broker)
-
 	node.OnConnect(func(client *centrifuge.Client) {
 		transport := client.Transport()
 		log.Printf("user %s connected via %s with protocol: %s", client.UserID(), transport.Name(), transport.Protocol())

--- a/_examples/document_sync/main.go
+++ b/_examples/document_sync/main.go
@@ -79,6 +79,27 @@ func main() {
 		LogHandler: handleLog,
 	})
 
+	redisShardConfigs := []centrifuge.RedisShardConfig{
+		{Address: "localhost:6379"},
+	}
+	var redisShards []*centrifuge.RedisShard
+	for _, redisConf := range redisShardConfigs {
+		redisShard, err := centrifuge.NewRedisShard(node, redisConf)
+		if err != nil {
+			log.Fatal(err)
+		}
+		redisShards = append(redisShards, redisShard)
+	}
+
+	broker, err := centrifuge.NewRedisBroker(node, centrifuge.RedisBrokerConfig{
+		// And configure a couple of shards to use.
+		Shards: redisShards,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	node.SetBroker(broker)
+
 	node.OnConnect(func(client *centrifuge.Client) {
 		transport := client.Transport()
 		log.Printf("user %s connected via %s with protocol: %s", client.UserID(), transport.Name(), transport.Protocol())

--- a/_examples/document_sync/rtdocument.js
+++ b/_examples/document_sync/rtdocument.js
@@ -48,7 +48,7 @@ class RealTimeDocument {
                 return;
             }
             // Process new messages immediately if initial state is already loaded.
-            const newVersion = this.#compareVersion(ctx, this.#version);
+            const newVersion = this.#compareVersion(this.#version, ctx.data);
             if (newVersion === null) {
                 this.#debugLog("Skip real-time publication", ctx);
                 return;
@@ -143,7 +143,7 @@ class RealTimeDocument {
 
     #processBufferedMessages() {
         this.#messageBuffer.forEach((msg) => {
-            const newVersion = this.#compareVersion(msg, this.#version);
+            const newVersion = this.#compareVersion(this.#version, msg.data);
             if (newVersion) {
                 this.#document = this.#applyUpdate(this.#document, msg.data);
                 this.#version = newVersion;

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -7,7 +7,7 @@ replace github.com/centrifugal/centrifuge => ../
 require (
 	github.com/FZambia/tarantool v0.2.2
 	github.com/centrifugal/centrifuge v0.8.2
-	github.com/centrifugal/protocol v0.13.2
+	github.com/centrifugal/protocol v0.13.3-0.20240526133111-8024bc1bfade
 	github.com/cristalhq/jwt/v5 v5.4.0
 	github.com/dchest/uniuri v1.2.0
 	github.com/gin-contrib/sessions v0.0.3

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -7,7 +7,7 @@ replace github.com/centrifugal/centrifuge => ../
 require (
 	github.com/FZambia/tarantool v0.2.2
 	github.com/centrifugal/centrifuge v0.8.2
-	github.com/centrifugal/protocol v0.13.3-0.20240526133111-8024bc1bfade
+	github.com/centrifugal/protocol v0.13.3
 	github.com/cristalhq/jwt/v5 v5.4.0
 	github.com/dchest/uniuri v1.2.0
 	github.com/gin-contrib/sessions v0.0.3

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -14,8 +14,8 @@ github.com/bradleypeabody/gorilla-sessions-memcache v0.0.0-20181103040241-659414
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.9.1 h1:6iJ6NqdoxCDr6mbY8h18oSO+cShGSMRGCEo7F2h0x8s=
 github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=
-github.com/centrifugal/protocol v0.13.3-0.20240526133111-8024bc1bfade h1:tFYeacS2QdbhU+A6LfJmc2gItdpU1IZ9dQL1nHJzgc0=
-github.com/centrifugal/protocol v0.13.3-0.20240526133111-8024bc1bfade/go.mod h1:7V5vI30VcoxJe4UD87xi7bOsvI0bmEhvbQuMjrFM2L4=
+github.com/centrifugal/protocol v0.13.3 h1:Ryt5uIYCz5wpJOHc0+L2dC1ty2OQzwdU4TV3pmPOfnA=
+github.com/centrifugal/protocol v0.13.3/go.mod h1:7V5vI30VcoxJe4UD87xi7bOsvI0bmEhvbQuMjrFM2L4=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F32mSOjUmXrMHnKwZdA8wcEefY7UVqBKYGjpdQY=

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -14,8 +14,8 @@ github.com/bradleypeabody/gorilla-sessions-memcache v0.0.0-20181103040241-659414
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.9.1 h1:6iJ6NqdoxCDr6mbY8h18oSO+cShGSMRGCEo7F2h0x8s=
 github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=
-github.com/centrifugal/protocol v0.13.2 h1:LLPp2KZBK++Vr5HDHTG9fMssapucir0qev4YAbjhiqA=
-github.com/centrifugal/protocol v0.13.2/go.mod h1:7V5vI30VcoxJe4UD87xi7bOsvI0bmEhvbQuMjrFM2L4=
+github.com/centrifugal/protocol v0.13.3-0.20240526133111-8024bc1bfade h1:tFYeacS2QdbhU+A6LfJmc2gItdpU1IZ9dQL1nHJzgc0=
+github.com/centrifugal/protocol v0.13.3-0.20240526133111-8024bc1bfade/go.mod h1:7V5vI30VcoxJe4UD87xi7bOsvI0bmEhvbQuMjrFM2L4=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F32mSOjUmXrMHnKwZdA8wcEefY7UVqBKYGjpdQY=

--- a/_examples/unidirectional_grpc/client/main.go
+++ b/_examples/unidirectional_grpc/client/main.go
@@ -17,7 +17,6 @@ var (
 )
 
 func handlePush(push *clientproto.Push) {
-	log.Printf("push received (type %d, channel %s, data %s", push.Type, push.Channel, fmt.Sprintf("%#v", string(push.Data)))
 	if push.Connect != nil {
 		log.Printf("connected to a server with ID: %s", push.Connect.Client)
 	} else if push.Pub != nil {
@@ -25,7 +24,7 @@ func handlePush(push *clientproto.Push) {
 	} else if push.Disconnect != nil {
 		log.Printf("disconnected from a server: %s", push.Disconnect.Reason)
 	} else {
-		log.Println("push type handling not implemented")
+		log.Printf("push type handling not implemented: %v", push)
 	}
 }
 

--- a/broker.go
+++ b/broker.go
@@ -17,6 +17,8 @@ type Publication struct {
 	// Tags contains a map with custom key-values attached to a Publication. Tags map
 	// will be delivered to a client.
 	Tags map[string]string
+	// Optional time of publication as Unix timestamp milliseconds.
+	Time int64
 }
 
 // ClientInfo contains information about client connection.

--- a/broker.go
+++ b/broker.go
@@ -17,7 +17,9 @@ type Publication struct {
 	// Tags contains a map with custom key-values attached to a Publication. Tags map
 	// will be delivered to a client.
 	Tags map[string]string
-	// Optional time of publication as Unix timestamp milliseconds.
+	// Optional time of publication as Unix timestamp milliseconds. At this point
+	// we use it for calculating PUB/SUB time lag, it's not exposed to the client
+	// protocol.
 	Time int64
 }
 

--- a/broker_memory.go
+++ b/broker_memory.go
@@ -104,6 +104,7 @@ func (b *MemoryBroker) Publish(ch string, data []byte, opts PublishOptions) (Str
 		Data: data,
 		Info: opts.ClientInfo,
 		Tags: opts.Tags,
+		Time: time.Now().UnixMilli(),
 	}
 	var prevPub *Publication
 	if opts.HistorySize > 0 && opts.HistoryTTL > 0 {

--- a/broker_redis.go
+++ b/broker_redis.go
@@ -613,6 +613,7 @@ func (b *RedisBroker) publish(s *shardWrapper, ch string, data []byte, opts Publ
 		Data: data,
 		Info: infoToProto(opts.ClientInfo),
 		Tags: opts.Tags,
+		Time: time.Now().UnixMilli(),
 	}
 	if opts.HistorySize <= 0 || opts.HistoryTTL <= 0 {
 		// In no history case we communicate delta flag over Publication field. This field is then

--- a/broker_redis_test.go
+++ b/broker_redis_test.go
@@ -1965,13 +1965,13 @@ func TestParseDeltaPush(t *testing.T) {
 		name           string
 		input          string
 		expectError    bool
-		expectedResult *deltaPublicationPush
+		expectedResult deltaPublicationPush
 	}{
 		{
 			name:        "valid data with colon in payload",
 			input:       "d1:1234567890:epoch1:4:test:18:payload:with:colon",
 			expectError: false,
-			expectedResult: &deltaPublicationPush{
+			expectedResult: deltaPublicationPush{
 				Offset:            1234567890,
 				Epoch:             "epoch1",
 				PrevPayloadLength: 4,
@@ -1984,7 +1984,7 @@ func TestParseDeltaPush(t *testing.T) {
 			name:        "valid data with empty payload",
 			input:       "d1:1234567890:epoch2:0::0:",
 			expectError: false,
-			expectedResult: &deltaPublicationPush{
+			expectedResult: deltaPublicationPush{
 				Offset:            1234567890,
 				Epoch:             "epoch2",
 				PrevPayloadLength: 0,

--- a/config.go
+++ b/config.go
@@ -48,6 +48,10 @@ type Config struct {
 	// will be disconnected with DisconnectInsufficientState.
 	// Zero value means 40 * time.Second.
 	ClientChannelPositionCheckDelay time.Duration
+	// Maximum allowed time lag for publications for subscribers with positioning on.
+	// By default, not used. See also pub_sub_time_lag_seconds as a helpful metric.
+	ClientChannelPositionMaxTimeLag time.Duration
+
 	// ClientQueueMaxSize is a maximum size of client's message queue in
 	// bytes. After this queue size exceeded Centrifuge closes client's connection.
 	// Zero value means 1048576 bytes (1MB).

--- a/config.go
+++ b/config.go
@@ -49,7 +49,9 @@ type Config struct {
 	// Zero value means 40 * time.Second.
 	ClientChannelPositionCheckDelay time.Duration
 	// Maximum allowed time lag for publications for subscribers with positioning on.
-	// By default, not used. See also pub_sub_time_lag_seconds as a helpful metric.
+	// When exceeded we mark connection with insufficient state. By default, not used - i.e.
+	// Centrifuge does not take lag into account for positioning.
+	// See also pub_sub_time_lag_seconds as a helpful metric.
 	ClientChannelPositionMaxTimeLag time.Duration
 
 	// ClientQueueMaxSize is a maximum size of client's message queue in

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/FZambia/eagle v0.1.0
 	github.com/Yiling-J/theine-go v0.3.2
-	github.com/centrifugal/protocol v0.13.2
+	github.com/centrifugal/protocol v0.13.3-0.20240526133111-8024bc1bfade
 	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.19.1
 	github.com/redis/rueidis v1.0.37

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/FZambia/eagle v0.1.0
 	github.com/Yiling-J/theine-go v0.3.2
-	github.com/centrifugal/protocol v0.13.3-0.20240526133111-8024bc1bfade
+	github.com/centrifugal/protocol v0.13.3
 	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.19.1
 	github.com/redis/rueidis v1.0.37

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Yiling-J/theine-go v0.3.2 h1:XcSdMPV9DwBD9gqqSxbBfVJnP8CCiqNSqp3C6Ypm
 github.com/Yiling-J/theine-go v0.3.2/go.mod h1:ygLXqrWPZT/a+PzK5hQ0+a6gu0lpAY5IudTcgnPleqI=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/centrifugal/protocol v0.13.3-0.20240526133111-8024bc1bfade h1:tFYeacS2QdbhU+A6LfJmc2gItdpU1IZ9dQL1nHJzgc0=
-github.com/centrifugal/protocol v0.13.3-0.20240526133111-8024bc1bfade/go.mod h1:7V5vI30VcoxJe4UD87xi7bOsvI0bmEhvbQuMjrFM2L4=
+github.com/centrifugal/protocol v0.13.3 h1:Ryt5uIYCz5wpJOHc0+L2dC1ty2OQzwdU4TV3pmPOfnA=
+github.com/centrifugal/protocol v0.13.3/go.mod h1:7V5vI30VcoxJe4UD87xi7bOsvI0bmEhvbQuMjrFM2L4=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Yiling-J/theine-go v0.3.2 h1:XcSdMPV9DwBD9gqqSxbBfVJnP8CCiqNSqp3C6Ypm
 github.com/Yiling-J/theine-go v0.3.2/go.mod h1:ygLXqrWPZT/a+PzK5hQ0+a6gu0lpAY5IudTcgnPleqI=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/centrifugal/protocol v0.13.2 h1:LLPp2KZBK++Vr5HDHTG9fMssapucir0qev4YAbjhiqA=
-github.com/centrifugal/protocol v0.13.2/go.mod h1:7V5vI30VcoxJe4UD87xi7bOsvI0bmEhvbQuMjrFM2L4=
+github.com/centrifugal/protocol v0.13.3-0.20240526133111-8024bc1bfade h1:tFYeacS2QdbhU+A6LfJmc2gItdpU1IZ9dQL1nHJzgc0=
+github.com/centrifugal/protocol v0.13.3-0.20240526133111-8024bc1bfade/go.mod h1:7V5vI30VcoxJe4UD87xi7bOsvI0bmEhvbQuMjrFM2L4=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/hub_test.go
+++ b/hub_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/centrifugal/centrifuge/internal/convert"
 
 	"github.com/centrifugal/protocol"
@@ -153,7 +155,10 @@ func (t *testTransport) Close(disconnect Disconnect) error {
 }
 
 func TestHub(t *testing.T) {
-	h := newHub(nil)
+	m, err := initMetricsRegistry(prometheus.DefaultRegisterer, "test")
+	require.NoError(t, err)
+
+	h := newHub(nil, m, 0)
 	c, err := newClient(context.Background(), defaultTestNode(), newTestTransport(func() {}))
 	require.NoError(t, err)
 	c.user = "test"
@@ -896,10 +901,12 @@ func TestHubBroadcastLeave(t *testing.T) {
 }
 
 func TestHubShutdown(t *testing.T) {
-	h := newHub(nil)
-	err := h.shutdown(context.Background())
+	m, err := initMetricsRegistry(prometheus.DefaultRegisterer, "test")
 	require.NoError(t, err)
-	h = newHub(nil)
+	h := newHub(nil, m, 0)
+	err = h.shutdown(context.Background())
+	require.NoError(t, err)
+	h = newHub(nil, m, 0)
 	c, err := newClient(context.Background(), defaultTestNode(), newTestTransport(func() {}))
 	require.NoError(t, err)
 	_ = h.add(c)
@@ -914,7 +921,9 @@ func TestHubShutdown(t *testing.T) {
 }
 
 func TestHubSubscriptions(t *testing.T) {
-	h := newHub(nil)
+	m, err := initMetricsRegistry(prometheus.DefaultRegisterer, "test")
+	require.NoError(t, err)
+	h := newHub(nil, m, 0)
 	c, err := newClient(context.Background(), defaultTestNode(), newTestTransport(func() {}))
 	require.NoError(t, err)
 
@@ -955,7 +964,9 @@ func TestHubSubscriptions(t *testing.T) {
 }
 
 func TestUserConnections(t *testing.T) {
-	h := newHub(nil)
+	m, err := initMetricsRegistry(prometheus.DefaultRegisterer, "test")
+	require.NoError(t, err)
+	h := newHub(nil, m, 0)
 	c, err := newClient(context.Background(), defaultTestNode(), newTestTransport(func() {}))
 	require.NoError(t, err)
 	_ = h.add(c)

--- a/node.go
+++ b/node.go
@@ -153,7 +153,6 @@ func New(c Config) (*Node, error) {
 		uid:            uid,
 		nodes:          newNodeRegistry(uid),
 		config:         c,
-		hub:            newHub(lg),
 		startedAt:      time.Now().Unix(),
 		shutdownCh:     make(chan struct{}),
 		logger:         lg,
@@ -173,6 +172,8 @@ func New(c Config) (*Node, error) {
 	} else {
 		n.metrics = m
 	}
+
+	n.hub = newHub(lg, n.metrics, c.ClientChannelPositionMaxTimeLag.Milliseconds())
 
 	b, err := NewMemoryBroker(n, MemoryBrokerConfig{})
 	if err != nil {
@@ -1253,6 +1254,7 @@ func pubFromProto(pub *protocol.Publication) *Publication {
 		Data:   pub.Data,
 		Info:   infoFromProto(pub.GetInfo()),
 		Tags:   pub.GetTags(),
+		Time:   pub.Time,
 	}
 }
 

--- a/node_test.go
+++ b/node_test.go
@@ -183,8 +183,9 @@ func nodeWithPresenceManager(presenceManager PresenceManager) *Node {
 
 func defaultNodeNoHandlers() *Node {
 	n, err := New(Config{
-		LogLevel:   LogLevelTrace,
-		LogHandler: func(entry LogEntry) {},
+		LogLevel:                        LogLevelTrace,
+		LogHandler:                      func(entry LogEntry) {},
+		ClientChannelPositionMaxTimeLag: 5 * time.Second,
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
In this PR we do not mark positioned clients with insufficient state upon receiving publication with the correct epoch but smaller offset.

We also introduce `ClientChannelPositionMaxTimeLag` option to mark positioned clients with insufficient state if publication lag exceeds threshold.

Also a histogram to monitor the time lag - time since publish till processing in Node's hub.