### PR TITLE
Handle evicted meta key scenario

### DIFF
--- a/internal/redis_lua/broker_history_add_stream.lua
+++ b/internal/redis_lua/broker_history_add_stream.lua
@@ -49,7 +49,20 @@ if use_delta == "1" then
     end
 end
 
-redis.call("xadd", stream_key, "MAXLEN", stream_size, top_offset, "d", message_payload)
+local had_error = false
+
+local status, _ = pcall(function()
+    return redis.call("xadd", stream_key, "MAXLEN", stream_size, top_offset, "d", message_payload)
+end)
+if current_epoch == new_epoch_if_empty and not status then
+    -- If an error occurred, delete the stream and re-add the message, this may happen when
+    -- meta key is evicted by Redis LRU/LFU strategies and the error like "The ID specified
+    -- in XADD is equal or smaller than the target stream top item" is returned. Clients will
+    -- be unsubscribed with the insufficent state in this case.
+    prev_message_payload = ""
+    redis.call("del", stream_key)
+    redis.call("xadd", stream_key, "MAXLEN", stream_size, top_offset, "d", message_payload)
+end
 redis.call("expire", stream_key, stream_ttl)
 
 if channel ~= '' then

--- a/internal/redis_lua/broker_history_add_stream.lua
+++ b/internal/redis_lua/broker_history_add_stream.lua
@@ -49,8 +49,6 @@ if use_delta == "1" then
     end
 end
 
-local had_error = false
-
 local status, _ = pcall(function()
     return redis.call("xadd", stream_key, "MAXLEN", stream_size, top_offset, "d", message_payload)
 end)

--- a/internal/redis_lua/broker_history_add_stream.lua
+++ b/internal/redis_lua/broker_history_add_stream.lua
@@ -32,7 +32,7 @@ if meta_expire ~= '0' then
 end
 
 local prev_message_payload = ""
-if use_delta == "1" and current_epoch ~= new_epoch_if_empty then
+if use_delta == "1" and top_offset ~= 1 then
     local prev_entries = redis.call("xrevrange", stream_key, "+", "-", "COUNT", 1)
     if #prev_entries > 0 then
         prev_message_payload = prev_entries[1][2]["d"]
@@ -49,7 +49,7 @@ if use_delta == "1" and current_epoch ~= new_epoch_if_empty then
     end
 end
 
-if current_epoch == new_epoch_if_empty then
+if top_offset == 1 then
     -- If a new epoch starts, try to delete existing stream, this may be important when
     -- meta key is evicted by Redis LRU/LFU strategies. So we emulating eviction of stream key
     -- here to keep meta key and stream keys consistent.


### PR DESCRIPTION
Relates https://github.com/centrifugal/centrifugo/issues/888

Currently when stream meta key not found (evicted by LRU/LFU strategies), Centrifuge returns an error:

```
The ID specified in XADD is equal or smaller than the target stream top item
```

Until stream expires. We handle this scenario here by deleting current stream - clients with recovery/positioning will be unsubscribed with insufficient state reason (because epoch changes).
