### PR TITLE
Channel namespace resolution for all metrics

### DIFF
--- a/_examples/chat_json/main.go
+++ b/_examples/chat_json/main.go
@@ -72,11 +72,6 @@ func main() {
 		LogLevel:       centrifuge.LogLevelInfo,
 		LogHandler:     handleLog,
 		HistoryMetaTTL: 24 * time.Hour,
-		Metrics: centrifuge.MetricsConfig{
-			GetChannelNamespaceLabel: func(channel string) string {
-				return channel
-			},
-		},
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/_examples/chat_json/main.go
+++ b/_examples/chat_json/main.go
@@ -68,11 +68,19 @@ func channelSubscribeAllowed(channel string) bool {
 }
 
 func main() {
-	node, _ := centrifuge.New(centrifuge.Config{
+	node, err := centrifuge.New(centrifuge.Config{
 		LogLevel:       centrifuge.LogLevelInfo,
 		LogHandler:     handleLog,
 		HistoryMetaTTL: 24 * time.Hour,
+		Metrics: centrifuge.MetricsConfig{
+			GetChannelNamespaceLabel: func(channel string) string {
+				return channel
+			},
+		},
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	node.OnConnecting(func(ctx context.Context, e centrifuge.ConnectEvent) (centrifuge.ConnectReply, error) {
 		cred, _ := centrifuge.GetCredentials(ctx)

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -1,8 +1,6 @@
 module github.com/centrifugal/centrifuge/_examples
 
-go 1.23
-
-toolchain go1.23.3
+go 1.21
 
 replace github.com/centrifugal/centrifuge => ../
 

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -1,6 +1,8 @@
 module github.com/centrifugal/centrifuge/_examples
 
-go 1.21
+go 1.23
+
+toolchain go1.23.3
 
 replace github.com/centrifugal/centrifuge => ../
 

--- a/broker_redis.go
+++ b/broker_redis.go
@@ -254,13 +254,13 @@ func (b *RedisBroker) getShard(channel string) *shardWrapper {
 // Run – see Broker.Run.
 func (b *RedisBroker) Run(h BrokerEventHandler) error {
 	// Run all shards.
-	for shardNum, shardWrapper := range b.shards {
-		err := b.runShard(shardWrapper, h)
+	for _, wrapper := range b.shards {
+		err := b.runShard(wrapper, h)
 		if err != nil {
 			return err
 		}
-		if err := b.checkCapabilities(shardWrapper.shard); err != nil {
-			return fmt.Errorf("capability error on shard [%d]: %v", shardNum, err)
+		if err := b.checkCapabilities(wrapper.shard); err != nil {
+			return fmt.Errorf("capability error on shard [%s]: %v", wrapper.shard.string(), err)
 		}
 	}
 	for i := 0; i < len(b.shards); i++ {
@@ -396,6 +396,7 @@ func (b *RedisBroker) runControlPubSub(s *RedisShard, eventHandler BrokerEventHa
 				case msg := <-workCh:
 					err := eventHandler.HandleControl(convert.StringToBytes(msg.Message))
 					if err != nil {
+						b.node.metrics.redisBrokerPubSubErrors.WithLabelValues("handle_control_message").Inc()
 						b.node.Log(NewLogEntry(LogLevelError, "error handling control message", map[string]any{"error": err.Error()}))
 					}
 				}
@@ -415,7 +416,8 @@ func (b *RedisBroker) runControlPubSub(s *RedisShard, eventHandler BrokerEventHa
 	err := conn.Do(context.Background(), conn.B().Subscribe().Channel(controlChannel, nodeChannel).Build()).Error()
 	if err != nil {
 		startOnce(err)
-		b.node.Log(NewLogEntry(LogLevelError, "control pub/sub error", map[string]any{"error": err.Error()}))
+		b.node.metrics.incRedisBrokerPubSubErrors("subscribe_control_channel")
+		b.node.Log(NewLogEntry(LogLevelError, "control pub/sub subscribe error", map[string]any{"error": err.Error(), "shard": s.string()}))
 		return
 	}
 
@@ -424,7 +426,8 @@ func (b *RedisBroker) runControlPubSub(s *RedisShard, eventHandler BrokerEventHa
 	select {
 	case err := <-wait:
 		if err != nil {
-			b.node.Log(NewLogEntry(LogLevelError, "control pub/sub error", map[string]any{"error": err.Error()}))
+			b.node.metrics.incRedisBrokerPubSubErrors("control_connection")
+			b.node.Log(NewLogEntry(LogLevelError, "control pub/sub connection error", map[string]any{"error": err.Error(), "shard": s.string()}))
 		}
 	case <-s.closeCh:
 	}
@@ -434,10 +437,13 @@ func (b *RedisBroker) runPubSub(s *shardWrapper, eventHandler BrokerEventHandler
 	numProcessors := b.config.numPubSubProcessors
 	numSubscribers := b.config.numPubSubSubscribers
 
+	shardChannel := string(b.pubSubShardChannelID(clusterShardIndex, psShardIndex, useShardedPubSub))
+
 	if b.node.LogEnabled(LogLevelDebug) {
 		logValues := map[string]any{
-			"shard":         s.shard.string(),
-			"numProcessors": numProcessors,
+			"shard":          s.shard.string(),
+			"num_processors": numProcessors,
+			"pub_sub_shard":  shardChannel,
 		}
 		if useShardedPubSub {
 			logValues["clusterShardIndex"] = clusterShardIndex
@@ -470,7 +476,8 @@ func (b *RedisBroker) runPubSub(s *shardWrapper, eventHandler BrokerEventHandler
 				case msg := <-ch:
 					err := b.handleRedisClientMessage(eventHandler, channelID(msg.Channel), convert.StringToBytes(msg.Message))
 					if err != nil {
-						b.node.Log(NewLogEntry(LogLevelError, "error handling client message", map[string]any{"error": err.Error()}))
+						b.node.metrics.incRedisBrokerPubSubErrors("handle_client_message")
+						b.node.Log(NewLogEntry(LogLevelError, "error handling client message", map[string]any{"error": err.Error(), "pub_sub_shard": shardChannel}))
 						continue
 					}
 				}
@@ -482,8 +489,6 @@ func (b *RedisBroker) runPubSub(s *shardWrapper, eventHandler BrokerEventHandler
 	defer cancel()
 	defer conn.Close()
 
-	shardChannel := string(b.pubSubShardChannelID(clusterShardIndex, psShardIndex, useShardedPubSub))
-
 	wait := conn.SetPubSubHooks(rueidis.PubSubHooks{
 		OnMessage: func(msg rueidis.PubSubMessage) {
 			select {
@@ -491,12 +496,13 @@ func (b *RedisBroker) runPubSub(s *shardWrapper, eventHandler BrokerEventHandler
 			case <-done:
 			}
 		},
-		OnSubscription: func(s rueidis.PubSubSubscription) {
+		OnSubscription: func(ps rueidis.PubSubSubscription) {
 			if !useShardedPubSub {
 				return
 			}
-			if s.Kind == "sunsubscribe" && s.Channel == shardChannel {
+			if ps.Kind == "sunsubscribe" && ps.Channel == shardChannel {
 				// Helps to handle slot migration.
+				b.node.Log(NewLogEntry(LogLevelInfo, "pub/sub restart due to slot migration", map[string]any{"pub_sub_shard": shardChannel, "shard": s.shard.string()}))
 				closeDoneOnce()
 			}
 		},
@@ -510,7 +516,8 @@ func (b *RedisBroker) runPubSub(s *shardWrapper, eventHandler BrokerEventHandler
 	}
 	if err != nil {
 		startOnce(err)
-		b.node.Log(NewLogEntry(LogLevelError, "pub/sub error", map[string]any{"error": err.Error()}))
+		b.node.metrics.incRedisBrokerPubSubErrors("subscribe_shard_channel")
+		b.node.Log(NewLogEntry(LogLevelError, "pub/sub subscribe error", map[string]any{"error": err.Error(), "shard": s.shard.string(), "pub_sub_shard": shardChannel}))
 		return
 	}
 
@@ -548,7 +555,7 @@ func (b *RedisBroker) runPubSub(s *shardWrapper, eventHandler BrokerEventHandler
 				if len(batch) > 0 && i%redisSubscribeBatchLimit == 0 {
 					err := subscribeBatch(batch)
 					if err != nil {
-						b.node.Log(NewLogEntry(LogLevelError, "error subscribing", map[string]any{"error": err.Error()}))
+						b.node.Log(NewLogEntry(LogLevelError, "error subscribing", map[string]any{"error": err.Error(), "shard": s.shard.string(), "pub_sub_shard": shardChannel}))
 						closeDoneOnce()
 						return
 					}
@@ -559,7 +566,8 @@ func (b *RedisBroker) runPubSub(s *shardWrapper, eventHandler BrokerEventHandler
 			if len(batch) > 0 {
 				err := subscribeBatch(batch)
 				if err != nil {
-					b.node.Log(NewLogEntry(LogLevelError, "error subscribing", map[string]any{"error": err.Error()}))
+					b.node.metrics.incRedisBrokerPubSubErrors("subscribe_channel")
+					b.node.Log(NewLogEntry(LogLevelError, "error subscribing", map[string]any{"error": err.Error(), "shard": s.shard.string(), "pub_sub_shard": shardChannel}))
 					closeDoneOnce()
 					return
 				}
@@ -570,7 +578,7 @@ func (b *RedisBroker) runPubSub(s *shardWrapper, eventHandler BrokerEventHandler
 	go func() {
 		wg.Wait()
 		if len(channels) > 0 && b.node.LogEnabled(LogLevelDebug) {
-			b.node.Log(NewLogEntry(LogLevelDebug, "resubscribed to channels", map[string]any{"elapsed": time.Since(started).String(), "numChannels": len(channels)}))
+			b.node.Log(NewLogEntry(LogLevelDebug, "resubscribed to channels", map[string]any{"elapsed": time.Since(started).String(), "num_channels": len(channels), "shard": s.shard.string(), "pub_sub_shard": shardChannel}))
 		}
 		select {
 		case <-done:
@@ -593,7 +601,8 @@ func (b *RedisBroker) runPubSub(s *shardWrapper, eventHandler BrokerEventHandler
 	case err := <-wait:
 		startOnce(err)
 		if err != nil {
-			b.node.Log(NewLogEntry(LogLevelError, "pub/sub error", map[string]any{"error": err.Error()}))
+			b.node.metrics.incRedisBrokerPubSubErrors("connection")
+			b.node.Log(NewLogEntry(LogLevelError, "pub/sub connection error", map[string]any{"error": err.Error(), "shard": s.shard.string(), "pub_sub_shard": shardChannel}))
 		}
 	case <-s.shard.closeCh:
 	}

--- a/broker_redis_test.go
+++ b/broker_redis_test.go
@@ -2070,7 +2070,7 @@ func TestParseDeltaPush(t *testing.T) {
 // 1000 streams with 200 messages in each stream, each message 500 bytes => 121MB in Redis.
 // 1000 streams with 400 messages in each stream, each message 500 bytes => 242MB in Redis.
 func TestRedisMemoryUsage(t *testing.T) {
-	//t.Skip()
+	t.Skip()
 	numStreams := 1000
 	numMessagesInStream := 400
 	messageSizeBytes := 500

--- a/broker_redis_test.go
+++ b/broker_redis_test.go
@@ -1590,9 +1590,10 @@ func BenchmarkRedisRecover_1Ch(b *testing.B) {
 			broker := newTestRedisBroker(b, node, tt.UseStreams, tt.UseCluster, tt.Port)
 			defer func() { _ = node.Shutdown(context.Background()) }()
 			defer stopRedisBroker(broker)
-			rawData := []byte("{}")
-			numMessages := 1000
-			numMissing := 5
+			rawData := []byte(randString(800))
+
+			numMessages := 10
+			numMissing := 10
 			for i := 1; i <= numMessages; i++ {
 				_, _, err := broker.Publish("channel", rawData, PublishOptions{HistorySize: numMessages, HistoryTTL: 300 * time.Second})
 				require.NoError(b, err)
@@ -2059,6 +2060,35 @@ func TestParseDeltaPush(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedResult, result)
+			}
+		})
+	}
+}
+
+// 1000 streams with 100 messages in each stream, each message 500 bytes => 63MB in Redis.
+// 2000 streams with 100 messages in each stream, each message 500 bytes => 126MB in Redis.
+// 1000 streams with 200 messages in each stream, each message 500 bytes => 121MB in Redis.
+// 1000 streams with 400 messages in each stream, each message 500 bytes => 242MB in Redis.
+func TestRedisMemoryUsage(t *testing.T) {
+	//t.Skip()
+	numStreams := 1000
+	numMessagesInStream := 400
+	messageSizeBytes := 500
+	for _, tt := range historyRedisTests {
+		t.Run(tt.Name, func(t *testing.T) {
+			node := testNode(t)
+			broker := newTestRedisBroker(t, node, tt.UseStreams, tt.UseCluster, tt.Port)
+			defer func() { _ = node.Shutdown(context.Background()) }()
+			defer stopRedisBroker(broker)
+			rawData := []byte(randString(messageSizeBytes))
+			for i := 0; i < numStreams; i++ {
+				for j := 0; j < numMessagesInStream; j++ {
+					_, _, err := broker.Publish("channel"+strconv.Itoa(i), rawData, PublishOptions{
+						HistorySize: numMessagesInStream,
+						HistoryTTL:  100 * time.Second,
+					})
+					require.NoError(t, err)
+				}
 			}
 		})
 	}

--- a/config.go
+++ b/config.go
@@ -2,6 +2,8 @@ package centrifuge
 
 import (
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Config contains Node configuration options.
@@ -53,7 +55,6 @@ type Config struct {
 	// Centrifuge does not take lag into account for positioning.
 	// See also pub_sub_time_lag_seconds as a helpful metric.
 	ClientChannelPositionMaxTimeLag time.Duration
-
 	// ClientQueueMaxSize is a maximum size of client's message queue in
 	// bytes. After this queue size exceeded Centrifuge closes client's connection.
 	// Zero value means 1048576 bytes (1MB).
@@ -99,31 +100,12 @@ type Config struct {
 	// When zero Centrifuge uses default 30 days which we believe is more than enough
 	// for most use cases.
 	HistoryMetaTTL time.Duration
-
-	// MetricsNamespace is a Prometheus metrics namespace to use for internal metrics.
-	// If not set then the default namespace name "centrifuge" will be used.
-	MetricsNamespace string
-	// GetChannelNamespaceLabel if set will be used by Centrifuge to extract channel_namespace
-	// label for some channel related metrics. Make sure to maintain low cardinality of returned
-	// values to avoid issues with Prometheus performance. This function may introduce sufficient
-	// overhead since it's called in hot paths - so it should be fast. Usage of this function for
-	// specific metrics must be enabled over ChannelNamespaceLabelForTransportMessagesSent and
-	// ChannelNamespaceLabelForTransportMessagesReceived options.
-	GetChannelNamespaceLabel func(channel string) string
-	// ChannelNamespaceLabelForTransportMessagesSent enables using GetChannelNamespaceLabel
-	// function for extracting channel_namespace label for transport_messages_sent and
-	// transport_messages_sent_size.
-	ChannelNamespaceLabelForTransportMessagesSent bool
-	// ChannelNamespaceLabelForTransportMessagesReceived enables using GetChannelNamespaceLabel
-	// function for extracting channel_namespace label for transport_messages_received and
-	// transport_messages_received_size.
-	ChannelNamespaceLabelForTransportMessagesReceived bool
-
+	// Metrics is MetricsConfig to configure Prometheus metrics provided by Centrifuge.
+	Metrics MetricsConfig
 	// GetChannelMediumOptions is a way to provide ChannelMediumOptions for specific channel.
 	// This function is called each time new channel appears on the Node.
 	// See the doc comment for ChannelMediumOptions for more details about channel medium concept.
 	GetChannelMediumOptions func(channel string) ChannelMediumOptions
-
 	// GetBroker when set allows returning a custom Broker to use for a specific channel. If not set
 	// then the default Node's Broker is always used for all channels. Also, Node's default Broker is
 	// always used for control channels. It's the responsibility of an application to call Broker.Run
@@ -155,6 +137,38 @@ const (
 	// considered actual.
 	nodeInfoMaxDelay = nodeInfoPublishInterval*2 + time.Second
 )
+
+// RegistererGatherer defines an interface that combines Registerer and Gatherer from Prometheus.
+// Prometheus Registry implements both interfaces.
+type RegistererGatherer interface {
+	prometheus.Registerer
+	prometheus.Gatherer
+}
+
+type MetricsConfig struct {
+	// MetricsNamespace is a Prometheus metrics namespace to use for Centrifuge metrics.
+	// If not set then the default metrics namespace name "centrifuge" will be used.
+	MetricsNamespace string
+	// RegistererGatherer is a Prometheus registerer and gatherer. If not set then a
+	// prometheus.DefaultRegisterer and prometheus.DefaultGatherer will be used.
+	RegistererGatherer RegistererGatherer
+
+	// GetChannelNamespaceLabel if set will be used by Centrifuge to extract channel_namespace
+	// label for channel related metrics. Make sure to maintain low cardinality of returned values
+	// to avoid issues with Prometheus performance. This function may introduce sufficient overhead
+	// since it's called in hot paths - so it should be fast. By default, Centrifuge uses cache
+	// of resolved channel namespace labels to avoid calling this function too often. See below
+	// ChannelNamespaceCacheSize and ChannelNamespaceCacheTTL options to tweak the cache behavior.
+	GetChannelNamespaceLabel func(channel string) string
+	// ChannelNamespaceCacheSize sets the size of the cache for channel namespace label resolution.
+	// Zero value will use cache size equal to 4096. Set -1 to disable cache (in that case make sure
+	// your GetChannelNamespaceLabel is fast and ideally does not allocate because it's called in hot
+	// paths).
+	ChannelNamespaceCacheSize int
+	// ChannelNamespaceCacheTTL sets the time after which resolved channel namespace for a channel
+	// will expire in the cache. If zero – default TTL 10 seconds is used.
+	ChannelNamespaceCacheTTL time.Duration
+}
 
 // PingPongConfig allows configuring application level ping-pong behavior.
 // Note that in current implementation PingPongConfig.PingInterval must be greater than PingPongConfig.PongTimeout.

--- a/config.go
+++ b/config.go
@@ -168,6 +168,17 @@ type MetricsConfig struct {
 	// ChannelNamespaceCacheTTL sets the time after which resolved channel namespace for a channel
 	// will expire in the cache. If zero – default TTL 10 seconds is used.
 	ChannelNamespaceCacheTTL time.Duration
+
+	// RegisteredClientNames is an optional list of known client names which will be allowed to be
+	// attached as labels to metrics. If client passed a name which is not in the list – then Centrifuge
+	// will use string "unregistered" as a client_name label. We need to be strict here to avoid
+	// Prometheus cardinality issues.
+	RegisteredClientNames []string
+	// CheckRegisteredClientVersion is a function to check whether the version passed by a client with a
+	// particular name is valid and can be used in metric values. When function is not set or returns
+	// false Centrifuge will use "unregistered" value for a client version. Note, the name argument here
+	// is an original name of client passed to Centrifuge.
+	CheckRegisteredClientVersion func(clientName string, clientVersion string) bool
 }
 
 // PingPongConfig allows configuring application level ping-pong behavior.

--- a/hub.go
+++ b/hub.go
@@ -70,17 +70,18 @@ func (h *Hub) shutdown(ctx context.Context) error {
 }
 
 // Add connection into clientHub connections registry.
-func (h *Hub) add(c *Client) error {
+func (h *Hub) add(c *Client) {
 	h.sessionsMu.Lock()
 	if c.sessionID() != "" {
 		h.sessions[c.sessionID()] = c
 	}
 	h.sessionsMu.Unlock()
-	return h.connShards[index(c.UserID(), numHubShards)].add(c)
+	h.connShards[index(c.UserID(), numHubShards)].add(c)
 }
 
 // Remove connection from clientHub connections registry.
-func (h *Hub) remove(c *Client) error {
+// Returns true if found and really removed from registry.
+func (h *Hub) remove(c *Client) bool {
 	h.sessionsMu.Lock()
 	if c.sessionID() != "" {
 		delete(h.sessions, c.sessionID())
@@ -128,7 +129,7 @@ func (h *Hub) addSub(ch string, sub subInfo) (bool, error) {
 }
 
 // removeSub removes connection from clientHub subscriptions registry.
-func (h *Hub) removeSub(ch string, c *Client) (bool, error) {
+func (h *Hub) removeSub(ch string, c *Client) (bool, bool) {
 	return h.subShards[index(ch, numHubShards)].removeSub(ch, c)
 }
 
@@ -416,7 +417,7 @@ func (h *connShard) userConnections(userID string) map[string]*Client {
 }
 
 // Add connection into clientHub connections registry.
-func (h *connShard) add(c *Client) error {
+func (h *connShard) add(c *Client) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -429,11 +430,11 @@ func (h *connShard) add(c *Client) error {
 		h.users[user] = make(map[string]struct{})
 	}
 	h.users[user][uid] = struct{}{}
-	return nil
 }
 
 // Remove connection from clientHub connections registry.
-func (h *connShard) remove(c *Client) error {
+// Returns true if found and really removed from registry.
+func (h *connShard) remove(c *Client) bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -444,10 +445,10 @@ func (h *connShard) remove(c *Client) error {
 
 	// try to find connection to delete, return early if not found.
 	if _, ok := h.users[user]; !ok {
-		return nil
+		return false
 	}
 	if _, ok := h.users[user][uid]; !ok {
-		return nil
+		return false
 	}
 
 	// actually remove connection from hub.
@@ -458,7 +459,7 @@ func (h *connShard) remove(c *Client) error {
 		delete(h.users, user)
 	}
 
-	return nil
+	return true
 }
 
 // NumClients returns total number of client connections.
@@ -533,7 +534,9 @@ func (h *subShard) addSub(ch string, sub subInfo) (bool, error) {
 }
 
 // removeSub removes connection from clientHub subscriptions registry.
-func (h *subShard) removeSub(ch string, c *Client) (bool, error) {
+// Returns true if channel does not have any subscribers left in first return value.
+// Returns true if found and really removed from registry in second return value.
+func (h *subShard) removeSub(ch string, c *Client) (bool, bool) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -541,10 +544,10 @@ func (h *subShard) removeSub(ch string, c *Client) (bool, error) {
 
 	// try to find subscription to delete, return early if not found.
 	if _, ok := h.subs[ch]; !ok {
-		return true, nil
+		return true, false
 	}
 	if _, ok := h.subs[ch][uid]; !ok {
-		return true, nil
+		return true, false
 	}
 
 	// actually remove subscription from hub.
@@ -553,10 +556,10 @@ func (h *subShard) removeSub(ch string, c *Client) (bool, error) {
 	// clean up subs map if it's needed.
 	if len(h.subs[ch]) == 0 {
 		delete(h.subs, ch)
-		return true, nil
+		return true, true
 	}
 
-	return false, nil
+	return false, true
 }
 
 type encodeError struct {

--- a/hub.go
+++ b/hub.go
@@ -791,7 +791,7 @@ func (h *subShard) broadcastPublication(channel string, sp StreamPosition, pub, 
 		}))
 	}
 
-	h.metrics.observeBroadcastDuration(now)
+	h.metrics.observeBroadcastDuration(now, channel)
 	return nil
 }
 

--- a/hub_test.go
+++ b/hub_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/centrifugal/centrifuge/internal/convert"
 
 	"github.com/centrifugal/protocol"
@@ -155,7 +153,9 @@ func (t *testTransport) Close(disconnect Disconnect) error {
 }
 
 func TestHub(t *testing.T) {
-	m, err := initMetricsRegistry(prometheus.DefaultRegisterer, "test")
+	m, err := initMetricsRegistry(MetricsConfig{
+		MetricsNamespace: "test",
+	})
 	require.NoError(t, err)
 
 	h := newHub(nil, m, 0)
@@ -463,7 +463,7 @@ func TestHubBroadcastPublication(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			n := defaultTestNode()
-			n.config.GetChannelNamespaceLabel = func(channel string) string {
+			n.config.Metrics.GetChannelNamespaceLabel = func(channel string) string {
 				return channel
 			}
 			defer func() { _ = n.Shutdown(context.Background()) }()
@@ -577,7 +577,7 @@ func TestHubBroadcastPublicationDelta(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			n := deltaTestNode()
-			n.config.GetChannelNamespaceLabel = func(channel string) string {
+			n.config.Metrics.GetChannelNamespaceLabel = func(channel string) string {
 				return channel
 			}
 			defer func() { _ = n.Shutdown(context.Background()) }()
@@ -657,7 +657,7 @@ func TestHubBroadcastPublicationDeltaAtMostOnce(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			n := deltaTestNodeNoRecovery()
-			n.config.GetChannelNamespaceLabel = func(channel string) string {
+			n.config.Metrics.GetChannelNamespaceLabel = func(channel string) string {
 				return channel
 			}
 			defer func() { _ = n.Shutdown(context.Background()) }()
@@ -737,7 +737,7 @@ func TestHubBroadcastPublicationDeltaAtMostOnceNoOffset(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			n := deltaTestNodeNoRecovery()
-			n.config.GetChannelNamespaceLabel = func(channel string) string {
+			n.config.Metrics.GetChannelNamespaceLabel = func(channel string) string {
 				return channel
 			}
 			defer func() { _ = n.Shutdown(context.Background()) }()
@@ -901,7 +901,9 @@ func TestHubBroadcastLeave(t *testing.T) {
 }
 
 func TestHubShutdown(t *testing.T) {
-	m, err := initMetricsRegistry(prometheus.DefaultRegisterer, "test")
+	m, err := initMetricsRegistry(MetricsConfig{
+		MetricsNamespace: "test",
+	})
 	require.NoError(t, err)
 	h := newHub(nil, m, 0)
 	err = h.shutdown(context.Background())
@@ -921,7 +923,9 @@ func TestHubShutdown(t *testing.T) {
 }
 
 func TestHubSubscriptions(t *testing.T) {
-	m, err := initMetricsRegistry(prometheus.DefaultRegisterer, "test")
+	m, err := initMetricsRegistry(MetricsConfig{
+		MetricsNamespace: "test",
+	})
 	require.NoError(t, err)
 	h := newHub(nil, m, 0)
 	c, err := newClient(context.Background(), defaultTestNode(), newTestTransport(func() {}))
@@ -964,7 +968,9 @@ func TestHubSubscriptions(t *testing.T) {
 }
 
 func TestUserConnections(t *testing.T) {
-	m, err := initMetricsRegistry(prometheus.DefaultRegisterer, "test")
+	m, err := initMetricsRegistry(MetricsConfig{
+		MetricsNamespace: "test",
+	})
 	require.NoError(t, err)
 	h := newHub(nil, m, 0)
 	c, err := newClient(context.Background(), defaultTestNode(), newTestTransport(func() {}))

--- a/hub_test.go
+++ b/hub_test.go
@@ -153,7 +153,7 @@ func (t *testTransport) Close(disconnect Disconnect) error {
 }
 
 func TestHub(t *testing.T) {
-	m, err := initMetricsRegistry(MetricsConfig{
+	m, err := newMetricsRegistry(MetricsConfig{
 		MetricsNamespace: "test",
 	})
 	require.NoError(t, err)
@@ -901,7 +901,7 @@ func TestHubBroadcastLeave(t *testing.T) {
 }
 
 func TestHubShutdown(t *testing.T) {
-	m, err := initMetricsRegistry(MetricsConfig{
+	m, err := newMetricsRegistry(MetricsConfig{
 		MetricsNamespace: "test",
 	})
 	require.NoError(t, err)
@@ -923,7 +923,7 @@ func TestHubShutdown(t *testing.T) {
 }
 
 func TestHubSubscriptions(t *testing.T) {
-	m, err := initMetricsRegistry(MetricsConfig{
+	m, err := newMetricsRegistry(MetricsConfig{
 		MetricsNamespace: "test",
 	})
 	require.NoError(t, err)
@@ -968,7 +968,7 @@ func TestHubSubscriptions(t *testing.T) {
 }
 
 func TestUserConnections(t *testing.T) {
-	m, err := initMetricsRegistry(MetricsConfig{
+	m, err := newMetricsRegistry(MetricsConfig{
 		MetricsNamespace: "test",
 	})
 	require.NoError(t, err)

--- a/metrics.go
+++ b/metrics.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/centrifugal/protocol"
-
+	"github.com/maypok86/otter"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -48,21 +48,23 @@ type metrics struct {
 	messagesSentCountLeave       prometheus.Counter
 	messagesSentCountControl     prometheus.Counter
 
-	actionCountAddClient                 prometheus.Counter
-	actionCountRemoveClient              prometheus.Counter
-	actionCountAddSub                    prometheus.Counter
-	actionCountRemoveSub                 prometheus.Counter
-	actionCountAddPresence               prometheus.Counter
-	actionCountRemovePresence            prometheus.Counter
-	actionCountPresence                  prometheus.Counter
-	actionCountPresenceStats             prometheus.Counter
-	actionCountHistory                   prometheus.Counter
-	actionCountHistoryRecover            prometheus.Counter
-	actionCountHistoryStreamTop          prometheus.Counter
-	actionCountHistoryStreamTopLatestPub prometheus.Counter
-	actionCountHistoryRemove             prometheus.Counter
-	actionCountSurvey                    prometheus.Counter
-	actionCountNotify                    prometheus.Counter
+	actionCountSurvey              prometheus.Counter
+	actionCountNotify              prometheus.Counter
+	actionCountAddClient           prometheus.Counter
+	actionCountRemoveClient        prometheus.Counter
+	actionCountAddSub              prometheus.Counter
+	actionCountBrokerSubscribe     prometheus.Counter
+	actionCountRemoveSub           prometheus.Counter
+	actionCountBrokerUnsubscribe   prometheus.Counter
+	actionCountAddPresence         prometheus.Counter
+	actionCountRemovePresence      prometheus.Counter
+	actionCountPresence            prometheus.Counter
+	actionCountPresenceStats       prometheus.Counter
+	actionCountHistory             prometheus.Counter
+	actionCountHistoryRecover      prometheus.Counter
+	actionCountHistoryRecoverCache prometheus.Counter
+	actionCountHistoryStreamTop    prometheus.Counter
+	actionCountHistoryRemove       prometheus.Counter
 
 	recoverCountYes prometheus.Counter
 	recoverCountNo  prometheus.Counter
@@ -84,12 +86,23 @@ type metrics struct {
 	commandDurationSubRefresh    prometheus.Observer
 	commandDurationUnknown       prometheus.Observer
 
-	pubSubLagHistogram         prometheus.Histogram
-	broadcastDurationHistogram prometheus.Histogram
-	pingPongDurationHistogram  *prometheus.HistogramVec
+	broadcastDurationHistogram *prometheus.HistogramVec
+
+	pubSubLagHistogram        prometheus.Histogram
+	pingPongDurationHistogram *prometheus.HistogramVec
+
+	config MetricsConfig
+
+	nsCache     *otter.Cache[string, string]
+	codeStrings map[uint32]string
 }
 
-func (m *metrics) observeCommandDuration(frameType protocol.FrameType, d time.Duration) {
+func (m *metrics) observeCommandDuration(frameType protocol.FrameType, d time.Duration, ch string) {
+	if ch != "" && m.config.GetChannelNamespaceLabel != nil {
+		m.commandDurationSummary.WithLabelValues(frameType.String(), m.getChannelNamespaceLabel(ch)).Observe(d.Seconds())
+		return
+	}
+
 	var observer prometheus.Observer
 
 	switch frameType {
@@ -128,8 +141,12 @@ func (m *metrics) observePubSubDeliveryLag(lagTimeMilli int64) {
 	m.pubSubLagHistogram.Observe(float64(lagTimeMilli) / 1000)
 }
 
-func (m *metrics) observeBroadcastDuration(started time.Time) {
-	m.broadcastDurationHistogram.Observe(time.Since(started).Seconds())
+func (m *metrics) observeBroadcastDuration(started time.Time, ch string) {
+	if m.config.GetChannelNamespaceLabel != nil {
+		m.broadcastDurationHistogram.WithLabelValues("publication", m.getChannelNamespaceLabel(ch)).Observe(time.Since(started).Seconds())
+		return
+	}
+	m.broadcastDurationHistogram.WithLabelValues("publication", m.getChannelNamespaceLabel(ch)).Observe(time.Since(started).Seconds())
 }
 
 func (m *metrics) observePingPongDuration(duration time.Duration, transport string) {
@@ -160,11 +177,39 @@ func (m *metrics) setNumNodes(n float64) {
 	m.numNodesGauge.Set(n)
 }
 
-func (m *metrics) incReplyError(frameType protocol.FrameType, code uint32) {
-	m.replyErrorCount.WithLabelValues(frameType.String(), strconv.FormatUint(uint64(code), 10)).Inc()
+func (m *metrics) getChannelNamespaceLabel(ch string) string {
+	if ch == "" {
+		return ""
+	}
+	nsLabel := ""
+	if m.config.GetChannelNamespaceLabel == nil {
+		return nsLabel
+	}
+	if m.nsCache == nil {
+		return m.config.GetChannelNamespaceLabel(ch)
+	}
+	var cached bool
+	if nsLabel, cached = m.nsCache.Get(ch); cached {
+		return nsLabel
+	}
+	nsLabel = m.config.GetChannelNamespaceLabel(ch)
+	m.nsCache.Set(ch, nsLabel)
+	return nsLabel
 }
 
-func (m *metrics) incRecover(success bool) {
+func (m *metrics) incReplyError(frameType protocol.FrameType, code uint32, ch string) {
+	m.replyErrorCount.WithLabelValues(frameType.String(), m.getCodeLabel(code), m.getChannelNamespaceLabel(ch)).Inc()
+}
+
+func (m *metrics) incRecover(success bool, ch string) {
+	if m.config.GetChannelNamespaceLabel != nil {
+		if success {
+			m.recoverCount.WithLabelValues("yes", m.getChannelNamespaceLabel(ch)).Inc()
+		} else {
+			m.recoverCount.WithLabelValues("no", m.getChannelNamespaceLabel(ch)).Inc()
+		}
+		return
+	}
 	if success {
 		m.recoverCountYes.Inc()
 	} else {
@@ -186,9 +231,9 @@ func (m *metrics) incTransportConnect(transport string) {
 }
 
 type transportMessageLabels struct {
-	Transport    string
-	ChannelGroup string
-	FrameType    string
+	Transport        string
+	ChannelNamespace string
+	FrameType        string
 }
 
 type transportMessagesSent struct {
@@ -206,16 +251,20 @@ var (
 	transportMessagesReceivedCache sync.Map
 )
 
-func (m *metrics) incTransportMessagesSent(transport string, frameType protocol.FrameType, channelGroup string, size int) {
+func (m *metrics) incTransportMessagesSent(transport string, frameType protocol.FrameType, channel string, size int) {
+	channelNamespace := ""
+	if channel != "" && m.config.GetChannelNamespaceLabel != nil {
+		channelNamespace = m.getChannelNamespaceLabel(channel)
+	}
 	labels := transportMessageLabels{
-		Transport:    transport,
-		ChannelGroup: channelGroup,
-		FrameType:    frameType.String(),
+		Transport:        transport,
+		ChannelNamespace: channelNamespace,
+		FrameType:        frameType.String(),
 	}
 	counters, ok := transportMessagesSentCache.Load(labels)
 	if !ok {
-		counterSent := m.transportMessagesSent.WithLabelValues(transport, labels.FrameType, channelGroup)
-		counterSentSize := m.transportMessagesSentSize.WithLabelValues(transport, labels.FrameType, channelGroup)
+		counterSent := m.transportMessagesSent.WithLabelValues(transport, labels.FrameType, channelNamespace)
+		counterSentSize := m.transportMessagesSentSize.WithLabelValues(transport, labels.FrameType, channelNamespace)
 		counters = transportMessagesSent{
 			counterSent:     counterSent,
 			counterSentSize: counterSentSize,
@@ -226,16 +275,20 @@ func (m *metrics) incTransportMessagesSent(transport string, frameType protocol.
 	counters.(transportMessagesSent).counterSentSize.Add(float64(size))
 }
 
-func (m *metrics) incTransportMessagesReceived(transport string, frameType protocol.FrameType, channelGroup string, size int) {
+func (m *metrics) incTransportMessagesReceived(transport string, frameType protocol.FrameType, channel string, size int) {
+	channelNamespace := ""
+	if channel != "" && m.config.GetChannelNamespaceLabel != nil {
+		channelNamespace = m.getChannelNamespaceLabel(channel)
+	}
 	labels := transportMessageLabels{
-		Transport:    transport,
-		ChannelGroup: channelGroup,
-		FrameType:    frameType.String(),
+		Transport:        transport,
+		ChannelNamespace: channelNamespace,
+		FrameType:        frameType.String(),
 	}
 	counters, ok := transportMessagesReceivedCache.Load(labels)
 	if !ok {
-		counterReceived := m.transportMessagesReceived.WithLabelValues(transport, labels.FrameType, channelGroup)
-		counterReceivedSize := m.transportMessagesReceivedSize.WithLabelValues(transport, labels.FrameType, channelGroup)
+		counterReceived := m.transportMessagesReceived.WithLabelValues(transport, labels.FrameType, channelNamespace)
+		counterReceivedSize := m.transportMessagesReceivedSize.WithLabelValues(transport, labels.FrameType, channelNamespace)
 		counters = transportMessagesReceived{
 			counterReceived:     counterReceived,
 			counterReceivedSize: counterReceivedSize,
@@ -246,15 +299,27 @@ func (m *metrics) incTransportMessagesReceived(transport string, frameType proto
 	counters.(transportMessagesReceived).counterReceivedSize.Add(float64(size))
 }
 
+func (m *metrics) getCodeLabel(code uint32) string {
+	codeStr, ok := m.codeStrings[code]
+	if !ok {
+		return strconv.FormatUint(uint64(code), 10)
+	}
+	return codeStr
+}
+
 func (m *metrics) incServerDisconnect(code uint32) {
-	m.serverDisconnectCount.WithLabelValues(strconv.FormatUint(uint64(code), 10)).Inc()
+	m.serverDisconnectCount.WithLabelValues(m.getCodeLabel(code)).Inc()
 }
 
-func (m *metrics) incServerUnsubscribe(code uint32) {
-	m.serverUnsubscribeCount.WithLabelValues(strconv.FormatUint(uint64(code), 10)).Inc()
+func (m *metrics) incServerUnsubscribe(code uint32, ch string) {
+	m.serverUnsubscribeCount.WithLabelValues(m.getCodeLabel(code), m.getChannelNamespaceLabel(ch)).Inc()
 }
 
-func (m *metrics) incMessagesSent(msgType string) {
+func (m *metrics) incMessagesSent(msgType string, ch string) {
+	if m.config.GetChannelNamespaceLabel != nil {
+		m.messagesSentCount.WithLabelValues(msgType, m.getChannelNamespaceLabel(ch)).Inc()
+		return
+	}
 	switch msgType {
 	case "publication":
 		m.messagesSentCountPublication.Inc()
@@ -265,11 +330,15 @@ func (m *metrics) incMessagesSent(msgType string) {
 	case "control":
 		m.messagesSentCountControl.Inc()
 	default:
-		m.messagesSentCount.WithLabelValues(msgType).Inc()
+		m.messagesSentCount.WithLabelValues(msgType, "").Inc()
 	}
 }
 
-func (m *metrics) incMessagesReceived(msgType string) {
+func (m *metrics) incMessagesReceived(msgType string, ch string) {
+	if m.config.GetChannelNamespaceLabel != nil {
+		m.messagesReceivedCount.WithLabelValues(msgType, m.getChannelNamespaceLabel(ch)).Inc()
+		return
+	}
 	switch msgType {
 	case "publication":
 		m.messagesReceivedCountPublication.Inc()
@@ -280,20 +349,32 @@ func (m *metrics) incMessagesReceived(msgType string) {
 	case "control":
 		m.messagesReceivedCountControl.Inc()
 	default:
-		m.messagesReceivedCount.WithLabelValues(msgType).Inc()
+		m.messagesReceivedCount.WithLabelValues(msgType, "").Inc()
 	}
 }
 
-func (m *metrics) incActionCount(action string) {
+func (m *metrics) incActionCount(action string, ch string) {
+	if m.config.GetChannelNamespaceLabel != nil {
+		m.actionCount.WithLabelValues(action, m.getChannelNamespaceLabel(ch)).Inc()
+		return
+	}
 	switch action {
+	case "survey":
+		m.actionCountSurvey.Inc()
+	case "notify":
+		m.actionCountNotify.Inc()
 	case "add_client":
 		m.actionCountAddClient.Inc()
 	case "remove_client":
 		m.actionCountRemoveClient.Inc()
 	case "add_subscription":
 		m.actionCountAddSub.Inc()
+	case "broker_subscribe":
+		m.actionCountBrokerSubscribe.Inc()
 	case "remove_subscription":
 		m.actionCountRemoveSub.Inc()
+	case "broker_unsubscribe":
+		m.actionCountBrokerUnsubscribe.Inc()
 	case "add_presence":
 		m.actionCountAddPresence.Inc()
 	case "remove_presence":
@@ -306,16 +387,14 @@ func (m *metrics) incActionCount(action string) {
 		m.actionCountHistory.Inc()
 	case "history_recover":
 		m.actionCountHistoryRecover.Inc()
+	case "history_recover_cache":
+		m.actionCountHistoryRecoverCache.Inc()
 	case "history_stream_top":
 		m.actionCountHistoryStreamTop.Inc()
-	case "history_stream_top_latest_pub":
-		m.actionCountHistoryStreamTopLatestPub.Inc()
 	case "history_remove":
 		m.actionCountHistoryRemove.Inc()
-	case "survey":
-		m.actionCountSurvey.Inc()
-	case "notify":
-		m.actionCountNotify.Inc()
+	default:
+		// unknown action, skip.
 	}
 }
 
@@ -323,39 +402,74 @@ func (m *metrics) observeSurveyDuration(op string, d time.Duration) {
 	m.surveyDurationSummary.WithLabelValues(op).Observe(d.Seconds())
 }
 
-func initMetricsRegistry(registry prometheus.Registerer, metricsNamespace string) (*metrics, error) {
+func initMetricsRegistry(config MetricsConfig) (*metrics, error) {
 	registryMu.Lock()
 	defer registryMu.Unlock()
 
+	metricsNamespace := config.MetricsNamespace
 	if metricsNamespace == "" {
 		metricsNamespace = defaultMetricsNamespace
 	}
-	if registry == nil {
-		registry = prometheus.DefaultRegisterer
+
+	var registerer prometheus.Registerer
+	if config.RegistererGatherer != nil {
+		registerer = config.RegistererGatherer
+	} else {
+		registerer = prometheus.DefaultRegisterer
 	}
 
-	m := &metrics{}
+	var nsCache *otter.Cache[string, string]
+	if config.GetChannelNamespaceLabel != nil {
+		cacheSize := config.ChannelNamespaceCacheSize
+		if cacheSize == 0 {
+			cacheSize = 4096
+		}
+		cacheTTL := config.ChannelNamespaceCacheTTL
+		if cacheTTL == 0 {
+			cacheTTL = 15 * time.Second
+		}
+		if cacheTTL < 0 {
+			return nil, errors.New("channel namespace cache TTL must be positive")
+		}
+		if cacheSize != -1 {
+			c, _ := otter.MustBuilder[string, string](cacheSize).
+				WithTTL(cacheTTL).
+				Build()
+			nsCache = &c
+		}
+	}
+
+	codeStrings := make(map[uint32]string)
+	for i := uint32(0); i <= 10000; i++ {
+		codeStrings[i] = strconv.FormatUint(uint64(i), 10)
+	}
+
+	m := &metrics{
+		config:      config,
+		nsCache:     nsCache,
+		codeStrings: codeStrings,
+	}
 
 	m.messagesSentCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricsNamespace,
 		Subsystem: "node",
 		Name:      "messages_sent_count",
 		Help:      "Number of messages sent by node to broker.",
-	}, []string{"type"})
+	}, []string{"type", "channel_namespace"})
 
 	m.messagesReceivedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricsNamespace,
 		Subsystem: "node",
 		Name:      "messages_received_count",
 		Help:      "Number of messages received from broker.",
-	}, []string{"type"})
+	}, []string{"type", "channel_namespace"})
 
 	m.actionCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricsNamespace,
 		Subsystem: "node",
 		Name:      "action_count",
 		Help:      "Number of various actions called.",
-	}, []string{"action"})
+	}, []string{"action", "channel_namespace"})
 
 	m.numClientsGauge = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: metricsNamespace,
@@ -407,19 +521,27 @@ func initMetricsRegistry(registry prometheus.Registerer, metricsNamespace string
 		Help:       "Survey duration summary.",
 	}, []string{"op"})
 
+	m.commandDurationSummary = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Namespace:  metricsNamespace,
+		Subsystem:  "client",
+		Name:       "command_duration_seconds",
+		Objectives: map[float64]float64{0.5: 0.05, 0.99: 0.001, 0.999: 0.0001},
+		Help:       "Client command duration summary.",
+	}, []string{"method", "channel_namespace"})
+
 	m.replyErrorCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricsNamespace,
 		Subsystem: "client",
 		Name:      "num_reply_errors",
 		Help:      "Number of errors in replies sent to clients.",
-	}, []string{"method", "code"})
+	}, []string{"method", "code", "channel_namespace"})
 
 	m.serverUnsubscribeCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricsNamespace,
 		Subsystem: "client",
 		Name:      "num_server_unsubscribes",
 		Help:      "Number of server initiated unsubscribes.",
-	}, []string{"code"})
+	}, []string{"code", "channel_namespace"})
 
 	m.serverDisconnectCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricsNamespace,
@@ -428,20 +550,12 @@ func initMetricsRegistry(registry prometheus.Registerer, metricsNamespace string
 		Help:      "Number of server initiated disconnects.",
 	}, []string{"code"})
 
-	m.commandDurationSummary = prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Namespace:  metricsNamespace,
-		Subsystem:  "client",
-		Name:       "command_duration_seconds",
-		Objectives: map[float64]float64{0.5: 0.05, 0.99: 0.001, 0.999: 0.0001},
-		Help:       "Client command duration summary.",
-	}, []string{"method"})
-
 	m.recoverCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricsNamespace,
 		Subsystem: "client",
 		Name:      "recover",
 		Help:      "Count of recover operations.",
-	}, []string{"recovered"})
+	}, []string{"recovered", "channel_namespace"})
 
 	m.pingPongDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: metricsNamespace,
@@ -496,7 +610,7 @@ func initMetricsRegistry(registry prometheus.Registerer, metricsNamespace string
 		Help:      "Pub sub lag in seconds",
 		Buckets:   []float64{0.001, 0.005, 0.010, 0.025, 0.050, 0.100, 0.200, 0.500, 1.000, 2.000, 5.000, 10.000},
 	})
-	m.broadcastDurationHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+	m.broadcastDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: metricsNamespace,
 		Subsystem: "node",
 		Name:      "broadcast_duration_seconds",
@@ -505,36 +619,38 @@ func initMetricsRegistry(registry prometheus.Registerer, metricsNamespace string
 			0.000001, 0.000005, 0.000010, 0.000050, 0.000100, 0.000250, 0.000500, // Microsecond resolution.
 			0.001, 0.005, 0.010, 0.025, 0.050, 0.100, 0.250, 0.500, // Millisecond resolution.
 			1.0, 2.5, 5.0, 10.0, // Second resolution.
-		}})
+		}}, []string{"type", "channel_namespace"})
 
-	m.messagesReceivedCountPublication = m.messagesReceivedCount.WithLabelValues("publication")
-	m.messagesReceivedCountJoin = m.messagesReceivedCount.WithLabelValues("join")
-	m.messagesReceivedCountLeave = m.messagesReceivedCount.WithLabelValues("leave")
-	m.messagesReceivedCountControl = m.messagesReceivedCount.WithLabelValues("control")
+	m.messagesReceivedCountPublication = m.messagesReceivedCount.WithLabelValues("publication", "")
+	m.messagesReceivedCountJoin = m.messagesReceivedCount.WithLabelValues("join", "")
+	m.messagesReceivedCountLeave = m.messagesReceivedCount.WithLabelValues("leave", "")
+	m.messagesReceivedCountControl = m.messagesReceivedCount.WithLabelValues("control", "")
 
-	m.messagesSentCountPublication = m.messagesSentCount.WithLabelValues("publication")
-	m.messagesSentCountJoin = m.messagesSentCount.WithLabelValues("join")
-	m.messagesSentCountLeave = m.messagesSentCount.WithLabelValues("leave")
-	m.messagesSentCountControl = m.messagesSentCount.WithLabelValues("control")
+	m.messagesSentCountPublication = m.messagesSentCount.WithLabelValues("publication", "")
+	m.messagesSentCountJoin = m.messagesSentCount.WithLabelValues("join", "")
+	m.messagesSentCountLeave = m.messagesSentCount.WithLabelValues("leave", "")
+	m.messagesSentCountControl = m.messagesSentCount.WithLabelValues("control", "")
 
-	m.actionCountAddClient = m.actionCount.WithLabelValues("add_client")
-	m.actionCountRemoveClient = m.actionCount.WithLabelValues("remove_client")
-	m.actionCountAddSub = m.actionCount.WithLabelValues("add_subscription")
-	m.actionCountRemoveSub = m.actionCount.WithLabelValues("remove_subscription")
-	m.actionCountAddPresence = m.actionCount.WithLabelValues("add_presence")
-	m.actionCountRemovePresence = m.actionCount.WithLabelValues("remove_presence")
-	m.actionCountPresence = m.actionCount.WithLabelValues("presence")
-	m.actionCountPresenceStats = m.actionCount.WithLabelValues("presence_stats")
-	m.actionCountHistory = m.actionCount.WithLabelValues("history")
-	m.actionCountHistoryRecover = m.actionCount.WithLabelValues("history_recover")
-	m.actionCountHistoryStreamTop = m.actionCount.WithLabelValues("history_stream_top")
-	m.actionCountHistoryStreamTopLatestPub = m.actionCount.WithLabelValues("history_stream_top_latest_pub")
-	m.actionCountHistoryRemove = m.actionCount.WithLabelValues("history_remove")
-	m.actionCountSurvey = m.actionCount.WithLabelValues("survey")
-	m.actionCountNotify = m.actionCount.WithLabelValues("notify")
+	m.actionCountAddClient = m.actionCount.WithLabelValues("add_client", "")
+	m.actionCountRemoveClient = m.actionCount.WithLabelValues("remove_client", "")
+	m.actionCountAddSub = m.actionCount.WithLabelValues("add_subscription", "")
+	m.actionCountBrokerSubscribe = m.actionCount.WithLabelValues("broker_subscribe", "")
+	m.actionCountRemoveSub = m.actionCount.WithLabelValues("remove_subscription", "")
+	m.actionCountBrokerUnsubscribe = m.actionCount.WithLabelValues("broker_unsubscribe", "")
+	m.actionCountAddPresence = m.actionCount.WithLabelValues("add_presence", "")
+	m.actionCountRemovePresence = m.actionCount.WithLabelValues("remove_presence", "")
+	m.actionCountPresence = m.actionCount.WithLabelValues("presence", "")
+	m.actionCountPresenceStats = m.actionCount.WithLabelValues("presence_stats", "")
+	m.actionCountHistory = m.actionCount.WithLabelValues("history", "")
+	m.actionCountHistoryRecover = m.actionCount.WithLabelValues("history_recover", "")
+	m.actionCountHistoryRecoverCache = m.actionCount.WithLabelValues("history_recover_cache", "")
+	m.actionCountHistoryStreamTop = m.actionCount.WithLabelValues("history_stream_top", "")
+	m.actionCountHistoryRemove = m.actionCount.WithLabelValues("history_remove", "")
+	m.actionCountSurvey = m.actionCount.WithLabelValues("survey", "")
+	m.actionCountNotify = m.actionCount.WithLabelValues("notify", "")
 
-	m.recoverCountYes = m.recoverCount.WithLabelValues("yes")
-	m.recoverCountNo = m.recoverCount.WithLabelValues("no")
+	m.recoverCountYes = m.recoverCount.WithLabelValues("yes", "")
+	m.recoverCountNo = m.recoverCount.WithLabelValues("no", "")
 
 	m.transportConnectCountWebsocket = m.transportConnectCount.WithLabelValues(transportWebsocket)
 	m.transportConnectCountHTTPStream = m.transportConnectCount.WithLabelValues(transportHTTPStream)
@@ -544,89 +660,49 @@ func initMetricsRegistry(registry prometheus.Registerer, metricsNamespace string
 		return frameType.String()
 	}
 
-	m.commandDurationConnect = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypeConnect))
-	m.commandDurationSubscribe = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypeSubscribe))
-	m.commandDurationUnsubscribe = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypeUnsubscribe))
-	m.commandDurationPublish = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypePublish))
-	m.commandDurationPresence = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypePresence))
-	m.commandDurationPresenceStats = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypePresenceStats))
-	m.commandDurationHistory = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypeHistory))
-	m.commandDurationSend = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypeSend))
-	m.commandDurationRPC = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypeRPC))
-	m.commandDurationRefresh = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypeRefresh))
-	m.commandDurationSubRefresh = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypeSubRefresh))
-	m.commandDurationUnknown = m.commandDurationSummary.WithLabelValues("unknown")
+	m.commandDurationConnect = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypeConnect), "")
+	m.commandDurationSubscribe = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypeSubscribe), "")
+	m.commandDurationUnsubscribe = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypeUnsubscribe), "")
+	m.commandDurationPublish = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypePublish), "")
+	m.commandDurationPresence = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypePresence), "")
+	m.commandDurationPresenceStats = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypePresenceStats), "")
+	m.commandDurationHistory = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypeHistory), "")
+	m.commandDurationSend = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypeSend), "")
+	m.commandDurationRPC = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypeRPC), "")
+	m.commandDurationRefresh = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypeRefresh), "")
+	m.commandDurationSubRefresh = m.commandDurationSummary.WithLabelValues(labelForMethod(protocol.FrameTypeSubRefresh), "")
+	m.commandDurationUnknown = m.commandDurationSummary.WithLabelValues("unknown", "")
 
 	var alreadyRegistered prometheus.AlreadyRegisteredError
 
-	if err := registry.Register(m.messagesSentCount); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.messagesReceivedCount); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.actionCount); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.numClientsGauge); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.numUsersGauge); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.numSubsGauge); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.numChannelsGauge); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.numNodesGauge); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.commandDurationSummary); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.replyErrorCount); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.serverUnsubscribeCount); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.serverDisconnectCount); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.recoverCount); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.pingPongDurationHistogram); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.transportConnectCount); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.transportMessagesSent); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.transportMessagesSentSize); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.transportMessagesReceived); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.transportMessagesReceivedSize); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.buildInfoGauge); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.surveyDurationSummary); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.pubSubLagHistogram); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
-	}
-	if err := registry.Register(m.broadcastDurationHistogram); err != nil && !errors.As(err, &alreadyRegistered) {
-		return nil, err
+	for _, collector := range []prometheus.Collector{
+		m.messagesSentCount,
+		m.messagesReceivedCount,
+		m.actionCount,
+		m.numClientsGauge,
+		m.numUsersGauge,
+		m.numSubsGauge,
+		m.numChannelsGauge,
+		m.numNodesGauge,
+		m.commandDurationSummary,
+		m.replyErrorCount,
+		m.serverUnsubscribeCount,
+		m.serverDisconnectCount,
+		m.recoverCount,
+		m.pingPongDurationHistogram,
+		m.transportConnectCount,
+		m.transportMessagesSent,
+		m.transportMessagesSentSize,
+		m.transportMessagesReceived,
+		m.transportMessagesReceivedSize,
+		m.buildInfoGauge,
+		m.surveyDurationSummary,
+		m.pubSubLagHistogram,
+		m.broadcastDurationHistogram,
+	} {
+		if err := registerer.Register(collector); err != nil && !errors.As(err, &alreadyRegistered) {
+			return nil, err
+		}
 	}
 	return m, nil
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func BenchmarkTransportMessagesSent(b *testing.B) {
-	m, err := initMetricsRegistry(MetricsConfig{
+	m, err := newMetricsRegistry(MetricsConfig{
 		MetricsNamespace: "test",
 	})
 	require.NoError(b, err)
@@ -27,7 +27,7 @@ func BenchmarkTransportMessagesSent(b *testing.B) {
 }
 
 func BenchmarkTransportMessagesReceived(b *testing.B) {
-	m, err := initMetricsRegistry(MetricsConfig{
+	m, err := newMetricsRegistry(MetricsConfig{
 		MetricsNamespace: "test",
 	})
 	require.NoError(b, err)
@@ -43,7 +43,7 @@ func BenchmarkTransportMessagesReceived(b *testing.B) {
 }
 
 func BenchmarkCommandDuration(b *testing.B) {
-	m, err := initMetricsRegistry(MetricsConfig{
+	m, err := newMetricsRegistry(MetricsConfig{
 		MetricsNamespace: "test",
 		GetChannelNamespaceLabel: func(channel string) string {
 			return channel
@@ -63,7 +63,7 @@ func BenchmarkCommandDuration(b *testing.B) {
 }
 
 func BenchmarkIncReplyError(b *testing.B) {
-	m, err := initMetricsRegistry(MetricsConfig{
+	m, err := newMetricsRegistry(MetricsConfig{
 		MetricsNamespace: "test",
 		GetChannelNamespaceLabel: func(channel string) string {
 			return channel
@@ -82,7 +82,7 @@ func BenchmarkIncReplyError(b *testing.B) {
 }
 
 func TestMetrics(t *testing.T) {
-	_, err := initMetricsRegistry(MetricsConfig{
+	_, err := newMetricsRegistry(MetricsConfig{
 		GetChannelNamespaceLabel: func(channel string) string {
 			return channel
 		},
@@ -131,7 +131,7 @@ func TestMetrics(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			m, err := initMetricsRegistry(MetricsConfig{
+			m, err := newMetricsRegistry(MetricsConfig{
 				MetricsNamespace:          tc.metricsNamespace,
 				GetChannelNamespaceLabel:  tc.getChannelNamespaceLabel,
 				ChannelNamespaceCacheSize: tc.channelNamespaceCacheSize,

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -3,6 +3,7 @@ package centrifuge
 import (
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/centrifugal/protocol"
 	"github.com/prometheus/client_golang/prometheus"
@@ -10,7 +11,9 @@ import (
 )
 
 func BenchmarkTransportMessagesSent(b *testing.B) {
-	m, err := initMetricsRegistry(prometheus.DefaultRegisterer, "test")
+	m, err := initMetricsRegistry(MetricsConfig{
+		MetricsNamespace: "test",
+	})
 	require.NoError(b, err)
 
 	b.ReportAllocs()
@@ -18,12 +21,15 @@ func BenchmarkTransportMessagesSent(b *testing.B) {
 		i := 0
 		for pb.Next() {
 			m.incTransportMessagesSent("test", protocol.FrameTypePushPublication, "channel"+strconv.Itoa(i%10), 200)
+			i++
 		}
 	})
 }
 
 func BenchmarkTransportMessagesReceived(b *testing.B) {
-	m, err := initMetricsRegistry(prometheus.DefaultRegisterer, "test")
+	m, err := initMetricsRegistry(MetricsConfig{
+		MetricsNamespace: "test",
+	})
 	require.NoError(b, err)
 
 	b.ReportAllocs()
@@ -31,6 +37,156 @@ func BenchmarkTransportMessagesReceived(b *testing.B) {
 		i := 0
 		for pb.Next() {
 			m.incTransportMessagesReceived("test", protocol.FrameTypePushPublication, "channel"+strconv.Itoa(i%10), 200)
+			i++
 		}
 	})
+}
+
+func BenchmarkCommandDuration(b *testing.B) {
+	m, err := initMetricsRegistry(MetricsConfig{
+		MetricsNamespace: "test",
+		GetChannelNamespaceLabel: func(channel string) string {
+			return channel
+		},
+	})
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			started := time.Now()
+			m.observeCommandDuration(protocol.FrameTypePresence, time.Since(started), "channel"+strconv.Itoa(i%1024))
+			i++
+		}
+	})
+}
+
+func BenchmarkIncReplyError(b *testing.B) {
+	m, err := initMetricsRegistry(MetricsConfig{
+		MetricsNamespace: "test",
+		GetChannelNamespaceLabel: func(channel string) string {
+			return channel
+		},
+	})
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			m.incReplyError(protocol.FrameTypePresence, 100, "channel"+strconv.Itoa(i%1024))
+			i++
+		}
+	})
+}
+
+func TestMetrics(t *testing.T) {
+	_, err := initMetricsRegistry(MetricsConfig{
+		GetChannelNamespaceLabel: func(channel string) string {
+			return channel
+		},
+		ChannelNamespaceCacheTTL: -1,
+	})
+	require.Error(t, err)
+
+	testCases := []struct {
+		name                      string
+		metricsNamespace          string
+		getChannelNamespaceLabel  func(channel string) string
+		channelNamespaceCacheSize int
+		registererGatherer        RegistererGatherer
+	}{
+		{
+			name: "no channel namespace",
+		},
+		{
+			name: "with channel namespace",
+			getChannelNamespaceLabel: func(channel string) string {
+				return channel
+			},
+		},
+		{
+			name: "with channel namespace and no cache",
+			getChannelNamespaceLabel: func(channel string) string {
+				return channel
+			},
+			channelNamespaceCacheSize: -1,
+		},
+		{
+			name: "with custom registry",
+			getChannelNamespaceLabel: func(channel string) string {
+				return channel
+			},
+			registererGatherer: prometheus.NewRegistry(),
+		},
+		{
+			name: "with metrics namespace",
+			getChannelNamespaceLabel: func(channel string) string {
+				return channel
+			},
+			metricsNamespace: "test",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := initMetricsRegistry(MetricsConfig{
+				MetricsNamespace:          tc.metricsNamespace,
+				GetChannelNamespaceLabel:  tc.getChannelNamespaceLabel,
+				ChannelNamespaceCacheSize: tc.channelNamespaceCacheSize,
+				RegistererGatherer:        tc.registererGatherer,
+			})
+			require.NoError(t, err)
+
+			for i := 0; i < 10; i++ {
+				for _, frameType := range []protocol.FrameType{
+					protocol.FrameTypeServerPing, protocol.FrameTypeClientPong, protocol.FrameTypePushConnect,
+					protocol.FrameTypePushSubscribe, protocol.FrameTypePushPublication, protocol.FrameTypePushJoin,
+					protocol.FrameTypePushLeave, protocol.FrameTypePushUnsubscribe, protocol.FrameTypePushMessage,
+					protocol.FrameTypePushRefresh, protocol.FrameTypePushDisconnect, protocol.FrameTypeConnect,
+					protocol.FrameTypeSubscribe, protocol.FrameTypePublish, protocol.FrameTypeUnsubscribe,
+					protocol.FrameTypeRPC, protocol.FrameTypePresence, protocol.FrameTypePresenceStats,
+					protocol.FrameTypeHistory, protocol.FrameTypeRefresh, protocol.FrameTypeSubRefresh,
+					protocol.FrameTypeSend,
+				} {
+					m.incTransportMessagesSent("test", frameType, "channel"+strconv.Itoa(i%2), 200)
+					m.incTransportMessagesReceived("test", frameType, "channel"+strconv.Itoa(i%2), 200)
+					m.observeCommandDuration(frameType, time.Second, "channel"+strconv.Itoa(i%2))
+					m.incReplyError(frameType, 100, "channel"+strconv.Itoa(i%2))
+				}
+
+				m.incActionCount("unknown", "channel")
+				for _, action := range []string{"survey", "notify", "add_client", "remove_client", "add_subscription", "broker_subscribe", "remove_subscription", "broker_unsubscribe", "add_presence", "remove_presence", "presence", "presence_stats", "history", "history_recover", "history_recover_cache", "history_stream_top", "history_remove"} {
+					m.incActionCount(action, "channel"+strconv.Itoa(i%2))
+				}
+				m.incActionCount("unknown", "")
+
+				for _, msgType := range []string{"publication", "join", "leave", "control", "unknown"} {
+					m.incMessagesSent(msgType, "channel"+strconv.Itoa(i%2))
+					m.incMessagesReceived(msgType, "channel"+strconv.Itoa(i%2))
+				}
+
+				m.observeSurveyDuration("test", time.Second)
+				m.incRecover(true, "channel"+strconv.Itoa(i%2))
+				m.incRecover(false, "channel"+strconv.Itoa(i%2))
+				m.observePubSubDeliveryLag(100)
+				m.observePubSubDeliveryLag(-10)
+				m.observePingPongDuration(time.Second, transportWebsocket)
+				for _, transport := range []string{transportWebsocket, transportSSE, transportHTTPStream, "unknown"} {
+					m.incTransportConnect(transport)
+				}
+				m.incServerDisconnect(3000)
+				m.incServerDisconnect(30000)
+				m.incServerUnsubscribe(2500, "channel"+strconv.Itoa(i%2))
+				m.observeBroadcastDuration(time.Now(), "channel"+strconv.Itoa(i%2))
+				m.setBuildInfo("1.0.0")
+				m.setNumChannels(100)
+				m.setNumClients(200)
+				m.setNumUsers(300)
+				m.setNumNodes(4)
+				m.setNumSubscriptions(500)
+			}
+		})
+	}
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -81,6 +81,82 @@ func BenchmarkIncReplyError(b *testing.B) {
 	})
 }
 
+func BenchmarkIncActionCount(b *testing.B) {
+	m, err := newMetricsRegistry(MetricsConfig{
+		MetricsNamespace: "test",
+		GetChannelNamespaceLabel: func(channel string) string {
+			return channel
+		},
+	})
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			m.incActionCount("history", "channel"+strconv.Itoa(i%1024))
+			i++
+		}
+	})
+}
+
+func BenchmarkIncRecover(b *testing.B) {
+	m, err := newMetricsRegistry(MetricsConfig{
+		MetricsNamespace: "test",
+		GetChannelNamespaceLabel: func(channel string) string {
+			return channel
+		},
+	})
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			m.incRecover(true, "channel"+strconv.Itoa(i%1024))
+			i++
+		}
+	})
+}
+
+func BenchmarkIncDisconnect(b *testing.B) {
+	m, err := newMetricsRegistry(MetricsConfig{
+		MetricsNamespace: "test",
+		GetChannelNamespaceLabel: func(channel string) string {
+			return channel
+		},
+	})
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			m.incServerDisconnect(3000)
+			i++
+		}
+	})
+}
+
+func BenchmarkIncUnsubscribe(b *testing.B) {
+	m, err := newMetricsRegistry(MetricsConfig{
+		MetricsNamespace: "test",
+		GetChannelNamespaceLabel: func(channel string) string {
+			return channel
+		},
+	})
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			m.incServerUnsubscribe(2500, "channel"+strconv.Itoa(i%1024))
+			i++
+		}
+	})
+}
+
 func TestMetrics(t *testing.T) {
 	_, err := newMetricsRegistry(MetricsConfig{
 		GetChannelNamespaceLabel: func(channel string) string {

--- a/node.go
+++ b/node.go
@@ -175,7 +175,7 @@ func New(c Config) (*Node, error) {
 	}
 	n.emulationSurveyHandler = newEmulationSurveyHandler(n)
 
-	m, err := initMetricsRegistry(c.Metrics)
+	m, err := newMetricsRegistry(c.Metrics)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing metrics: %v", err)
 	}

--- a/node.go
+++ b/node.go
@@ -982,21 +982,26 @@ func (n *Node) pubDisconnect(user string, disconnect Disconnect, clientID string
 
 // addClient registers authenticated connection in clientConnectionHub
 // this allows to make operations with user connection on demand.
-func (n *Node) addClient(c *Client) error {
+func (n *Node) addClient(c *Client) {
 	n.metrics.incActionCount("add_client", "")
-	return n.hub.add(c)
+	n.metrics.connectionsInflight.WithLabelValues(c.transport.Name(), c.metricName, c.metricVersion).Inc()
+	n.hub.add(c)
 }
 
 // removeClient removes client connection from connection registry.
-func (n *Node) removeClient(c *Client) error {
+func (n *Node) removeClient(c *Client) {
 	n.metrics.incActionCount("remove_client", "")
-	return n.hub.remove(c)
+	removed := n.hub.remove(c)
+	if removed {
+		n.metrics.connectionsInflight.WithLabelValues(c.transport.Name(), c.metricName, c.metricVersion).Dec()
+	}
 }
 
 // addSubscription registers subscription of connection on channel in both
 // Hub and Broker.
 func (n *Node) addSubscription(ch string, sub subInfo) error {
 	n.metrics.incActionCount("add_subscription", ch)
+	n.metrics.subscriptionsInflight.WithLabelValues(sub.client.metricName, n.metrics.getChannelNamespaceLabel(ch)).Inc()
 	mu := n.subLock(ch)
 	mu.Lock()
 	defer mu.Unlock()
@@ -1047,9 +1052,9 @@ func (n *Node) removeSubscription(ch string, c *Client) error {
 	mu := n.subLock(ch)
 	mu.Lock()
 	defer mu.Unlock()
-	empty, err := n.hub.removeSub(ch, c)
-	if err != nil {
-		return err
+	empty, wasRemoved := n.hub.removeSub(ch, c)
+	if wasRemoved {
+		n.metrics.subscriptionsInflight.WithLabelValues(c.metricName, n.metrics.getChannelNamespaceLabel(ch)).Dec()
 	}
 	if empty {
 		submittedAt := time.Now()

--- a/node.go
+++ b/node.go
@@ -175,11 +175,11 @@ func New(c Config) (*Node, error) {
 	}
 	n.emulationSurveyHandler = newEmulationSurveyHandler(n)
 
-	if m, err := initMetricsRegistry(prometheus.DefaultRegisterer, c.MetricsNamespace); err != nil {
-		return nil, err
-	} else {
-		n.metrics = m
+	m, err := initMetricsRegistry(c.Metrics)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing metrics: %v", err)
 	}
+	n.metrics = m
 
 	n.hub = newHub(lg, n.metrics, c.ClientChannelPositionMaxTimeLag.Milliseconds())
 
@@ -189,11 +189,11 @@ func New(c Config) (*Node, error) {
 	}
 	n.SetBroker(b)
 
-	m, err := NewMemoryPresenceManager(n, MemoryPresenceManagerConfig{})
+	pm, err := NewMemoryPresenceManager(n, MemoryPresenceManagerConfig{})
 	if err != nil {
 		return nil, err
 	}
-	n.SetPresenceManager(m)
+	n.SetPresenceManager(pm)
 
 	return n, nil
 }
@@ -347,9 +347,17 @@ func (n *Node) initMetrics() error {
 	if n.config.NodeInfoMetricsAggregateInterval == 0 {
 		return nil
 	}
+
+	var gatherer prometheus.Gatherer
+	if n.metrics.config.RegistererGatherer != nil {
+		gatherer = n.metrics.config.RegistererGatherer
+	} else {
+		gatherer = prometheus.DefaultGatherer
+	}
+
 	metricsSink := make(chan eagle.Metrics)
 	n.metricsExporter = eagle.New(eagle.Config{
-		Gatherer: prometheus.DefaultGatherer,
+		Gatherer: gatherer,
 		Interval: n.config.NodeInfoMetricsAggregateInterval,
 		Sink:     metricsSink,
 	})
@@ -491,7 +499,7 @@ func (n *Node) Survey(ctx context.Context, op string, data []byte, toNodeID stri
 		return nil, errSurveyHandlerNotRegistered
 	}
 
-	n.metrics.incActionCount("survey")
+	n.metrics.incActionCount("survey", "")
 	started := time.Now()
 	defer func() {
 		n.metrics.observeSurveyDuration(op, time.Since(started))
@@ -646,7 +654,7 @@ func (n *Node) Info() (Info, error) {
 // handleControl handles messages from control channel - control messages used for internal
 // communication between nodes to share state or proto.
 func (n *Node) handleControl(data []byte) error {
-	n.metrics.incMessagesReceived("control")
+	n.metrics.incMessagesReceived("control", "")
 
 	cmd, err := n.controlDecoder.DecodeCommand(data)
 	if err != nil {
@@ -700,7 +708,7 @@ func (n *Node) handleControl(data []byte) error {
 // coming from Broker. The goal of method is to deliver this message
 // to all clients on this node currently subscribed to channel.
 func (n *Node) handlePublication(ch string, sp StreamPosition, pub, prevPub, localPrevPub *Publication) error {
-	n.metrics.incMessagesReceived("publication")
+	n.metrics.incMessagesReceived("publication", ch)
 	numSubscribers := n.hub.NumSubscribers(ch)
 	hasCurrentSubscribers := numSubscribers > 0
 	if !hasCurrentSubscribers {
@@ -712,7 +720,7 @@ func (n *Node) handlePublication(ch string, sp StreamPosition, pub, prevPub, loc
 // handleJoin handles join messages - i.e. broadcasts it to
 // interested local clients subscribed to channel.
 func (n *Node) handleJoin(ch string, info *ClientInfo) error {
-	n.metrics.incMessagesReceived("join")
+	n.metrics.incMessagesReceived("join", ch)
 	numSubscribers := n.hub.NumSubscribers(ch)
 	hasCurrentSubscribers := numSubscribers > 0
 	if !hasCurrentSubscribers {
@@ -724,7 +732,7 @@ func (n *Node) handleJoin(ch string, info *ClientInfo) error {
 // handleLeave handles leave messages - i.e. broadcasts it to
 // interested local clients subscribed to channel.
 func (n *Node) handleLeave(ch string, info *ClientInfo) error {
-	n.metrics.incMessagesReceived("leave")
+	n.metrics.incMessagesReceived("leave", ch)
 	numSubscribers := n.hub.NumSubscribers(ch)
 	hasCurrentSubscribers := numSubscribers > 0
 	if !hasCurrentSubscribers {
@@ -738,7 +746,7 @@ func (n *Node) publish(ch string, data []byte, opts ...PublishOption) (PublishRe
 	for _, opt := range opts {
 		opt(pubOpts)
 	}
-	n.metrics.incMessagesSent("publication")
+	n.metrics.incMessagesSent("publication", ch)
 	streamPos, fromCache, err := n.getBroker(ch).Publish(ch, data, *pubOpts)
 	if err != nil {
 		return PublishResult{}, err
@@ -778,14 +786,14 @@ func (n *Node) Publish(channel string, data []byte, opts ...PublishOption) (Publ
 // publishJoin allows publishing join message into channel when someone subscribes on it
 // or leave message when someone unsubscribes from channel.
 func (n *Node) publishJoin(ch string, info *ClientInfo) error {
-	n.metrics.incMessagesSent("join")
+	n.metrics.incMessagesSent("join", ch)
 	return n.getBroker(ch).PublishJoin(ch, info)
 }
 
 // publishLeave allows publishing join message into channel when someone subscribes on it
 // or leave message when someone unsubscribes from channel.
 func (n *Node) publishLeave(ch string, info *ClientInfo) error {
-	n.metrics.incMessagesSent("leave")
+	n.metrics.incMessagesSent("leave", ch)
 	return n.getBroker(ch).PublishLeave(ch, info)
 }
 
@@ -802,7 +810,7 @@ func (n *Node) Notify(op string, data []byte, toNodeID string) error {
 		return errNotificationHandlerNotRegistered
 	}
 
-	n.metrics.incActionCount("notify")
+	n.metrics.incActionCount("notify", "")
 
 	if toNodeID == "" || n.ID() == toNodeID {
 		// Invoke handler on this node since control message handler
@@ -832,7 +840,7 @@ func (n *Node) Notify(op string, data []byte, toNodeID string) error {
 // publishControl publishes message into control channel so all running
 // nodes will receive and handle it.
 func (n *Node) publishControl(cmd *controlpb.Command, nodeID string) error {
-	n.metrics.incMessagesSent("control")
+	n.metrics.incMessagesSent("control", "")
 	data, err := n.controlEncoder.EncodeCommand(cmd)
 	if err != nil {
 		return err
@@ -975,20 +983,20 @@ func (n *Node) pubDisconnect(user string, disconnect Disconnect, clientID string
 // addClient registers authenticated connection in clientConnectionHub
 // this allows to make operations with user connection on demand.
 func (n *Node) addClient(c *Client) error {
-	n.metrics.incActionCount("add_client")
+	n.metrics.incActionCount("add_client", "")
 	return n.hub.add(c)
 }
 
 // removeClient removes client connection from connection registry.
 func (n *Node) removeClient(c *Client) error {
-	n.metrics.incActionCount("remove_client")
+	n.metrics.incActionCount("remove_client", "")
 	return n.hub.remove(c)
 }
 
 // addSubscription registers subscription of connection on channel in both
 // Hub and Broker.
 func (n *Node) addSubscription(ch string, sub subInfo) error {
-	n.metrics.incActionCount("add_subscription")
+	n.metrics.incActionCount("add_subscription", ch)
 	mu := n.subLock(ch)
 	mu.Lock()
 	defer mu.Unlock()
@@ -1012,6 +1020,7 @@ func (n *Node) addSubscription(ch string, sub subInfo) error {
 			}
 		}
 
+		n.metrics.incActionCount("broker_subscribe", ch)
 		err := n.getBroker(ch).Subscribe(ch)
 		if err != nil {
 			_, _ = n.hub.removeSub(ch, sub.client)
@@ -1034,7 +1043,7 @@ func (n *Node) addSubscription(ch string, sub subInfo) error {
 // removeSubscription removes subscription of connection on channel
 // from Hub and Broker.
 func (n *Node) removeSubscription(ch string, c *Client) error {
-	n.metrics.incActionCount("remove_subscription")
+	n.metrics.incActionCount("remove_subscription", ch)
 	mu := n.subLock(ch)
 	mu.Lock()
 	defer mu.Unlock()
@@ -1054,6 +1063,7 @@ func (n *Node) removeSubscription(ch string, c *Client) error {
 			defer mu.Unlock()
 			empty := n.hub.NumSubscribers(ch) == 0
 			if empty {
+				n.metrics.incActionCount("broker_unsubscribe", ch)
 				err := n.getBroker(ch).Unsubscribe(ch)
 				if err != nil {
 					// Cool down a bit since broker is not ready to process unsubscription.
@@ -1189,7 +1199,7 @@ func (n *Node) addPresence(ch string, uid string, info *ClientInfo) error {
 	if presenceManager == nil {
 		return nil
 	}
-	n.metrics.incActionCount("add_presence")
+	n.metrics.incActionCount("add_presence", ch)
 	return presenceManager.AddPresence(ch, uid, info)
 }
 
@@ -1199,7 +1209,7 @@ func (n *Node) removePresence(ch string, clientID string, userID string) error {
 	if presenceManager == nil {
 		return nil
 	}
-	n.metrics.incActionCount("remove_presence")
+	n.metrics.incActionCount("remove_presence", ch)
 	return presenceManager.RemovePresence(ch, clientID, userID)
 }
 
@@ -1228,7 +1238,7 @@ func (n *Node) Presence(ch string) (PresenceResult, error) {
 	if presenceManager == nil {
 		return PresenceResult{}, ErrorNotAvailable
 	}
-	n.metrics.incActionCount("presence")
+	n.metrics.incActionCount("presence", ch)
 	if n.config.UseSingleFlight {
 		result, err, _ := presenceGroup.Do(ch, func() (any, error) {
 			return n.presence(ch, presenceManager)
@@ -1316,7 +1326,7 @@ func (n *Node) PresenceStats(ch string) (PresenceStatsResult, error) {
 	if presenceManager == nil {
 		return PresenceStatsResult{}, ErrorNotAvailable
 	}
-	n.metrics.incActionCount("presence_stats")
+	n.metrics.incActionCount("presence_stats", ch)
 	if n.config.UseSingleFlight {
 		result, err, _ := presenceStatsGroup.Do(ch, func() (any, error) {
 			return n.presenceStats(ch, presenceManager)
@@ -1371,7 +1381,7 @@ func (n *Node) history(ch string, opts *HistoryOptions) (HistoryResult, error) {
 // History allows extracting Publications in channel.
 // The channel must belong to namespace where history is on.
 func (n *Node) History(ch string, opts ...HistoryOption) (HistoryResult, error) {
-	n.metrics.incActionCount("history")
+	n.metrics.incActionCount("history", ch)
 	historyOpts := &HistoryOptions{}
 	for _, opt := range opts {
 		opt(historyOpts)
@@ -1404,7 +1414,7 @@ func (n *Node) History(ch string, opts ...HistoryOption) (HistoryResult, error) 
 
 // recoverHistory recovers publications since StreamPosition last seen by client.
 func (n *Node) recoverHistory(ch string, since StreamPosition, historyMetaTTL time.Duration) (HistoryResult, error) {
-	n.metrics.incActionCount("history_recover")
+	n.metrics.incActionCount("history_recover", ch)
 	limit := NoLimit
 	maxPublicationLimit := n.config.RecoveryMaxPublicationLimit
 	if maxPublicationLimit > 0 {
@@ -1418,13 +1428,7 @@ func (n *Node) recoverHistory(ch string, since StreamPosition, historyMetaTTL ti
 
 // recoverCache recovers last publication in channel.
 func (n *Node) recoverCache(ch string, historyMetaTTL time.Duration) (*Publication, StreamPosition, error) {
-	n.metrics.incActionCount("history_recover")
-	return n.streamTopLatestPub(ch, historyMetaTTL)
-}
-
-// streamTopLatestPub returns latest publication in channel with actual stream position.
-func (n *Node) streamTopLatestPub(ch string, historyMetaTTL time.Duration) (*Publication, StreamPosition, error) {
-	n.metrics.incActionCount("history_stream_top_latest_pub")
+	n.metrics.incActionCount("history_recover_cache", ch)
 	hr, err := n.History(ch, WithHistoryFilter(HistoryFilter{
 		Limit:   1,
 		Reverse: true,
@@ -1441,7 +1445,7 @@ func (n *Node) streamTopLatestPub(ch string, historyMetaTTL time.Duration) (*Pub
 
 // streamTop returns current stream top StreamPosition for a channel.
 func (n *Node) streamTop(ch string, historyMetaTTL time.Duration) (StreamPosition, error) {
-	n.metrics.incActionCount("history_stream_top")
+	n.metrics.incActionCount("history_stream_top", ch)
 	historyResult, err := n.History(ch, WithHistoryMetaTTL(historyMetaTTL))
 	if err != nil {
 		return StreamPosition{}, err
@@ -1469,7 +1473,7 @@ func (n *Node) checkPosition(ch string, clientPosition StreamPosition, historyMe
 
 // RemoveHistory removes channel history.
 func (n *Node) RemoveHistory(ch string) error {
-	n.metrics.incActionCount("history_remove")
+	n.metrics.incActionCount("history_remove", ch)
 	return n.getBroker(ch).RemoveHistory(ch)
 }
 


### PR DESCRIPTION
Rework of metrics code to support channel namespace resolution for all relevant operations.

Outside that:

* Support setting custom Prometheus registry
* Better performance for some existing metrics
* Built-in cache for GetChannelNamespaceLabel results
* More metrics like client connections inflight and subscriptions inflight