### PR TITLE
Skip useless delta updates – send full payload instead

### DIFF
--- a/client.go
+++ b/client.go
@@ -3038,24 +3038,21 @@ func (c *Client) makeRecoveredPubsDeltaFossil(recoveredPubs []*protocol.Publicat
 	if len(recoveredPubs) > 1 {
 		for i, pub := range recoveredPubs[1:] {
 			patch := fdelta.Create(prevPub.Data, pub.Data)
-			var deltaPub *protocol.Publication
+			delta := true
+			deltaData := patch
+			if len(patch) >= len(pub.Data) {
+				delta = false
+				deltaData = pub.Data
+			}
 			if c.transport.Protocol() == ProtocolTypeJSON {
-				// For JSON case we need to use JSON string (js) for patch.
-				deltaPub = &protocol.Publication{
-					Offset: pub.Offset,
-					Data:   json.Escape(convert.BytesToString(patch)),
-					Info:   pub.Info,
-					Tags:   pub.Tags,
-					Delta:  true,
-				}
-			} else {
-				deltaPub = &protocol.Publication{
-					Offset: pub.Offset,
-					Data:   patch,
-					Info:   pub.Info,
-					Tags:   pub.Tags,
-					Delta:  true,
-				}
+				deltaData = json.Escape(convert.BytesToString(deltaData))
+			}
+			deltaPub := &protocol.Publication{
+				Offset: pub.Offset,
+				Data:   deltaData,
+				Info:   pub.Info,
+				Tags:   pub.Tags,
+				Delta:  delta,
 			}
 			recoveredPubs[i+1] = deltaPub
 			prevPub = recoveredPubs[i]

--- a/hub.go
+++ b/hub.go
@@ -582,22 +582,21 @@ func getDeltaPub(prevPub *Publication, fullPub *protocol.Publication, key prepar
 	deltaPub := fullPub
 	if prevPub != nil && key.DeltaType == DeltaTypeFossil {
 		patch := fdelta.Create(prevPub.Data, fullPub.Data)
+		delta := true
+		deltaData := patch
+		if len(patch) >= len(fullPub.Data) {
+			delta = false
+			deltaData = fullPub.Data
+		}
 		if key.ProtocolType == protocol.TypeJSON {
-			deltaPub = &protocol.Publication{
-				Offset: fullPub.Offset,
-				Data:   json.Escape(convert.BytesToString(patch)),
-				Info:   fullPub.Info,
-				Tags:   fullPub.Tags,
-				Delta:  true,
-			}
-		} else {
-			deltaPub = &protocol.Publication{
-				Offset: fullPub.Offset,
-				Data:   patch,
-				Info:   fullPub.Info,
-				Tags:   fullPub.Tags,
-				Delta:  true,
-			}
+			deltaData = json.Escape(convert.BytesToString(deltaData))
+		}
+		deltaPub = &protocol.Publication{
+			Offset: fullPub.Offset,
+			Data:   deltaData,
+			Info:   fullPub.Info,
+			Tags:   fullPub.Tags,
+			Delta:  delta,
 		}
 	} else if prevPub == nil && key.ProtocolType == protocol.TypeJSON && key.DeltaType == DeltaTypeFossil {
 		// In JSON and Fossil case we need to send full state in JSON string format.


### PR DESCRIPTION
If the size of delta patch is greater than full publication payload – skip sending delta, just use the full payload.