### PR TITLE
FlushLatest option for ChannelBatchConfig

### DIFF
--- a/client_experimental.go
+++ b/client_experimental.go
@@ -128,7 +128,8 @@ type ChannelBatchConfig struct {
 	// MaxDelay is the maximum time to wait before flushing.
 	MaxDelay time.Duration
 	// FlushLatest if true, then Centrifuge flushes only the latest item in the batch
-	// upon reaching the MaxSize or MaxDelay.
+	// upon reaching the MaxSize or MaxDelay. Skipping on this level does not work
+	// with delta compression.
 	FlushLatest bool
 }
 

--- a/client_experimental.go
+++ b/client_experimental.go
@@ -26,8 +26,6 @@ func (c *Client) WritePublication(channel string, publication *Publication, sp S
 	pub := pubToProto(publication)
 	protoType := c.transport.Protocol().toProto()
 
-	maxBatchSize, maxBatchDelay := c.node.getBatchConfig(channel)
-
 	if protoType == protocol.TypeJSON {
 		if c.transport.Unidirectional() {
 			push := &protocol.Push{Channel: channel, Pub: pub}
@@ -37,7 +35,7 @@ func (c *Client) WritePublication(channel string, publication *Publication, sp S
 				go func(c *Client) { c.Disconnect(DisconnectInappropriateProtocol) }(c)
 				return err
 			}
-			return c.writePublicationNoDelta(channel, pub, jsonPush, sp, maxBatchSize, maxBatchDelay)
+			return c.writePublicationNoDelta(channel, pub, jsonPush, sp, c.node.getBatchConfig(channel))
 		} else {
 			push := &protocol.Push{Channel: channel, Pub: pub}
 			var err error
@@ -46,7 +44,7 @@ func (c *Client) WritePublication(channel string, publication *Publication, sp S
 				go func(c *Client) { c.Disconnect(DisconnectInappropriateProtocol) }(c)
 				return err
 			}
-			return c.writePublicationNoDelta(channel, pub, jsonReply, sp, maxBatchSize, maxBatchDelay)
+			return c.writePublicationNoDelta(channel, pub, jsonReply, sp, c.node.getBatchConfig(channel))
 		}
 	} else if protoType == protocol.TypeProtobuf {
 		if c.transport.Unidirectional() {
@@ -56,7 +54,7 @@ func (c *Client) WritePublication(channel string, publication *Publication, sp S
 			if err != nil {
 				return err
 			}
-			return c.writePublicationNoDelta(channel, pub, protobufPush, sp, maxBatchSize, maxBatchDelay)
+			return c.writePublicationNoDelta(channel, pub, protobufPush, sp, c.node.getBatchConfig(channel))
 		} else {
 			push := &protocol.Push{Channel: channel, Pub: pub}
 			var err error
@@ -64,7 +62,7 @@ func (c *Client) WritePublication(channel string, publication *Publication, sp S
 			if err != nil {
 				return err
 			}
-			return c.writePublicationNoDelta(channel, pub, protobufReply, sp, maxBatchSize, maxBatchDelay)
+			return c.writePublicationNoDelta(channel, pub, protobufReply, sp, c.node.getBatchConfig(channel))
 		}
 	}
 
@@ -129,15 +127,19 @@ type ChannelBatchConfig struct {
 	MaxSize int64
 	// MaxDelay is the maximum time to wait before flushing.
 	MaxDelay time.Duration
+	// FlushLatest if true, then Centrifuge flushes only the latest item in the batch
+	// upon reaching the MaxSize or MaxDelay.
+	FlushLatest bool
 }
 
 // channelWriter buffers queue.Item objects and flushes them after a fixed delay
 // or when a specific batch size is reached.
 type channelWriter struct {
-	mu      sync.Mutex
-	buffer  []queue.Item
-	timer   *time.Timer
-	flushFn func([]queue.Item) error
+	mu         sync.Mutex
+	buffer     []queue.Item
+	timer      *time.Timer
+	flushFn    func([]queue.Item) error
+	latestOnly bool
 }
 
 // newChannelWriter creates a new channelWriter with the given delay and maxBatchSize.
@@ -154,7 +156,7 @@ func (w *channelWriter) close(flushRemaining bool) {
 		w.timer = nil
 	}
 	if flushRemaining && len(w.buffer) > 0 { // If there are any buffered items, flush them.
-		w.flushLocked()
+		w.flushLocked(w.latestOnly)
 	}
 	w.buffer = nil
 	w.mu.Unlock()
@@ -162,26 +164,27 @@ func (w *channelWriter) close(flushRemaining bool) {
 
 // Add appends an item to the buffer. It starts a delay timer if this is the first item,
 // and flushes immediately if the batch size is reached.
-func (w *channelWriter) Add(item queue.Item, ch string, maxBatchDelay time.Duration, maxBatchSize int64) {
+func (w *channelWriter) Add(item queue.Item, config ChannelBatchConfig) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	w.latestOnly = config.FlushLatest
 	w.buffer = append(w.buffer, item)
-	if maxBatchDelay > 0 && len(w.buffer) == 1 && w.timer == nil { // Start the flush timer for the first item and if no active timer.
-		w.timer = timers.AcquireTimer(maxBatchDelay)
-		go w.waitTimer(w.timer, ch)
+	if config.MaxDelay > 0 && len(w.buffer) == 1 && w.timer == nil { // Start the flush timer for the first item and if no active timer.
+		w.timer = timers.AcquireTimer(config.MaxDelay)
+		go w.waitTimer(w.timer)
 	}
 	// Flush immediately if batch size is reached.
-	if maxBatchSize > 0 && int64(len(w.buffer)) >= maxBatchSize {
+	if config.MaxSize > 0 && int64(len(w.buffer)) >= config.MaxSize {
 		if w.timer != nil {
 			w.timer.Stop()
 			w.timer = nil // Set timer to nil so waitTimer knows it was cancelled.
 		}
-		w.flushLocked()
+		w.flushLocked(w.latestOnly)
 	}
 }
 
 // waitTimer waits for the timer to fire, then flushes the batch.
-func (w *channelWriter) waitTimer(tm *time.Timer, ch string) {
+func (w *channelWriter) waitTimer(tm *time.Timer) {
 	<-tm.C // Wait for the timer to fire.
 	timers.ReleaseTimer(tm)
 	w.mu.Lock()
@@ -191,16 +194,23 @@ func (w *channelWriter) waitTimer(tm *time.Timer, ch string) {
 		return
 	}
 	if len(w.buffer) > 0 { // If there are any items, flush the buffer.
-		w.flushLocked()
+		w.flushLocked(w.latestOnly)
 	}
 	w.timer = nil // Mark the timer as no longer active.
 	w.mu.Unlock()
 }
 
 // flushLocked flushes the current buffer. It assumes the caller holds the lock.
-func (w *channelWriter) flushLocked() {
+func (w *channelWriter) flushLocked(latestOnly bool) {
+	if len(w.buffer) == 0 {
+		return
+	}
 	batch := w.buffer
 	w.buffer = w.buffer[:0]
+	if latestOnly {
+		// flush only latest item in the batch.
+		batch = batch[len(batch)-1:]
+	}
 	_ = w.flushFn(batch)
 }
 
@@ -258,7 +268,7 @@ func (pcw *perChannelWriter) delWriter(channel string, flushRemaining bool) {
 }
 
 // Add routes an item to its configuration-specific aggregator.
-func (pcw *perChannelWriter) Add(item queue.Item, ch string, maxBatchDelay time.Duration, maxBatchSize int64) {
+func (pcw *perChannelWriter) Add(item queue.Item, ch string, config ChannelBatchConfig) {
 	w := pcw.getWriter(ch)
-	w.Add(item, ch, maxBatchDelay, maxBatchSize)
+	w.Add(item, config)
 }

--- a/client_experimental_test.go
+++ b/client_experimental_test.go
@@ -32,7 +32,7 @@ func BenchmarkPerChannelWriter(b *testing.B) {
 		wg.Add(1) // Each added message increments the WaitGroup counter.
 		channelName := "channel-" + strconv.Itoa(i%numChannels)
 		item := queue.Item{Channel: channelName}
-		w.Add(item, channelName, 10*time.Millisecond, 128)
+		w.Add(item, channelName, ChannelBatchConfig{MaxDelay: 10 * time.Millisecond, MaxSize: 128})
 	}
 	w.Close(true)
 	wg.Wait() // Wait for all messages to be flushed.
@@ -121,6 +121,58 @@ func TestClientSubscribeReceivePublication_ChannelBatching_BatchSize(t *testing.
 	}()
 
 	_, err := node.Publish("test", []byte(`{"text": "test message"}`))
+	require.NoError(t, err)
+
+	select {
+	case <-time.After(time.Second):
+		require.Fail(t, "timeout receiving publication")
+	case <-done:
+	}
+}
+
+func TestClientSubscribeReceivePublication_ChannelBatching_FlushLatestOnly(t *testing.T) {
+	t.Parallel()
+	node := defaultTestNode()
+	node.config.GetChannelBatchConfig = func(channel string) ChannelBatchConfig {
+		return ChannelBatchConfig{
+			MaxSize:     2,
+			MaxDelay:    0,
+			FlushLatest: true,
+		}
+	}
+	defer func() { _ = node.Shutdown(context.Background()) }()
+	transport := newTestTransport(func() {})
+	transport.sink = make(chan []byte, 100)
+	ctx := context.Background()
+	newCtx := SetCredentials(ctx, &Credentials{UserID: "42"})
+	client, _ := newClient(newCtx, node, transport)
+
+	connectClientV2(t, client)
+
+	rwWrapper := testReplyWriterWrapper()
+
+	client.channels["test"] = ChannelContext{}
+	subCtx := client.subscribeCmd(&protocol.SubscribeRequest{
+		Channel: "test",
+	}, SubscribeReply{}, &protocol.Command{}, false, time.Now(), rwWrapper.rw)
+	require.Nil(t, subCtx.disconnect)
+	require.Nil(t, rwWrapper.replies[0].Error)
+
+	done := make(chan struct{})
+	go func() {
+		for data := range transport.sink {
+			if strings.Contains(string(data), "test message 1") {
+				panic("should not receive first message")
+			}
+			if strings.Contains(string(data), "test message 2") {
+				close(done)
+			}
+		}
+	}()
+
+	_, err := node.Publish("test", []byte(`{"text": "test message 1"}`))
+	require.NoError(t, err)
+	_, err = node.Publish("test", []byte(`{"text": "test message 2"}`))
 	require.NoError(t, err)
 
 	select {

--- a/hub_test.go
+++ b/hub_test.go
@@ -599,7 +599,7 @@ func TestHubBroadcastPublicationDelta(t *testing.T) {
 				&Publication{Data: []byte(`{"data": "broadcast_data"}`), Offset: 1},
 				nil,
 				nil,
-				0, 0,
+				ChannelBatchConfig{},
 			)
 			require.NoError(t, err)
 
@@ -621,7 +621,7 @@ func TestHubBroadcastPublicationDelta(t *testing.T) {
 				StreamPosition{Offset: 2, Epoch: res.StreamPosition.Epoch},
 				&Publication{Data: []byte(`{"data": "broadcast_data"}`), Offset: 2},
 				&Publication{Data: []byte(`{"data": "broadcast_data"}`), Offset: 1},
-				nil, 0, 0,
+				nil, ChannelBatchConfig{},
 			)
 			require.NoError(t, err)
 
@@ -679,7 +679,7 @@ func TestHubBroadcastPublicationDeltaAtMostOnce(t *testing.T) {
 				StreamPosition{Offset: 1, Epoch: res.StreamPosition.Epoch},
 				&Publication{Data: []byte(`{"data": "broadcast_data"}`), Offset: 1},
 				nil,
-				nil, 0, 0,
+				nil, ChannelBatchConfig{},
 			)
 			require.NoError(t, err)
 
@@ -701,7 +701,7 @@ func TestHubBroadcastPublicationDeltaAtMostOnce(t *testing.T) {
 				StreamPosition{Offset: 2, Epoch: res.StreamPosition.Epoch},
 				&Publication{Data: []byte(`{"data": "broadcast_data"}`), Offset: 2},
 				nil,
-				&Publication{Data: []byte(`{"data": "broadcast_data"}`), Offset: 1}, 0, 0,
+				&Publication{Data: []byte(`{"data": "broadcast_data"}`), Offset: 1}, ChannelBatchConfig{},
 			)
 			require.NoError(t, err)
 
@@ -756,7 +756,7 @@ func TestHubBroadcastPublicationDeltaAtMostOnceNoOffset(t *testing.T) {
 				StreamPosition{},
 				&Publication{Data: []byte(`{"data": "broadcast_data"}`)},
 				nil,
-				nil, 0, 0,
+				nil, ChannelBatchConfig{},
 			)
 			require.NoError(t, err)
 
@@ -779,7 +779,7 @@ func TestHubBroadcastPublicationDeltaAtMostOnceNoOffset(t *testing.T) {
 				&Publication{Data: []byte(`{"data": "broadcast_data"}`)},
 				nil,
 				&Publication{Data: []byte(`{"data": "broadcast_data"}`)},
-				0, 0,
+				ChannelBatchConfig{},
 			)
 			require.NoError(t, err)
 
@@ -829,11 +829,11 @@ func TestHubBroadcastJoin(t *testing.T) {
 			c.channels["test_channel"] = chCtx
 
 			// Broadcast to not existed channel.
-			err := n.hub.broadcastJoin("not_test_channel", &ClientInfo{ClientID: "broadcast_client"}, 0, 0)
+			err := n.hub.broadcastJoin("not_test_channel", &ClientInfo{ClientID: "broadcast_client"}, ChannelBatchConfig{})
 			require.NoError(t, err)
 
 			// Broadcast to existed channel.
-			err = n.hub.broadcastJoin("test_channel", &ClientInfo{ClientID: "broadcast_client"}, 0, 0)
+			err = n.hub.broadcastJoin("test_channel", &ClientInfo{ClientID: "broadcast_client"}, ChannelBatchConfig{})
 			require.NoError(t, err)
 		LOOP:
 			for {
@@ -880,11 +880,11 @@ func TestHubBroadcastLeave(t *testing.T) {
 			c.channels["test_channel"] = chCtx
 
 			// Broadcast to not existed channel.
-			err := n.hub.broadcastLeave("not_test_channel", &ClientInfo{ClientID: "broadcast_client"}, 0, 0)
+			err := n.hub.broadcastLeave("not_test_channel", &ClientInfo{ClientID: "broadcast_client"}, ChannelBatchConfig{})
 			require.NoError(t, err)
 
 			// Broadcast to existed channel.
-			err = n.hub.broadcastLeave("test_channel", &ClientInfo{ClientID: "broadcast_client"}, 0, 0)
+			err = n.hub.broadcastLeave("test_channel", &ClientInfo{ClientID: "broadcast_client"}, ChannelBatchConfig{})
 			require.NoError(t, err)
 		LOOP:
 			for {
@@ -1116,7 +1116,7 @@ func BenchmarkHub_MassiveBroadcast(b *testing.B) {
 						}
 					}
 				}()
-				_ = n.hub.broadcastPublication(channel, streamPosition, pub, nil, nil, 0, 0)
+				_ = n.hub.broadcastPublication(channel, streamPosition, pub, nil, nil, ChannelBatchConfig{})
 				wg.Wait()
 			}
 		})
@@ -1170,7 +1170,7 @@ func TestHubBroadcastInappropriateProtocol_Join(t *testing.T) {
 		}
 		err := n.hub.broadcastJoin("test_channel", &ClientInfo{
 			ChanInfo: []byte(`{111`),
-		}, 0, 0)
+		}, ChannelBatchConfig{})
 		require.NoError(t, err)
 		waitWithTimeout(t, done)
 	}
@@ -1199,7 +1199,7 @@ func TestHubBroadcastInappropriateProtocol_Leave(t *testing.T) {
 		}
 		err := n.hub.broadcastLeave("test_channel", &ClientInfo{
 			ChanInfo: []byte(`{111`),
-		}, 0, 0)
+		}, ChannelBatchConfig{})
 		require.NoError(t, err)
 		waitWithTimeout(t, done)
 	}

--- a/node.go
+++ b/node.go
@@ -710,20 +710,14 @@ func (n *Node) handlePublication(ch string, sp StreamPosition, pub, prevPub, loc
 	if !hasCurrentSubscribers {
 		return nil
 	}
-	maxBatchSize, maxBatchDelay := n.getBatchConfig(ch)
-	return n.hub.broadcastPublication(ch, sp, pub, prevPub, localPrevPub, maxBatchSize, maxBatchDelay)
+	return n.hub.broadcastPublication(ch, sp, pub, prevPub, localPrevPub, n.getBatchConfig(ch))
 }
 
-func (n *Node) getBatchConfig(channel string) (int64, time.Duration) {
-	var (
-		maxBatchSize  int64
-		maxBatchDelay time.Duration
-	)
+func (n *Node) getBatchConfig(channel string) ChannelBatchConfig {
 	if n.config.GetChannelBatchConfig != nil {
-		batchConfig := n.config.GetChannelBatchConfig(channel)
-		maxBatchSize, maxBatchDelay = batchConfig.MaxSize, batchConfig.MaxDelay
+		return n.config.GetChannelBatchConfig(channel)
 	}
-	return maxBatchSize, maxBatchDelay
+	return ChannelBatchConfig{}
 }
 
 // handleJoin handles join messages - i.e. broadcasts it to
@@ -735,8 +729,7 @@ func (n *Node) handleJoin(ch string, info *ClientInfo) error {
 	if !hasCurrentSubscribers {
 		return nil
 	}
-	maxBatchSize, maxBatchDelay := n.getBatchConfig(ch)
-	return n.hub.broadcastJoin(ch, info, maxBatchSize, maxBatchDelay)
+	return n.hub.broadcastJoin(ch, info, n.getBatchConfig(ch))
 }
 
 // handleLeave handles leave messages - i.e. broadcasts it to
@@ -748,8 +741,7 @@ func (n *Node) handleLeave(ch string, info *ClientInfo) error {
 	if !hasCurrentSubscribers {
 		return nil
 	}
-	maxBatchSize, maxBatchDelay := n.getBatchConfig(ch)
-	return n.hub.broadcastLeave(ch, info, maxBatchSize, maxBatchDelay)
+	return n.hub.broadcastLeave(ch, info, n.getBatchConfig(ch))
 }
 
 func (n *Node) publish(ch string, data []byte, opts ...PublishOption) (PublishResult, error) {


### PR DESCRIPTION
Should be handy to reduce size of data sent in streams with entire state in publications. Where intermediary message loss is safe and beneficial.

```go
type ChannelBatchConfig struct {
	// MaxSize is the maximum number of messages to batch before flushing.
	MaxSize int64
	// MaxDelay is the maximum time to wait before flushing.
	MaxDelay time.Duration
	// FlushLatest if true, then Centrifuge flushes only the latest item in the batch
	// upon reaching the MaxSize or MaxDelay.
	FlushLatest bool // <- THIS ONE!
}
```