### PR TITLE
Per channel writer for per channel batching

### DIFF
--- a/client.go
+++ b/client.go
@@ -2637,8 +2637,9 @@ func (c *Client) startWriter(batchDelay time.Duration, maxMessagesInFrame int, q
 
 		c.messageWriter = newWriter(messageWriterConf, queueInitialCap)
 		go c.messageWriter.run(batchDelay, maxMessagesInFrame)
-
-		c.perChannelWriter = newPerChannelWriter(c.writeQueueItems)
+		if c.node.config.GetChannelBatchConfig != nil {
+			c.perChannelWriter = newPerChannelWriter(c.writeQueueItems)
+		}
 	})
 }
 

--- a/client_experimental.go
+++ b/client_experimental.go
@@ -118,13 +118,6 @@ func (c *Client) writeQueueItems(items []queue.Item) error {
 	return nil
 }
 
-func (c *Client) getChannelWriteConfig(channel string) ChannelBatchConfig {
-	if c.node.config.GetChannelBatchConfig == nil {
-		return ChannelBatchConfig{}
-	}
-	return c.node.config.GetChannelBatchConfig(channel)
-}
-
 // ChannelBatchConfig allows configuring how to write push messages to a channel
 // during broadcasts (applied for publication, join and leave pushes).
 // This API is EXPERIMENTAL and may be changed/removed.

