### PR TITLE
Unidirectional connect without automatic error to disconnect transform

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,3 +8,4 @@ ignore:
   - "internal/controlpb/control*"  # generated code
   - "client_experimental.go"  # experimental code
   - "internal/websocket/*"  # embedded Gorilla WebSocket fork
+  - "internal/websocket/examples/autobahn/*"  # embedded Gorilla WebSocket fork

--- a/broker_memory_test.go
+++ b/broker_memory_test.go
@@ -588,6 +588,11 @@ func TestClientSubscribeRecover(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			node := defaultNodeNoHandlers()
 			node.config.RecoveryMaxPublicationLimit = tt.Limit
+
+			node.OnCacheEmpty(func(event CacheEmptyEvent) (CacheEmptyReply, error) {
+				return CacheEmptyReply{}, nil
+			})
+
 			node.OnConnect(func(client *Client) {
 				client.OnSubscribe(func(event SubscribeEvent, cb SubscribeCallback) {
 					opts := SubscribeOptions{EnableRecovery: true, RecoveryMode: tt.RecoveryMode}

--- a/client.go
+++ b/client.go
@@ -343,7 +343,8 @@ func (c *Client) Connect(req ConnectRequest) {
 
 // ConnectNoErrorToDisconnect is the same as Client.Connect but does not try to extract
 // Disconnect code from the error returned by the connect logic, instead it just returns
-// the error to the caller. This error must be handled by the caller on the Transport level.
+// the error to the caller. This error must be handled by the caller on the Transport level,
+// and the connection must be closed on Transport level upon receiving an error.
 func (c *Client) ConnectNoErrorToDisconnect(req ConnectRequest) error {
 	return c.unidirectionalConnect(req.toProto(), 0, false)
 }

--- a/client.go
+++ b/client.go
@@ -353,10 +353,14 @@ func (c *Client) getDisconnectPushReply(d Disconnect) ([]byte, error) {
 		Code:   d.Code,
 		Reason: d.Reason,
 	}
+	push := &protocol.Push{
+		Disconnect: disconnect,
+	}
+	if c.node.LogEnabled(LogLevelTrace) {
+		c.traceOutPush(push)
+	}
 	return c.encodeReply(&protocol.Reply{
-		Push: &protocol.Push{
-			Disconnect: disconnect,
-		},
+		Push: push,
 	})
 }
 
@@ -2446,6 +2450,9 @@ func (c *Client) connectCmd(req *protocol.ConnectRequest, cmd *protocol.Command,
 				return nil, DisconnectServerError
 			}
 			c.writeEncodedPush(protoReply, rw, "", protocol.FrameTypePushConnect)
+			if c.node.LogEnabled(LogLevelTrace) {
+				c.traceOutPush(&protocol.Push{Connect: protoReply.Push.Connect})
+			}
 		}
 	} else {
 		protoReply, err := c.getConnectCommandReply(res)
@@ -2642,11 +2649,15 @@ func (c *Client) getSubscribePushReply(channel string, res *protocol.SubscribeRe
 		Positioned:  res.GetPositioned(),
 		Data:        res.Data,
 	}
+	push := &protocol.Push{
+		Channel:   channel,
+		Subscribe: sub,
+	}
+	if c.node.LogEnabled(LogLevelTrace) {
+		c.traceOutPush(push)
+	}
 	return c.encodeReply(&protocol.Reply{
-		Push: &protocol.Push{
-			Channel:   channel,
-			Subscribe: sub,
-		},
+		Push: push,
 	})
 }
 

--- a/client.go
+++ b/client.go
@@ -330,7 +330,7 @@ func extractUnidirectionalDisconnect(err error) Disconnect {
 	}
 }
 
-// UnidirectionalConnect supposed to be called only from a unidirectional transport layer
+// Connect supposed to be called only from a unidirectional transport layer
 // to pass initial information about connection and thus initiate Node.OnConnecting
 // event. Bidirectional transport initiate connecting workflow automatically
 // since client passes Connect command upon successful connection establishment
@@ -343,8 +343,8 @@ func (c *Client) Connect(req ConnectRequest) {
 
 // ConnectNoDisconnect is the same as Client.Connect but does not try to extract Disconnect
 // code from the error returned by the connect logic, instead it just returns the error
-// to the caller. This error must be handled on the Transport level.
-func (c *Client) ConnectWithoutDisconnect(req ConnectRequest) error {
+// to the caller. This error must be handled by the caller on the Transport level.
+func (c *Client) ConnectNoDisconnect(req ConnectRequest) error {
 	return c.unidirectionalConnect(req.toProto(), 0, false)
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -3985,7 +3985,7 @@ func TestClientUnsubscribeDuringSubscribeCorrectChannels(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestClientConnectNoDisconnect(t *testing.T) {
+func TestClientConnectNoErrorToDisconnect(t *testing.T) {
 	t.Parallel()
 	errBoom := errors.New("boom")
 
@@ -4011,7 +4011,7 @@ func TestClientConnectNoDisconnect(t *testing.T) {
 			ctx := context.Background()
 			newCtx := SetCredentials(ctx, &Credentials{UserID: "42"})
 			client, _ := newClient(newCtx, node, transport)
-			err := client.ConnectNoDisconnect(ConnectRequest{})
+			err := client.ConnectNoErrorToDisconnect(ConnectRequest{})
 			require.Equal(t, tt.Err, err)
 		})
 	}

--- a/events.go
+++ b/events.go
@@ -466,11 +466,11 @@ type CommandProcessedEvent struct {
 	// Error may be set to non-nil if Command processing resulted into error.
 	Error error
 	// Reply to the command. Reply may be pooled - see comment of CommandProcessedEvent.
-	// This Reply may be nil in the following cases:
+	// This Reply may be nil, for example in the following cases:
 	// 1. For Send command since send commands do not have replies
-	// 2. When Disconnect field of CommandProcessedEvent is not nil
-	// 3. When unidirectional transport connects (we create Connect Command artificially
-	// with id: 1 and we never send replies to unidirectional transport, only pushes).
+	// 2. When command processing resulted into disconnection of the client without sending a reply.
+	// 3. When unidirectional transport connects (Centrifuge creates Connect Command artificially
+	//    with id: 1 and never sends replies to the unidirectional transport, only pushes).
 	Reply *protocol.Reply
 	// Started is a time command was passed to Client for processing.
 	Started time.Time

--- a/events.go
+++ b/events.go
@@ -463,8 +463,8 @@ type CommandReadHandler func(*Client, CommandReadEvent) error
 type CommandProcessedEvent struct {
 	// Command which was processed. May be pooled - see comment of CommandProcessedEvent.
 	Command *protocol.Command
-	// Disconnect may be set if Command processing resulted into disconnection.
-	Disconnect *Disconnect
+	// Error may be set to non-nil if Command processing resulted into error.
+	Error error
 	// Reply to the command. Reply may be pooled - see comment of CommandProcessedEvent.
 	// This Reply may be nil in the following cases:
 	// 1. For Send command since send commands do not have replies
@@ -477,8 +477,8 @@ type CommandProcessedEvent struct {
 }
 
 // newCommandProcessedEvent is a helper to create CommandProcessedEvent.
-func newCommandProcessedEvent(command *protocol.Command, disconnect *Disconnect, reply *protocol.Reply, started time.Time) CommandProcessedEvent {
-	return CommandProcessedEvent{Command: command, Disconnect: disconnect, Reply: reply, Started: started}
+func newCommandProcessedEvent(command *protocol.Command, err error, reply *protocol.Reply, started time.Time) CommandProcessedEvent {
+	return CommandProcessedEvent{Command: command, Error: err, Reply: reply, Started: started}
 }
 
 // CommandProcessedHandler allows setting a callback which will be called after

--- a/handler_http_stream_test.go
+++ b/handler_http_stream_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -57,6 +58,56 @@ func TestHTTPStreamHandler(t *testing.T) {
 		require.NoError(t, err)
 		var reply protocol.Reply
 		err = json.Unmarshal(msg, &reply)
+		require.NoError(t, err)
+		require.NotNil(t, reply.Connect)
+		require.Equal(t, uint32(1), reply.Id)
+		require.NotZero(t, reply.Connect.Session)
+		require.NotZero(t, reply.Connect.Node)
+		break
+	}
+}
+
+func TestHTTPStreamHandler_Protobuf(t *testing.T) {
+	t.Parallel()
+	n, _ := New(Config{
+		LogLevel: LogLevelDebug,
+	})
+
+	n.OnConnecting(func(ctx context.Context, event ConnectEvent) (ConnectReply, error) {
+		return ConnectReply{Credentials: &Credentials{
+			UserID: "test",
+		}}, nil
+	})
+
+	require.NoError(t, n.Run())
+	defer func() { _ = n.Shutdown(context.Background()) }()
+	mux := http.NewServeMux()
+	mux.Handle("/connection/http_stream", NewHTTPStreamHandler(n, HTTPStreamConfig{}))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	url := server.URL + "/connection/http_stream"
+	client := &http.Client{Timeout: 5 * time.Second}
+	command := &protocol.Command{
+		Id:      1,
+		Connect: &protocol.ConnectRequest{},
+	}
+	enc := protocol.NewProtobufCommandEncoder()
+	protoData, err := enc.Encode(command)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(protoData))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	defer func() { _ = resp.Body.Close() }()
+
+	dec := newProtobufStreamCommandDecoder(resp.Body)
+	for {
+		reply, _, err := dec.decode()
 		require.NoError(t, err)
 		require.NotNil(t, reply.Connect)
 		require.Equal(t, uint32(1), reply.Id)
@@ -129,4 +180,34 @@ type jsonStreamDecoder struct {
 func (d *jsonStreamDecoder) decode() ([]byte, error) {
 	line, _, err := d.r.ReadLine()
 	return line, err
+}
+
+type protobufStreamCommandDecoder struct {
+	reader *bufio.Reader
+}
+
+func newProtobufStreamCommandDecoder(reader io.Reader) *protobufStreamCommandDecoder {
+	return &protobufStreamCommandDecoder{reader: bufio.NewReader(reader)}
+}
+
+func (d *protobufStreamCommandDecoder) decode() (*protocol.Reply, int, error) {
+	msgLength, err := binary.ReadUvarint(d.reader)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	b := make([]byte, msgLength)
+	n, err := io.ReadFull(d.reader, b)
+	if err != nil {
+		return nil, 0, err
+	}
+	if uint64(n) != msgLength {
+		return nil, 0, io.ErrShortBuffer
+	}
+	var c protocol.Reply
+	err = c.UnmarshalVT(b[:int(msgLength)])
+	if err != nil {
+		return nil, 0, err
+	}
+	return &c, int(msgLength) + 8, nil
 }


### PR DESCRIPTION
Now `.Connect` method automatically transforms any error to client protocol disconnect code. Sometimes though we want to postpone error processing, for example if we want to return some special status code in HTTP-based unidirectional transports. This PR adds `.ConnectNoErrorToDisconnect` method to let the caller process the error itself.

`CommandProcessedHandler` now accepts original error inside `CommandProcessedEvent` returned from processing instead of `*Disconnect`.