### PR TITLE
Options to utilize Redis replicas

### DIFF
--- a/_examples/redis_broker_presence/main.go
+++ b/_examples/redis_broker_presence/main.go
@@ -98,6 +98,13 @@ func main() {
 	redisShardConfigs := []centrifuge.RedisShardConfig{
 		{Address: "localhost:6379"},
 		//{Address: "localhost:6380"},
+		//{
+		//	ClusterAddresses:  []string{"localhost:7000", "localhost:7001", "localhost:7002"},
+		//},
+		//{
+		//	SentinelAddresses:  []string{"localhost:26379"},
+		//	SentinelMasterName: "mymaster",
+		//},
 	}
 	var redisShards []*centrifuge.RedisShard
 	for _, redisConf := range redisShardConfigs {

--- a/broker_redis.go
+++ b/broker_redis.go
@@ -103,6 +103,11 @@ type RedisBrokerConfig struct {
 	// Iteration over history in reversed order not supported with lists.
 	UseLists bool
 
+	// Subscribe on replica Redis nodes. This only works for Redis Cluster
+	// and Sentinel setups and requires replica client to be initialized in
+	// each RedisShard using RedisShardConfig.InitReplicaClient.
+	SubscribeOnReplica bool
+
 	// SkipPubSub enables mode when Redis broker only saves history, without
 	// publishing to channels and using PUB/SUB.
 	SkipPubSub bool
@@ -144,6 +149,14 @@ type RedisBrokerConfig struct {
 func NewRedisBroker(n *Node, config RedisBrokerConfig) (*RedisBroker, error) {
 	if len(config.Shards) == 0 {
 		return nil, errors.New("broker: no Redis shards provided in configuration")
+	}
+
+	if config.SubscribeOnReplica {
+		for i, s := range config.Shards {
+			if s.replicaClient == nil {
+				return nil, fmt.Errorf("broker: SubscribeOnReplica enabled but no replica client initialized in shard[%d] (InitReplicaClient option)", i)
+			}
+		}
 	}
 
 	if len(config.Shards) > 1 {
@@ -379,7 +392,12 @@ func (b *RedisBroker) runControlPubSub(s *RedisShard, eventHandler BrokerEventHa
 	}
 	defer closeDoneOnce()
 
-	conn, cancel := s.client.Dedicate()
+	client := s.client
+	if b.config.SubscribeOnReplica {
+		client = s.replicaClient
+	}
+
+	conn, cancel := client.Dedicate()
 	defer cancel()
 	defer conn.Close()
 
@@ -478,7 +496,12 @@ func (b *RedisBroker) runPubSub(s *shardWrapper, eventHandler BrokerEventHandler
 		}(processingCh)
 	}
 
-	conn, cancel := s.shard.client.Dedicate()
+	client := s.shard.client
+	if b.config.SubscribeOnReplica {
+		client = s.shard.replicaClient
+	}
+
+	conn, cancel := client.Dedicate()
 	defer cancel()
 	defer conn.Close()
 

--- a/presence_redis.go
+++ b/presence_redis.go
@@ -58,6 +58,11 @@ type RedisPresenceManagerConfig struct {
 	// maintaining expiration index in ZSET – so both useful from the throughput and memory usage
 	// perspective.
 	UseHashFieldTTL bool
+
+	// ReadFromReplica enables reading presence information from replica Redis servers.
+	// This only works in Redis Cluster and Sentinel setups and requires replica client
+	// to be initialized in each RedisShard using RedisShardConfig.InitReplicaClient.
+	ReadFromReplica bool
 }
 
 var (
@@ -78,6 +83,18 @@ var (
 func NewRedisPresenceManager(n *Node, config RedisPresenceManagerConfig) (*RedisPresenceManager, error) {
 	if len(config.Shards) == 0 {
 		return nil, errors.New("presence: no Redis shards provided in configuration")
+	}
+
+	if config.ReadFromReplica && !config.UseHashFieldTTL {
+		return nil, errors.New("presence: ReadFromReplica requires UseHashFieldTTL to be enabled")
+	}
+
+	if config.ReadFromReplica {
+		for i, s := range config.Shards {
+			if s.replicaClient == nil {
+				return nil, fmt.Errorf("presence: ReadFromReplica enabled but no replica client initialized in shard[%d] (InitReplicaClient option)", i)
+			}
+		}
 	}
 
 	if len(config.Shards) > 1 {
@@ -237,7 +254,11 @@ func (m *RedisPresenceManager) presence(s *RedisShard, ch string) (map[string]*C
 	if err != nil {
 		return nil, err
 	}
-	resp, err := m.presenceScript.Exec(context.Background(), s.client, keys, args).ToArray()
+	client := s.client
+	if m.config.ReadFromReplica {
+		client = s.replicaClient
+	}
+	resp, err := m.presenceScript.Exec(context.Background(), client, keys, args).ToArray()
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +294,12 @@ func (m *RedisPresenceManager) presenceStats(s *RedisShard, ch string) (Presence
 	if err != nil {
 		return PresenceStats{}, err
 	}
-	replies, err := m.presenceStatsScript.Exec(context.Background(), s.client, keys, args).ToArray()
+	client := s.client
+	if m.config.ReadFromReplica {
+		client = s.replicaClient
+	}
+
+	replies, err := m.presenceStatsScript.Exec(context.Background(), client, keys, args).ToArray()
 	if err != nil {
 		return PresenceStats{}, err
 	}


### PR DESCRIPTION
Possibility to:

* Use Redis replica for subscribing to channels
* Use Redis replica for reading presence info (requires `UseHashFieldTTL: true`)