### PR TITLE
Add Controller interface

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -48,8 +48,6 @@ type BrokerEventHandler interface {
 	HandleJoin(ch string, info *ClientInfo) error
 	// HandleLeave to handle received Leave messages.
 	HandleLeave(ch string, info *ClientInfo) error
-	// HandleControl to handle received control data.
-	HandleControl(data []byte) error
 }
 
 // HistoryFilter allows filtering history according to fields set.
@@ -126,9 +124,9 @@ type PublishOptions struct {
 
 // Broker is responsible for PUB/SUB mechanics.
 type Broker interface {
-	// Run called once on start when broker already set to node. At
+	// RegisterBrokerEventHandler called once on start when Broker already set to Node. At
 	// this moment node is ready to process broker events.
-	Run(BrokerEventHandler) error
+	RegisterBrokerEventHandler(BrokerEventHandler) error
 
 	// Subscribe node on channel to listen all messages coming from channel.
 	Subscribe(ch string) error
@@ -160,10 +158,6 @@ type Broker interface {
 	PublishJoin(ch string, info *ClientInfo) error
 	// PublishLeave publishes Leave Push message into channel.
 	PublishLeave(ch string, info *ClientInfo) error
-	// PublishControl allows sending control command data. If nodeID is empty string
-	// then message should be delivered to all running nodes, if nodeID is set then
-	// message should be delivered only to node with specified ID.
-	PublishControl(data []byte, nodeID, shardKey string) error
 
 	// History used to extract Publications from history stream.
 	// Publications returned according to HistoryFilter which allows to set several

--- a/broker_memory.go
+++ b/broker_memory.go
@@ -67,8 +67,8 @@ func NewMemoryBroker(n *Node, _ MemoryBrokerConfig) (*MemoryBroker, error) {
 	return b, nil
 }
 
-// Run runs memory broker.
-func (b *MemoryBroker) Run(h BrokerEventHandler) error {
+// RegisterBrokerEventHandler runs memory broker.
+func (b *MemoryBroker) RegisterBrokerEventHandler(h BrokerEventHandler) error {
 	b.eventHandler = h
 	go b.expireResultCache()
 	b.historyHub.runCleanups()
@@ -192,11 +192,6 @@ func (b *MemoryBroker) PublishJoin(ch string, info *ClientInfo) error {
 // PublishLeave - see Broker interface description.
 func (b *MemoryBroker) PublishLeave(ch string, info *ClientInfo) error {
 	return b.eventHandler.HandleLeave(ch, info)
-}
-
-// PublishControl - see Broker interface description.
-func (b *MemoryBroker) PublishControl(data []byte, _, _ string) error {
-	return b.eventHandler.HandleControl(data)
 }
 
 // Subscribe is noop here.

--- a/broker_redis.go
+++ b/broker_redis.go
@@ -39,6 +39,7 @@ const (
 )
 
 var _ Broker = (*RedisBroker)(nil)
+var _ Controller = (*RedisBroker)(nil)
 
 type pubSubStart struct {
 	once  sync.Once
@@ -250,7 +251,6 @@ func NewRedisBroker(n *Node, config RedisBrokerConfig) (*RedisBroker, error) {
 
 		shardWrapper.subClients = subChannels
 		shardWrapper.pubSubStartChannels = pubSubStartChannels
-		shardWrapper.controlPubSubStart = &controlPubSubStart{errCh: make(chan error, 1)}
 	}
 
 	return b, nil
@@ -280,11 +280,42 @@ func (b *RedisBroker) getShard(channel string) *shardWrapper {
 	return b.shards[consistentIndex(channel, len(b.shards))]
 }
 
-// Run – see Broker.Run.
-func (b *RedisBroker) Run(h BrokerEventHandler) error {
+func (b *RedisBroker) RegisterControlEventHandler(h ControlEventHandler) error {
+	for _, wrapper := range b.shards {
+		wrapper.controlPubSubStart = &controlPubSubStart{errCh: make(chan error, 1)}
+		err := b.runControlShard(wrapper, h)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PublishControl - see Broker.PublishControl.
+func (b *RedisBroker) PublishControl(data []byte, nodeID string, _ string) error {
+	currentRound := atomic.AddUint64(&b.controlRound, 1)
+	index := currentRound % uint64(len(b.shards))
+	s := b.shards[index]
+	return b.publishControl(s, data, nodeID)
+}
+
+func (b *RedisBroker) publishControl(s *shardWrapper, data []byte, nodeID string) error {
+	var chID channelID
+	if nodeID == "" {
+		chID = channelID(b.controlChannel)
+	} else {
+		chID = b.nodeChannelID(nodeID)
+	}
+	cmd := s.shard.client.B().Publish().Channel(string(chID)).Message(convert.BytesToString(data)).Build()
+	resp := s.shard.client.Do(context.Background(), cmd)
+	return resp.Error()
+}
+
+// RegisterBrokerEventHandler – see Broker.RegisterBrokerEventHandler.
+func (b *RedisBroker) RegisterBrokerEventHandler(h BrokerEventHandler) error {
 	// Run all shards.
 	for _, wrapper := range b.shards {
-		err := b.runShard(wrapper, h)
+		err := b.runPubSubShard(wrapper, h)
 		if err != nil {
 			return err
 		}
@@ -293,7 +324,9 @@ func (b *RedisBroker) Run(h BrokerEventHandler) error {
 		}
 	}
 	for i := 0; i < len(b.shards); i++ {
-		<-b.shards[i].controlPubSubStart.errCh
+		if b.shards[i].controlPubSubStart != nil {
+			<-b.shards[i].controlPubSubStart.errCh
+		}
 		for j := 0; j < len(b.shards[i].pubSubStartChannels); j++ {
 			for k := 0; k < len(b.shards[i].pubSubStartChannels[j]); k++ {
 				<-b.shards[i].pubSubStartChannels[j][k].errCh
@@ -345,10 +378,7 @@ func (b *RedisBroker) runForever(fn func()) {
 	}
 }
 
-func (b *RedisBroker) runShard(s *shardWrapper, h BrokerEventHandler) error {
-	if b.config.SkipPubSub {
-		return nil
-	}
+func (b *RedisBroker) runControlShard(s *shardWrapper, h ControlEventHandler) error {
 	go b.runForever(func() {
 		select {
 		case <-b.closeCh:
@@ -361,6 +391,13 @@ func (b *RedisBroker) runShard(s *shardWrapper, h BrokerEventHandler) error {
 			})
 		})
 	})
+	return nil
+}
+
+func (b *RedisBroker) runPubSubShard(s *shardWrapper, h BrokerEventHandler) error {
+	if b.config.SkipPubSub {
+		return nil
+	}
 
 	for i := 0; i < len(s.subClients); i++ { // Cluster shards.
 		clusterShardIndex := i
@@ -406,7 +443,7 @@ func getPubSubStartLogFields(s *RedisShard, logFields map[string]any) map[string
 	return startLogFields
 }
 
-func (b *RedisBroker) runControlPubSub(s *RedisShard, logFields map[string]any, eventHandler BrokerEventHandler, startOnce func(error)) {
+func (b *RedisBroker) runControlPubSub(s *RedisShard, logFields map[string]any, eventHandler ControlEventHandler, startOnce func(error)) {
 	b.node.logger.log(newLogEntry(LogLevelDebug, "running Redis control PUB/SUB", getPubSubStartLogFields(s, logFields)))
 	defer func() {
 		b.node.logger.log(newLogEntry(LogLevelDebug, "stopping Redis control PUB/SUB", logFields))
@@ -922,26 +959,6 @@ func (b *RedisBroker) publishLeave(s *shardWrapper, ch string, info *ClientInfo)
 		cmd := s.shard.client.B().Publish().Channel(string(chID)).Message(convert.BytesToString(append(leaveTypePrefix, byteMessage...))).Build()
 		resp = s.shard.client.Do(context.Background(), cmd)
 	}
-	return resp.Error()
-}
-
-// PublishControl - see Broker.PublishControl.
-func (b *RedisBroker) PublishControl(data []byte, nodeID string, _ string) error {
-	currentRound := atomic.AddUint64(&b.controlRound, 1)
-	index := currentRound % uint64(len(b.shards))
-	s := b.shards[index]
-	return b.publishControl(s, data, nodeID)
-}
-
-func (b *RedisBroker) publishControl(s *shardWrapper, data []byte, nodeID string) error {
-	var chID channelID
-	if nodeID == "" {
-		chID = channelID(b.controlChannel)
-	} else {
-		chID = b.nodeChannelID(nodeID)
-	}
-	cmd := s.shard.client.B().Publish().Channel(string(chID)).Message(convert.BytesToString(data)).Build()
-	resp := s.shard.client.Do(context.Background(), cmd)
 	return resp.Error()
 }
 

--- a/broker_redis_test.go
+++ b/broker_redis_test.go
@@ -1027,7 +1027,8 @@ func TestRedisPubSubTwoNodes(t *testing.T) {
 					return nil
 				},
 			}
-			_ = b1.Run(brokerEventHandler)
+			_ = b1.RegisterControlEventHandler(brokerEventHandler)
+			_ = b1.RegisterBrokerEventHandler(brokerEventHandler)
 
 			for i := 0; i < msgNum; i++ {
 				require.NoError(t, b1.Subscribe("test"+strconv.Itoa(i)))
@@ -1130,7 +1131,8 @@ func TestRedisPubSubTwoNodesWithDelta(t *testing.T) {
 					return nil
 				},
 			}
-			_ = b1.Run(brokerEventHandler)
+			_ = b1.RegisterControlEventHandler(brokerEventHandler)
+			_ = b1.RegisterBrokerEventHandler(brokerEventHandler)
 
 			require.NoError(t, b1.Subscribe(ch))
 
@@ -1231,7 +1233,8 @@ func TestRedisClusterShardedPubSub(t *testing.T) {
 			return nil
 		},
 	}
-	_ = b1.Run(brokerEventHandler)
+	_ = b1.RegisterControlEventHandler(brokerEventHandler)
+	_ = b1.RegisterBrokerEventHandler(brokerEventHandler)
 
 	for i := 0; i < msgNum; i++ {
 		require.NoError(t, b1.Subscribe("test"+strconv.Itoa(i)))
@@ -1815,7 +1818,8 @@ func BenchmarkPubSubThroughput(b *testing.B) {
 					return nil
 				},
 			}
-			_ = b1.Run(brokerEventHandler)
+			_ = b1.RegisterControlEventHandler(brokerEventHandler)
+			_ = b1.RegisterBrokerEventHandler(brokerEventHandler)
 
 			for i := 0; i < numChannels; i++ {
 				require.NoError(b, b1.Subscribe("test"+strconv.Itoa(i)))

--- a/controller.go
+++ b/controller.go
@@ -1,0 +1,18 @@
+package centrifuge
+
+// ControlEventHandler can handle messages received from Controller.
+type ControlEventHandler interface {
+	// HandleControl to handle received control data.
+	HandleControl(data []byte) error
+}
+
+type Controller interface {
+	// RegisterControlEventHandler called once on start when controller already set to node. At
+	// this moment node is ready to process controller events.
+	RegisterControlEventHandler(ControlEventHandler) error
+	// PublishControl allows sending control command data. If nodeID is empty string
+	// then message should be delivered to all running nodes, if nodeID is set then
+	// message should be delivered only to node with specified ID. If shardKey is set
+	// then it can be used for ordering control (now not used).
+	PublishControl(data []byte, nodeID, shardKey string) error
+}


### PR DESCRIPTION
This detaches Controller interface from Broker interface.

This provides:

1. Possibility to implement Controller using a backend different from Broker.
2. Possibility to use different Redis setups for Controller and Broker purposes.