--- a/client_experimental_test.go
+++ b/client_experimental_test.go
@@ -2,8 +2,6 @@ package centrifuge
 
 import (
 	"context"
-	"github.com/centrifugal/protocol"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"strings"
 	"sync"
@@ -11,6 +9,9 @@ import (
 	"time"
 
 	"github.com/centrifugal/centrifuge/internal/queue"
+
+	"github.com/centrifugal/protocol"
+	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkPerChannelWriter(b *testing.B) {
@@ -40,11 +41,11 @@ func BenchmarkPerChannelWriter(b *testing.B) {
 func TestClientSubscribeReceivePublication_ChannelBatching_Delay(t *testing.T) {
 	t.Parallel()
 	node := defaultTestNode()
-	node.config.GetChannelBatchConfig = func(channel string) (ChannelBatchConfig, bool) {
+	node.config.GetChannelBatchConfig = func(channel string) (ChannelBatchConfig, error) {
 		return ChannelBatchConfig{
-			MaxBatchSize: 0,
-			WriteDelay:   10 * time.Millisecond,
-		}, true
+			MaxSize:  0,
+			MaxDelay: 10 * time.Millisecond,
+		}, nil
 	}
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	transport := newTestTransport(func() {})
@@ -86,11 +87,11 @@ func TestClientSubscribeReceivePublication_ChannelBatching_Delay(t *testing.T) {
 func TestClientSubscribeReceivePublication_ChannelBatching_BatchSize(t *testing.T) {
 	t.Parallel()
 	node := defaultTestNode()
-	node.config.GetChannelBatchConfig = func(channel string) (ChannelBatchConfig, bool) {
+	node.config.GetChannelBatchConfig = func(channel string) (ChannelBatchConfig, error) {
 		return ChannelBatchConfig{
-			MaxBatchSize: 1,
-			WriteDelay:   0,
-		}, true
+			MaxSize:  1,
+			MaxDelay: 0,
+		}, nil
 	}
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	transport := newTestTransport(func() {})

--- a/client_experimental_test.go
+++ b/client_experimental_test.go
@@ -1,0 +1,130 @@
+package centrifuge
+
+import (
+	"context"
+	"github.com/centrifugal/protocol"
+	"github.com/stretchr/testify/require"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/centrifugal/centrifuge/internal/queue"
+)
+
+func BenchmarkPerChannelWriter(b *testing.B) {
+	const numChannels = 10
+	var wg sync.WaitGroup
+
+	flushFn := func(items []queue.Item) error {
+		for range items {
+			wg.Done()
+		}
+		return nil
+	}
+
+	w := newPerChannelWriter(flushFn)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		wg.Add(1) // Each added message increments the WaitGroup counter.
+		channelName := "channel-" + strconv.Itoa(i%numChannels)
+		item := queue.Item{Channel: channelName}
+		w.Add(item, 10*time.Millisecond, 128)
+	}
+	w.Close(true)
+	wg.Wait() // Wait for all messages to be flushed.
+}
+
+func TestClientSubscribeReceivePublication_ChannelBatching_Delay(t *testing.T) {
+	t.Parallel()
+	node := defaultTestNode()
+	node.config.GetChannelBatchConfig = func(channel string) (ChannelBatchConfig, bool) {
+		return ChannelBatchConfig{
+			MaxBatchSize: 0,
+			WriteDelay:   10 * time.Millisecond,
+		}, true
+	}
+	defer func() { _ = node.Shutdown(context.Background()) }()
+	transport := newTestTransport(func() {})
+	transport.sink = make(chan []byte, 100)
+	ctx := context.Background()
+	newCtx := SetCredentials(ctx, &Credentials{UserID: "42"})
+	client, _ := newClient(newCtx, node, transport)
+
+	connectClientV2(t, client)
+
+	rwWrapper := testReplyWriterWrapper()
+
+	client.channels["test"] = ChannelContext{}
+	subCtx := client.subscribeCmd(&protocol.SubscribeRequest{
+		Channel: "test",
+	}, SubscribeReply{}, &protocol.Command{}, false, time.Now(), rwWrapper.rw)
+	require.Nil(t, subCtx.disconnect)
+	require.Nil(t, rwWrapper.replies[0].Error)
+
+	done := make(chan struct{})
+	go func() {
+		for data := range transport.sink {
+			if strings.Contains(string(data), "test message") {
+				close(done)
+			}
+		}
+	}()
+
+	_, err := node.Publish("test", []byte(`{"text": "test message"}`))
+	require.NoError(t, err)
+
+	select {
+	case <-time.After(time.Second):
+		require.Fail(t, "timeout receiving publication")
+	case <-done:
+	}
+}
+
+func TestClientSubscribeReceivePublication_ChannelBatching_BatchSize(t *testing.T) {
+	t.Parallel()
+	node := defaultTestNode()
+	node.config.GetChannelBatchConfig = func(channel string) (ChannelBatchConfig, bool) {
+		return ChannelBatchConfig{
+			MaxBatchSize: 1,
+			WriteDelay:   0,
+		}, true
+	}
+	defer func() { _ = node.Shutdown(context.Background()) }()
+	transport := newTestTransport(func() {})
+	transport.sink = make(chan []byte, 100)
+	ctx := context.Background()
+	newCtx := SetCredentials(ctx, &Credentials{UserID: "42"})
+	client, _ := newClient(newCtx, node, transport)
+
+	connectClientV2(t, client)
+
+	rwWrapper := testReplyWriterWrapper()
+
+	client.channels["test"] = ChannelContext{}
+	subCtx := client.subscribeCmd(&protocol.SubscribeRequest{
+		Channel: "test",
+	}, SubscribeReply{}, &protocol.Command{}, false, time.Now(), rwWrapper.rw)
+	require.Nil(t, subCtx.disconnect)
+	require.Nil(t, rwWrapper.replies[0].Error)
+
+	done := make(chan struct{})
+	go func() {
+		for data := range transport.sink {
+			if strings.Contains(string(data), "test message") {
+				close(done)
+			}
+		}
+	}()
+
+	_, err := node.Publish("test", []byte(`{"text": "test message"}`))
+	require.NoError(t, err)
+
+	select {
+	case <-time.After(time.Second):
+		require.Fail(t, "timeout receiving publication")
+	case <-done:
+	}
+}

--- a/client_experimental_test.go
+++ b/client_experimental_test.go
@@ -32,7 +32,7 @@ func BenchmarkPerChannelWriter(b *testing.B) {
 		wg.Add(1) // Each added message increments the WaitGroup counter.
 		channelName := "channel-" + strconv.Itoa(i%numChannels)
 		item := queue.Item{Channel: channelName}
-		w.Add(item, 10*time.Millisecond, 128)
+		w.Add(item, channelName, 10*time.Millisecond, 128)
 	}
 	w.Close(true)
 	wg.Wait() // Wait for all messages to be flushed.
@@ -41,11 +41,11 @@ func BenchmarkPerChannelWriter(b *testing.B) {
 func TestClientSubscribeReceivePublication_ChannelBatching_Delay(t *testing.T) {
 	t.Parallel()
 	node := defaultTestNode()
-	node.config.GetChannelBatchConfig = func(channel string) (ChannelBatchConfig, error) {
+	node.config.GetChannelBatchConfig = func(channel string) ChannelBatchConfig {
 		return ChannelBatchConfig{
 			MaxSize:  0,
 			MaxDelay: 10 * time.Millisecond,
-		}, nil
+		}
 	}
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	transport := newTestTransport(func() {})
@@ -87,11 +87,11 @@ func TestClientSubscribeReceivePublication_ChannelBatching_Delay(t *testing.T) {
 func TestClientSubscribeReceivePublication_ChannelBatching_BatchSize(t *testing.T) {
 	t.Parallel()
 	node := defaultTestNode()
-	node.config.GetChannelBatchConfig = func(channel string) (ChannelBatchConfig, error) {
+	node.config.GetChannelBatchConfig = func(channel string) ChannelBatchConfig {
 		return ChannelBatchConfig{
 			MaxSize:  1,
 			MaxDelay: 0,
-		}, nil
+		}
 	}
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	transport := newTestTransport(func() {})

--- a/config.go
+++ b/config.go
@@ -130,9 +130,8 @@ type Config struct {
 	// batching, so you can expect memory overhead. But batching may be useful for reducing CPU usage
 	// coming from write system calls in channels with high publication rate. If GetChannelBatchConfig
 	// not set then no batching is used on per-channel level. This function may be called in the hot
-	// broadcast path, so must be fast. If an error is returned from this function – message will be
-	// skipped by Centrifuge. This is an EXPERIMENTAL feature.
-	GetChannelBatchConfig func(channel string) (ChannelBatchConfig, error)
+	// broadcast path, so must be fast. This is an EXPERIMENTAL feature.
+	GetChannelBatchConfig func(channel string) ChannelBatchConfig
 }
 
 const (

--- a/config.go
+++ b/config.go
@@ -124,6 +124,13 @@ type Config struct {
 	// transports. If not set or code not found in the mapping then Centrifuge falls back to the default
 	// mapping defined internally.
 	UnidirectionalCodeToDisconnect map[uint32]Disconnect
+	// GetChannelBatchConfig allows configuring per-channel write batching. Batching config if
+	// returned is applied for publications and join/leave channel pushes. The cost of batching
+	// are extra goroutines for each channel used in batching, so you expect some memory overhead.
+	// But batching is generally useful for reducing CPU usage coming from write system calls in
+	// channels with high publication rate. If GetChannelBatchConfig not set then no batching is
+	// used. This is an EXPERIMENTAL feature.
+	GetChannelBatchConfig func(channel string) (ChannelBatchConfig, bool)
 }
 
 const (

--- a/config.go
+++ b/config.go
@@ -125,12 +125,14 @@ type Config struct {
 	// mapping defined internally.
 	UnidirectionalCodeToDisconnect map[uint32]Disconnect
 	// GetChannelBatchConfig allows configuring per-channel write batching. Batching config if
-	// returned is applied for publications and join/leave channel pushes. The cost of batching
-	// are extra goroutines for each channel used in batching, so you expect some memory overhead.
-	// But batching is generally useful for reducing CPU usage coming from write system calls in
-	// channels with high publication rate. If GetChannelBatchConfig not set then no batching is
-	// used. This is an EXPERIMENTAL feature.
-	GetChannelBatchConfig func(channel string) (ChannelBatchConfig, bool)
+	// returned is applied for publications and join/leave channel pushes for all channel subscribers.
+	// The cost of batching are extra goroutines, buffers and extra timers for each channel used in
+	// batching, so you can expect memory overhead. But batching may be useful for reducing CPU usage
+	// coming from write system calls in channels with high publication rate. If GetChannelBatchConfig
+	// not set then no batching is used on per-channel level. This function may be called in the hot
+	// broadcast path, so must be fast. If an error is returned from this function – message will be
+	// skipped by Centrifuge. This is an EXPERIMENTAL feature.
+	GetChannelBatchConfig func(channel string) (ChannelBatchConfig, error)
 }
 
 const (

--- a/hub_test.go
+++ b/hub_test.go
@@ -599,6 +599,7 @@ func TestHubBroadcastPublicationDelta(t *testing.T) {
 				&Publication{Data: []byte(`{"data": "broadcast_data"}`), Offset: 1},
 				nil,
 				nil,
+				0, 0,
 			)
 			require.NoError(t, err)
 
@@ -620,7 +621,7 @@ func TestHubBroadcastPublicationDelta(t *testing.T) {
 				StreamPosition{Offset: 2, Epoch: res.StreamPosition.Epoch},
 				&Publication{Data: []byte(`{"data": "broadcast_data"}`), Offset: 2},
 				&Publication{Data: []byte(`{"data": "broadcast_data"}`), Offset: 1},
-				nil,
+				nil, 0, 0,
 			)
 			require.NoError(t, err)
 
@@ -678,7 +679,7 @@ func TestHubBroadcastPublicationDeltaAtMostOnce(t *testing.T) {
 				StreamPosition{Offset: 1, Epoch: res.StreamPosition.Epoch},
 				&Publication{Data: []byte(`{"data": "broadcast_data"}`), Offset: 1},
 				nil,
-				nil,
+				nil, 0, 0,
 			)
 			require.NoError(t, err)
 
@@ -700,7 +701,7 @@ func TestHubBroadcastPublicationDeltaAtMostOnce(t *testing.T) {
 				StreamPosition{Offset: 2, Epoch: res.StreamPosition.Epoch},
 				&Publication{Data: []byte(`{"data": "broadcast_data"}`), Offset: 2},
 				nil,
-				&Publication{Data: []byte(`{"data": "broadcast_data"}`), Offset: 1},
+				&Publication{Data: []byte(`{"data": "broadcast_data"}`), Offset: 1}, 0, 0,
 			)
 			require.NoError(t, err)
 
@@ -755,7 +756,7 @@ func TestHubBroadcastPublicationDeltaAtMostOnceNoOffset(t *testing.T) {
 				StreamPosition{},
 				&Publication{Data: []byte(`{"data": "broadcast_data"}`)},
 				nil,
-				nil,
+				nil, 0, 0,
 			)
 			require.NoError(t, err)
 
@@ -778,6 +779,7 @@ func TestHubBroadcastPublicationDeltaAtMostOnceNoOffset(t *testing.T) {
 				&Publication{Data: []byte(`{"data": "broadcast_data"}`)},
 				nil,
 				&Publication{Data: []byte(`{"data": "broadcast_data"}`)},
+				0, 0,
 			)
 			require.NoError(t, err)
 
@@ -827,11 +829,11 @@ func TestHubBroadcastJoin(t *testing.T) {
 			c.channels["test_channel"] = chCtx
 
 			// Broadcast to not existed channel.
-			err := n.hub.broadcastJoin("not_test_channel", &ClientInfo{ClientID: "broadcast_client"})
+			err := n.hub.broadcastJoin("not_test_channel", &ClientInfo{ClientID: "broadcast_client"}, 0, 0)
 			require.NoError(t, err)
 
 			// Broadcast to existed channel.
-			err = n.hub.broadcastJoin("test_channel", &ClientInfo{ClientID: "broadcast_client"})
+			err = n.hub.broadcastJoin("test_channel", &ClientInfo{ClientID: "broadcast_client"}, 0, 0)
 			require.NoError(t, err)
 		LOOP:
 			for {
@@ -878,11 +880,11 @@ func TestHubBroadcastLeave(t *testing.T) {
 			c.channels["test_channel"] = chCtx
 
 			// Broadcast to not existed channel.
-			err := n.hub.broadcastLeave("not_test_channel", &ClientInfo{ClientID: "broadcast_client"})
+			err := n.hub.broadcastLeave("not_test_channel", &ClientInfo{ClientID: "broadcast_client"}, 0, 0)
 			require.NoError(t, err)
 
 			// Broadcast to existed channel.
-			err = n.hub.broadcastLeave("test_channel", &ClientInfo{ClientID: "broadcast_client"})
+			err = n.hub.broadcastLeave("test_channel", &ClientInfo{ClientID: "broadcast_client"}, 0, 0)
 			require.NoError(t, err)
 		LOOP:
 			for {
@@ -1114,7 +1116,7 @@ func BenchmarkHub_MassiveBroadcast(b *testing.B) {
 						}
 					}
 				}()
-				_ = n.hub.broadcastPublication(channel, streamPosition, pub, nil, nil)
+				_ = n.hub.broadcastPublication(channel, streamPosition, pub, nil, nil, 0, 0)
 				wg.Wait()
 			}
 		})
@@ -1168,7 +1170,7 @@ func TestHubBroadcastInappropriateProtocol_Join(t *testing.T) {
 		}
 		err := n.hub.broadcastJoin("test_channel", &ClientInfo{
 			ChanInfo: []byte(`{111`),
-		})
+		}, 0, 0)
 		require.NoError(t, err)
 		waitWithTimeout(t, done)
 	}
@@ -1197,7 +1199,7 @@ func TestHubBroadcastInappropriateProtocol_Leave(t *testing.T) {
 		}
 		err := n.hub.broadcastLeave("test_channel", &ClientInfo{
 			ChanInfo: []byte(`{111`),
-		})
+		}, 0, 0)
 		require.NoError(t, err)
 		waitWithTimeout(t, done)
 	}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -14,7 +14,7 @@ type Item struct {
 
 // Queue is an unbounded queue of Item.
 // The queue is goroutine safe.
-// Inspired by http://blog.dubbelboer.com/2015/04/25/go-faster-queue.html (MIT)
+// Inspired by http://blog.dubbelboer.com/2015/04/25/go-faster-queue.html (MIT).
 type Queue struct {
 	mu      sync.RWMutex
 	cond    *sync.Cond
@@ -59,21 +59,6 @@ func (q *Queue) resize(n int) {
 	q.head = 0
 	q.nodes = nodes
 }
-
-//// Write mutex must be held when calling.
-//func (q *Queue) resize(n int) {
-//	nodes := make([]Item, n)
-//	if q.head < q.tail {
-//		copy(nodes, q.nodes[q.head:q.tail])
-//	} else {
-//		copy(nodes, q.nodes[q.head:])
-//		copy(nodes[len(q.nodes)-q.head:], q.nodes[:q.tail])
-//	}
-//
-//	q.tail = q.cnt % n
-//	q.head = 0
-//	q.nodes = nodes
-//}
 
 // Add an Item to the back of the queue
 // will return false if the queue is closed.
@@ -204,46 +189,6 @@ func (q *Queue) Remove() (Item, bool) {
 	q.mu.Unlock()
 	return i, true
 }
-
-//// RemoveMany removes up to maxItems items from the queue.
-//// If maxItems is -1, it removes all available items.
-//// It returns the slice of removed items and a boolean indicating whether
-//// at least one item was removed (false means no messages were available).
-//func (q *Queue) RemoveMany(maxItems int) ([]Item, bool) {
-//	q.mu.Lock()
-//
-//	// Return false if there are no messages.
-//	if q.cnt == 0 {
-//		q.mu.Unlock()
-//		return nil, false
-//	}
-//
-//	// Determine how many messages to remove.
-//	var count int
-//	if maxItems == -1 || q.cnt < maxItems {
-//		count = q.cnt
-//	} else {
-//		count = maxItems
-//	}
-//
-//	messages := make([]Item, 0, count)
-//
-//	for i := 0; i < count; i++ {
-//		msg := q.nodes[q.head]
-//		q.head = (q.head + 1) % len(q.nodes)
-//		messages = append(messages, msg)
-//		q.cnt--
-//		q.size -= len(msg.Data)
-//		// Resize the underlying slice if needed. It's important to keep resize
-//		// inside loop to avoid slice out of bounds issues.
-//		if n := len(q.nodes) / 2; n >= q.initCap && q.cnt <= n {
-//			q.resize(n)
-//		}
-//	}
-//
-//	q.mu.Unlock()
-//	return messages, true
-//}
 
 // RemoveMany removes up to maxItems items from the queue.
 // If maxItems is -1, it removes all available items.

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -274,15 +274,20 @@ func (q *Queue) RemoveMany(maxItems int) ([]Item, bool) {
 		messages = append(messages, msg)
 		q.cnt--
 		q.size -= len(msg.Data)
-		//// Resize the underlying slice if needed. It's important to keep resize
-		//// inside loop to avoid slice out of bounds issues.
-		//if n := len(q.nodes) / 2; n >= q.initCap && q.cnt <= n {
-		//	q.resize(n)
-		//}
 	}
 
-	// Resize only once after all removals if needed.
-	if n := len(q.nodes) / 2; n >= q.initCap && q.cnt <= n {
+	// Find n to resize to.
+	n := -1
+	k := len(q.nodes) / 2
+	for {
+		if k >= q.initCap && q.cnt <= k {
+			n = k
+		} else {
+			break
+		}
+		k /= 2
+	}
+	if n != -1 {
 		q.resize(n)
 	}
 

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -75,6 +75,27 @@ func (q *Queue) Add(i Item) bool {
 	return true
 }
 
+// AddMany items.
+func (q *Queue) AddMany(items ...Item) bool {
+	q.mu.Lock()
+	if q.closed {
+		q.mu.Unlock()
+		return false
+	}
+	for _, i := range items {
+		if q.cnt == len(q.nodes) {
+			q.resize(q.cnt * 2)
+		}
+		q.nodes[q.tail] = i
+		q.tail = (q.tail + 1) % len(q.nodes)
+		q.size += len(i.Data)
+		q.cnt++
+	}
+	q.cond.Signal()
+	q.mu.Unlock()
+	return true
+}
+
 // Close the queue and discard all entries in the queue
 // all goroutines in wait() will return
 func (q *Queue) Close() {

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -37,20 +37,43 @@ func New(initialCapacity int) *Queue {
 	return sq
 }
 
-// WriteMany mutex must be held when calling
 func (q *Queue) resize(n int) {
 	nodes := make([]Item, n)
+	// Handle empty queue case.
+	if q.cnt == 0 {
+		q.head = 0
+		q.tail = 0
+		q.nodes = nodes
+		return
+	}
+	// Normal case: copy the items from the old slice.
 	if q.head < q.tail {
 		copy(nodes, q.nodes[q.head:q.tail])
 	} else {
-		copy(nodes, q.nodes[q.head:])
-		copy(nodes[len(q.nodes)-q.head:], q.nodes[:q.tail])
+		// Copy the segment from head to end.
+		copied := copy(nodes, q.nodes[q.head:])
+		// Copy the segment from beginning to tail.
+		copy(nodes[copied:], q.nodes[:q.tail])
 	}
-
 	q.tail = q.cnt % n
 	q.head = 0
 	q.nodes = nodes
 }
+
+//// Write mutex must be held when calling.
+//func (q *Queue) resize(n int) {
+//	nodes := make([]Item, n)
+//	if q.head < q.tail {
+//		copy(nodes, q.nodes[q.head:q.tail])
+//	} else {
+//		copy(nodes, q.nodes[q.head:])
+//		copy(nodes[len(q.nodes)-q.head:], q.nodes[:q.tail])
+//	}
+//
+//	q.tail = q.cnt % n
+//	q.head = 0
+//	q.nodes = nodes
+//}
 
 // Add an Item to the back of the queue
 // will return false if the queue is closed.
@@ -180,6 +203,91 @@ func (q *Queue) Remove() (Item, bool) {
 
 	q.mu.Unlock()
 	return i, true
+}
+
+//// RemoveMany removes up to maxItems items from the queue.
+//// If maxItems is -1, it removes all available items.
+//// It returns the slice of removed items and a boolean indicating whether
+//// at least one item was removed (false means no messages were available).
+//func (q *Queue) RemoveMany(maxItems int) ([]Item, bool) {
+//	q.mu.Lock()
+//
+//	// Return false if there are no messages.
+//	if q.cnt == 0 {
+//		q.mu.Unlock()
+//		return nil, false
+//	}
+//
+//	// Determine how many messages to remove.
+//	var count int
+//	if maxItems == -1 || q.cnt < maxItems {
+//		count = q.cnt
+//	} else {
+//		count = maxItems
+//	}
+//
+//	messages := make([]Item, 0, count)
+//
+//	for i := 0; i < count; i++ {
+//		msg := q.nodes[q.head]
+//		q.head = (q.head + 1) % len(q.nodes)
+//		messages = append(messages, msg)
+//		q.cnt--
+//		q.size -= len(msg.Data)
+//		// Resize the underlying slice if needed. It's important to keep resize
+//		// inside loop to avoid slice out of bounds issues.
+//		if n := len(q.nodes) / 2; n >= q.initCap && q.cnt <= n {
+//			q.resize(n)
+//		}
+//	}
+//
+//	q.mu.Unlock()
+//	return messages, true
+//}
+
+// RemoveMany removes up to maxItems items from the queue.
+// If maxItems is -1, it removes all available items.
+// It returns the slice of removed items and a boolean indicating whether
+// at least one item was removed (false means no messages were available).
+func (q *Queue) RemoveMany(maxItems int) ([]Item, bool) {
+	q.mu.Lock()
+
+	// Return false if there are no messages.
+	if q.cnt == 0 {
+		q.mu.Unlock()
+		return nil, false
+	}
+
+	// Determine how many messages to remove.
+	var count int
+	if maxItems == -1 || q.cnt < maxItems {
+		count = q.cnt
+	} else {
+		count = maxItems
+	}
+
+	messages := make([]Item, 0, count)
+
+	for i := 0; i < count; i++ {
+		msg := q.nodes[q.head]
+		q.head = (q.head + 1) % len(q.nodes)
+		messages = append(messages, msg)
+		q.cnt--
+		q.size -= len(msg.Data)
+		//// Resize the underlying slice if needed. It's important to keep resize
+		//// inside loop to avoid slice out of bounds issues.
+		//if n := len(q.nodes) / 2; n >= q.initCap && q.cnt <= n {
+		//	q.resize(n)
+		//}
+	}
+
+	// Resize only once after all removals if needed.
+	if n := len(q.nodes) / 2; n >= q.initCap && q.cnt <= n {
+		q.resize(n)
+	}
+
+	q.mu.Unlock()
+	return messages, true
 }
 
 // Cap returns the capacity (without allocations)

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -87,6 +87,26 @@ func TestByteQueueAddMany(t *testing.T) {
 	require.Equal(t, "2", string(s.Data))
 }
 
+func TestByteQueueRemoveMany(t *testing.T) {
+	q := New(initialCapacity)
+	q.AddMany(testItem([]byte("1")), testItem([]byte("2")))
+	ok := q.Wait()
+	require.Equal(t, true, ok)
+	items, ok := q.RemoveMany(-1)
+	require.Equal(t, true, ok)
+	require.Equal(t, 2, len(items))
+}
+
+func TestByteQueueRemoveManyFixed(t *testing.T) {
+	q := New(initialCapacity)
+	q.AddMany(testItem([]byte("1")), testItem([]byte("2")))
+	ok := q.Wait()
+	require.Equal(t, true, ok)
+	items, ok := q.RemoveMany(2)
+	require.Equal(t, true, ok)
+	require.Equal(t, 2, len(items))
+}
+
 func TestQueueClose(t *testing.T) {
 	q := New(initialCapacity)
 

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -71,7 +71,23 @@ func TestByteQueueWait(t *testing.T) {
 	require.Equal(t, "3", string(s.Data))
 }
 
-func TestByteQueueClose(t *testing.T) {
+func TestByteQueueAddMany(t *testing.T) {
+	q := New(initialCapacity)
+	q.AddMany(testItem([]byte("1")), testItem([]byte("2")))
+	ok := q.Wait()
+	require.Equal(t, true, ok)
+	s, ok := q.Remove()
+	require.Equal(t, true, ok)
+	require.Equal(t, "1", string(s.Data))
+
+	ok = q.Wait()
+	require.Equal(t, true, ok)
+	s, ok = q.Remove()
+	require.Equal(t, true, ok)
+	require.Equal(t, "2", string(s.Data))
+}
+
+func TestQueueClose(t *testing.T) {
 	q := New(initialCapacity)
 
 	// test removing from empty queue

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -143,6 +143,68 @@ func TestByteQueueCloseRemaining(t *testing.T) {
 	require.Equal(t, 0, len(messages))
 }
 
+func TestQueueAddConsume(t *testing.T) {
+	// Add many items to queue and then consume.
+	// Make sure item data is expected.
+	q := New(initialCapacity)
+
+	for range 5 {
+		for i := 0; i < 1000; i++ {
+			q.Add(testItem([]byte("test" + strconv.Itoa(i))))
+		}
+		for i := 0; i < 1000; i++ {
+			items, _ := q.RemoveMany(1)
+			require.Equal(t, "test"+strconv.Itoa(i), string(items[0].Data))
+		}
+	}
+
+	require.Equal(t, 0, q.Size())
+	require.Equal(t, initialCapacity, q.Cap())
+	require.Equal(t, 0, q.Len())
+}
+
+func TestQueueAddConsumeInBatch(t *testing.T) {
+	// Add many items to queue and then consume.
+	// Make sure item data is expected.
+	q := New(initialCapacity)
+
+	for range 5 {
+		for i := 0; i < 1000; i++ {
+			q.Add(testItem([]byte("test" + strconv.Itoa(i))))
+		}
+		for i := 0; i < 100; i++ {
+			items, _ := q.RemoveMany(10)
+			for j := 0; j < 10; j++ {
+				require.Equal(t, "test"+strconv.Itoa(i*10+j), string(items[j].Data))
+			}
+		}
+	}
+
+	require.Equal(t, 0, q.Size())
+	require.Equal(t, initialCapacity, q.Cap())
+	require.Equal(t, 0, q.Len())
+}
+
+func TestQueueAddConsumeAll(t *testing.T) {
+	// Add many items to queue and then consume.
+	// Make sure item data is expected.
+	q := New(initialCapacity)
+
+	for range 5 {
+		for i := 0; i < 1000; i++ {
+			q.Add(testItem([]byte("test" + strconv.Itoa(i))))
+		}
+		items, _ := q.RemoveMany(-1)
+		for i := 0; i < 1000; i++ {
+			require.Equal(t, "test"+strconv.Itoa(i), string(items[i].Data))
+		}
+	}
+
+	require.Equal(t, 0, q.Size())
+	require.Equal(t, initialCapacity, q.Cap())
+	require.Equal(t, 0, q.Len())
+}
+
 func BenchmarkQueueAdd(b *testing.B) {
 	q := New(initialCapacity)
 	b.ResetTimer()

--- a/metrics.go
+++ b/metrics.go
@@ -281,7 +281,7 @@ func newMetricsRegistry(config MetricsConfig) (*metrics, error) {
 		Namespace: metricsNamespace,
 		Subsystem: "transport",
 		Name:      "messages_sent_size",
-		Help:      "MaxBatchSize in bytes of messages sent to client connections over specific transport (uncompressed and does not include framing overhead).",
+		Help:      "MaxSize in bytes of messages sent to client connections over specific transport (uncompressed and does not include framing overhead).",
 	}, []string{"transport", "frame_type", "channel_namespace"})
 
 	m.transportMessagesReceived = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -295,7 +295,7 @@ func newMetricsRegistry(config MetricsConfig) (*metrics, error) {
 		Namespace: metricsNamespace,
 		Subsystem: "transport",
 		Name:      "messages_received_size",
-		Help:      "MaxBatchSize in bytes of messages received from client connections over specific transport (uncompressed and does not include framing overhead).",
+		Help:      "MaxSize in bytes of messages received from client connections over specific transport (uncompressed and does not include framing overhead).",
 	}, []string{"transport", "frame_type", "channel_namespace"})
 
 	m.pubSubLagHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{

--- a/metrics.go
+++ b/metrics.go
@@ -281,7 +281,7 @@ func newMetricsRegistry(config MetricsConfig) (*metrics, error) {
 		Namespace: metricsNamespace,
 		Subsystem: "transport",
 		Name:      "messages_sent_size",
-		Help:      "Size in bytes of messages sent to client connections over specific transport (uncompressed and does not include framing overhead).",
+		Help:      "MaxBatchSize in bytes of messages sent to client connections over specific transport (uncompressed and does not include framing overhead).",
 	}, []string{"transport", "frame_type", "channel_namespace"})
 
 	m.transportMessagesReceived = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -295,7 +295,7 @@ func newMetricsRegistry(config MetricsConfig) (*metrics, error) {
 		Namespace: metricsNamespace,
 		Subsystem: "transport",
 		Name:      "messages_received_size",
-		Help:      "Size in bytes of messages received from client connections over specific transport (uncompressed and does not include framing overhead).",
+		Help:      "MaxBatchSize in bytes of messages received from client connections over specific transport (uncompressed and does not include framing overhead).",
 	}, []string{"transport", "frame_type", "channel_namespace"})
 
 	m.pubSubLagHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{

--- a/node.go
+++ b/node.go
@@ -710,26 +710,20 @@ func (n *Node) handlePublication(ch string, sp StreamPosition, pub, prevPub, loc
 	if !hasCurrentSubscribers {
 		return nil
 	}
-	maxBatchSize, maxBatchDelay, err := n.getBatchConfig(ch)
-	if err != nil {
-		return err
-	}
+	maxBatchSize, maxBatchDelay := n.getBatchConfig(ch)
 	return n.hub.broadcastPublication(ch, sp, pub, prevPub, localPrevPub, maxBatchSize, maxBatchDelay)
 }
 
-func (n *Node) getBatchConfig(channel string) (int64, time.Duration, error) {
+func (n *Node) getBatchConfig(channel string) (int64, time.Duration) {
 	var (
 		maxBatchSize  int64
 		maxBatchDelay time.Duration
 	)
 	if n.config.GetChannelBatchConfig != nil {
-		batchConfig, err := n.config.GetChannelBatchConfig(channel)
-		if err != nil {
-			return 0, 0, fmt.Errorf("error getting channel batch config: %v", err)
-		}
+		batchConfig := n.config.GetChannelBatchConfig(channel)
 		maxBatchSize, maxBatchDelay = batchConfig.MaxSize, batchConfig.MaxDelay
 	}
-	return maxBatchSize, maxBatchDelay, nil
+	return maxBatchSize, maxBatchDelay
 }
 
 // handleJoin handles join messages - i.e. broadcasts it to
@@ -741,10 +735,7 @@ func (n *Node) handleJoin(ch string, info *ClientInfo) error {
 	if !hasCurrentSubscribers {
 		return nil
 	}
-	maxBatchSize, maxBatchDelay, err := n.getBatchConfig(ch)
-	if err != nil {
-		return err
-	}
+	maxBatchSize, maxBatchDelay := n.getBatchConfig(ch)
 	return n.hub.broadcastJoin(ch, info, maxBatchSize, maxBatchDelay)
 }
 
@@ -757,10 +748,7 @@ func (n *Node) handleLeave(ch string, info *ClientInfo) error {
 	if !hasCurrentSubscribers {
 		return nil
 	}
-	maxBatchSize, maxBatchDelay, err := n.getBatchConfig(ch)
-	if err != nil {
-		return err
-	}
+	maxBatchSize, maxBatchDelay := n.getBatchConfig(ch)
 	return n.hub.broadcastLeave(ch, info, maxBatchSize, maxBatchDelay)
 }
 

--- a/writer.go
+++ b/writer.go
@@ -41,8 +41,7 @@ const (
 
 func (w *writer) waitSendMessage(maxMessagesInFrame int, writeDelay time.Duration) bool {
 	// Wait for message from the queue.
-	ok := w.messages.Wait()
-	if !ok {
+	if !w.messages.Wait() {
 		return false
 	}
 

--- a/writer.go
+++ b/writer.go
@@ -139,6 +139,17 @@ func (w *writer) enqueue(item queue.Item) *Disconnect {
 	return nil
 }
 
+func (w *writer) enqueueMany(item ...queue.Item) *Disconnect {
+	ok := w.messages.AddMany(item...)
+	if !ok {
+		return &DisconnectConnectionClosed
+	}
+	if w.config.MaxQueueSize > 0 && w.messages.Size() > w.config.MaxQueueSize {
+		return &DisconnectSlow
+	}
+	return nil
+}
+
 func (w *writer) close(flushRemaining bool) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()


### PR DESCRIPTION
Per channel batching configuration. Now Centrifuge provides a way to batch messages on Client level, but more granular per channel control is sometimes required. This PR adds experimental support for defining batching configuration on a channel level. Batching works on intermediary level between Client and Client's main writer. It costs additional resources but if properly configured may help to reduce CPU usage drastically due to reduce system calls number.