### PR TITLE
Cache preflight requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,14 @@ http.Handle("/connection/http_stream", CORS(centrifuge.NewHTTPStreamHandler(node
 
 You can also configure CORS on load-balancer/reverse-proxy level.
 
+### Server timeouts and HTTP-based real-time transports
+
+Centrifuge uses [http.ResponseController](https://pkg.go.dev/net/http#ResponseController) when working with timeouts in HTTP-streaming and Server-Sent Events (SSE) handlers. This allows having custom timeouts for HTTP server. But if you are using HTTP middlewares which provide a custom implementation of `http.ResponseWriter` – then make sure they implement `Unwrap` method to access original `http.ResponseWriter` for `ResponseController` to work correctly. As per `http` package documentation:
+
+> The ResponseWriter should be the original value passed to the [Handler.ServeHTTP] method, or have an Unwrap method returning the original ResponseWriter.
+
+If handlers can't access original `http.ResponseWriter` – then you will observe connection closing corresponding to your HTTP server's `ReadTimeout` setting.
+
 ### For contributors
 
 #### Running integration tests locally

--- a/broker_redis.go
+++ b/broker_redis.go
@@ -1111,12 +1111,12 @@ var (
 )
 
 func (b *RedisBroker) handleRedisClientMessage(eventHandler BrokerEventHandler, chID channelID, data []byte) error {
-	pushData, pushType, sp, delta, prevPayload, ok := extractPushData(data)
+	pushData, typeOfPush, sp, delta, prevPayload, ok := extractPushData(data)
 	if !ok {
 		return fmt.Errorf("malformed PUB/SUB data: %s", data)
 	}
 	channel := b.extractChannel(chID)
-	if pushType == pubPushType {
+	if typeOfPush == pubPushType {
 		var pub protocol.Publication
 		err := pub.UnmarshalVT(pushData)
 		if err != nil {
@@ -1144,14 +1144,14 @@ func (b *RedisBroker) handleRedisClientMessage(eventHandler BrokerEventHandler, 
 		} else {
 			_ = eventHandler.HandlePublication(channel, pubFromProto(&pub), sp, delta, nil)
 		}
-	} else if pushType == joinPushType {
+	} else if typeOfPush == joinPushType {
 		var info protocol.ClientInfo
 		err := info.UnmarshalVT(pushData)
 		if err != nil {
 			return err
 		}
 		_ = eventHandler.HandleJoin(channel, infoFromProto(&info))
-	} else if pushType == leavePushType {
+	} else if typeOfPush == leavePushType {
 		var info protocol.ClientInfo
 		err := info.UnmarshalVT(pushData)
 		if err != nil {

--- a/emulation.go
+++ b/emulation.go
@@ -41,7 +41,9 @@ func NewEmulationHandler(node *Node, config EmulationConfig) *EmulationHandler {
 func (s *EmulationHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodOptions {
 		// For pre-flight browser requests.
-		rw.WriteHeader(http.StatusOK)
+		rw.Header().Set("Access-Control-Max-Age", "300")
+		rw.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		rw.WriteHeader(http.StatusNoContent)
 		return
 	}
 
@@ -58,7 +60,7 @@ func (s *EmulationHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 			rw.WriteHeader(http.StatusRequestEntityTooLarge)
 			return
 		}
-		rw.WriteHeader(http.StatusInternalServerError)
+		rw.WriteHeader(statusCodeClientConnectionClosed)
 		return
 	}
 

--- a/emulation.go
+++ b/emulation.go
@@ -46,6 +46,10 @@ func (s *EmulationHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		rw.WriteHeader(http.StatusNoContent)
 		return
 	}
+	if r.Method != http.MethodPost {
+		rw.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
 
 	maxBytesSize := s.config.MaxRequestBodySize
 	if maxBytesSize == 0 {

--- a/emulation_test.go
+++ b/emulation_test.go
@@ -34,6 +34,27 @@ func TestEmulationHandler_Options(t *testing.T) {
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
+func TestEmulationHandler_UnknownMethod(t *testing.T) {
+	t.Parallel()
+	n, _ := New(Config{})
+	require.NoError(t, n.Run())
+	defer func() { _ = n.Shutdown(context.Background()) }()
+	mux := http.NewServeMux()
+	mux.Handle("/emulation", NewEmulationHandler(n, EmulationConfig{}))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	url := server.URL + "/emulation"
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	req, err := http.NewRequest(http.MethodPatch, url, bytes.NewBuffer(nil))
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+}
+
 func TestEmulationHandler_RequestTooLarge(t *testing.T) {
 	t.Parallel()
 	n, _ := New(Config{})

--- a/emulation_test.go
+++ b/emulation_test.go
@@ -31,7 +31,7 @@ func TestEmulationHandler_Options(t *testing.T) {
 
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
 func TestEmulationHandler_RequestTooLarge(t *testing.T) {

--- a/handler_http_stream_test.go
+++ b/handler_http_stream_test.go
@@ -164,7 +164,7 @@ func TestHTTPStreamHandler_Options(t *testing.T) {
 
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
 func newJSONStreamDecoder(body io.Reader) *jsonStreamDecoder {

--- a/writer.go
+++ b/writer.go
@@ -150,7 +150,6 @@ func (w *writer) close(flushRemaining bool) error {
 	if flushRemaining {
 		remaining := w.messages.CloseRemaining()
 		if len(remaining) > 0 {
-			// TODO: make it respect MaxMessagesInFrame option.
 			_ = w.config.WriteManyFn(remaining...)
 		}
 	} else {


### PR DESCRIPTION
Add `rw.Header().Set("Access-Control-Max-Age", "300")` to OPTIONS requests for emulation and http_stream handlers. This helps to avoid sending preflight requests with every request.

Other changes:

* return 499 when can't read body instead of 500 in emulation, HTTP-streaming and SSE handlers
* return 204 instead of 200 for preflight requests
* document `http.ResponseController` usage in emulation transports