### PR TITLE
Possibility to provide version and version epoch fields for publication

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -122,6 +122,12 @@ type PublishOptions struct {
 	IdempotentResultTTL time.Duration
 	// UseDelta enables using delta encoding for the publication.
 	UseDelta bool
+	// AppStreamPosition is an optional stream position that can be used by Centrifuge
+	// to understand the position of the publication in the app's stream. This stream
+	// position is not used by the broker and is only used for the purpose of skipping
+	// non-actual messages (due to unordered processing). Mostly useful for channels
+	// where the entire state is sent in the publication.
+	AppStreamPosition *StreamPosition
 }
 
 // Broker is responsible for PUB/SUB mechanics.

--- a/broker.go
+++ b/broker.go
@@ -122,12 +122,14 @@ type PublishOptions struct {
 	IdempotentResultTTL time.Duration
 	// UseDelta enables using delta encoding for the publication.
 	UseDelta bool
-	// AppStreamPosition is an optional stream position that can be used by Centrifuge
-	// to understand the position of the publication in the app's stream. This stream
-	// position is not used by the broker and is only used for the purpose of skipping
-	// non-actual messages (due to unordered processing). Mostly useful for channels
-	// where the entire state is sent in the publication.
-	AppStreamPosition *StreamPosition
+	// Version of Publication. This is a tip to Centrifuge to skip non-actual
+	// publications. Mostly useful for cases when Publication contains the entire
+	// state.
+	Version uint64
+	// VersionEpoch is a string that is used to identify the epoch of version of the
+	// publication. Use it if version may be reused in the future. For example, if
+	// version comes from in-memory system which can lose data, or due to eviction, etc.
+	VersionEpoch string
 }
 
 // Broker is responsible for PUB/SUB mechanics.

--- a/broker.go
+++ b/broker.go
@@ -124,7 +124,7 @@ type PublishOptions struct {
 	UseDelta bool
 	// Version of Publication. This is a tip to Centrifuge to skip non-actual
 	// publications. Mostly useful for cases when Publication contains the entire
-	// state.
+	// state. Version only used when history is configured.
 	Version uint64
 	// VersionEpoch is a string that is used to identify the epoch of version of the
 	// publication. Use it if version may be reused in the future. For example, if

--- a/broker_memory.go
+++ b/broker_memory.go
@@ -383,26 +383,24 @@ func (h *historyHub) add(ch string, pub *Publication, opts PublishOptions) (Stre
 		}
 	}
 
-	var appStreamPosition memstream.AppStreamPosition
-	if opts.AppStreamPosition != nil {
+	if opts.Version > 0 {
 		if stream, ok := h.streams[ch]; ok {
-			appTopOffset := stream.AppTopOffset()
-			appTopEpoch := stream.AppEpoch()
-			if (opts.AppStreamPosition.Epoch == "" || opts.AppStreamPosition.Epoch == appTopEpoch) &&
-				opts.AppStreamPosition.Offset <= appTopOffset {
+			topVersion := stream.TopVersion()
+			topVersionEpoch := stream.TopVersionEpoch()
+			if (opts.VersionEpoch == "" || opts.VersionEpoch == topVersionEpoch) &&
+				opts.Version <= topVersion {
 				// We can skip the unordered publication.
 				return StreamPosition{Offset: stream.Top(), Epoch: stream.Epoch()}, nil, true, nil
 			}
 		}
-		appStreamPosition = memstream.AppStreamPosition(*opts.AppStreamPosition)
 	}
 
 	if stream, ok := h.streams[ch]; ok {
-		offset, _ = stream.Add(pub, opts.HistorySize, appStreamPosition)
+		offset, _ = stream.Add(pub, opts.HistorySize, opts.Version, opts.VersionEpoch)
 		epoch = stream.Epoch()
 	} else {
 		stream := memstream.New()
-		offset, _ = stream.Add(pub, opts.HistorySize, appStreamPosition)
+		offset, _ = stream.Add(pub, opts.HistorySize, opts.Version, opts.VersionEpoch)
 		epoch = stream.Epoch()
 		h.streams[ch] = stream
 	}

--- a/broker_memory_test.go
+++ b/broker_memory_test.go
@@ -229,10 +229,10 @@ func TestMemoryHistoryHub(t *testing.T) {
 	ch1 := "channel1"
 	ch2 := "channel2"
 	pub := newTestPublication()
-	_, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second})
-	_, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second})
-	_, _, _ = h.add(ch2, pub, PublishOptions{HistorySize: 2, HistoryTTL: time.Second})
-	_, _, _ = h.add(ch2, pub, PublishOptions{HistorySize: 2, HistoryTTL: time.Second})
+	_, _, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second})
+	_, _, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second})
+	_, _, _, _ = h.add(ch2, pub, PublishOptions{HistorySize: 2, HistoryTTL: time.Second})
+	_, _, _, _ = h.add(ch2, pub, PublishOptions{HistorySize: 2, HistoryTTL: time.Second})
 
 	hist, _, err := h.get(ch1, HistoryOptions{
 		Filter: HistoryFilter{
@@ -271,10 +271,10 @@ func TestMemoryHistoryHub(t *testing.T) {
 	require.Equal(t, 0, len(hist))
 
 	// test history messages limit
-	_, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 10, HistoryTTL: time.Second})
-	_, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 10, HistoryTTL: time.Second})
-	_, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 10, HistoryTTL: time.Second})
-	_, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 10, HistoryTTL: time.Second})
+	_, _, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 10, HistoryTTL: time.Second})
+	_, _, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 10, HistoryTTL: time.Second})
+	_, _, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 10, HistoryTTL: time.Second})
+	_, _, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 10, HistoryTTL: time.Second})
 	hist, _, err = h.get(ch1, HistoryOptions{
 		Filter: HistoryFilter{
 			Limit: -1,
@@ -291,8 +291,8 @@ func TestMemoryHistoryHub(t *testing.T) {
 	require.Equal(t, 1, len(hist))
 
 	// test history limit greater than history size
-	_, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second})
-	_, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second})
+	_, _, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second})
+	_, _, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second})
 	hist, _, err = h.get(ch1, HistoryOptions{
 		Filter: HistoryFilter{
 			Limit: 2,
@@ -312,10 +312,10 @@ func TestMemoryHistoryHubMetaTTL(t *testing.T) {
 	h.RLock()
 	require.Equal(t, int64(0), h.nextRemoveCheck)
 	h.RUnlock()
-	_, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second})
-	_, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second})
-	_, _, _ = h.add(ch2, pub, PublishOptions{HistorySize: 2, HistoryTTL: time.Second})
-	_, _, _ = h.add(ch2, pub, PublishOptions{HistorySize: 2, HistoryTTL: time.Second})
+	_, _, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second})
+	_, _, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second})
+	_, _, _, _ = h.add(ch2, pub, PublishOptions{HistorySize: 2, HistoryTTL: time.Second})
+	_, _, _, _ = h.add(ch2, pub, PublishOptions{HistorySize: 2, HistoryTTL: time.Second})
 	h.RLock()
 	require.True(t, h.nextRemoveCheck > 0)
 	require.Equal(t, 2, len(h.streams))
@@ -350,10 +350,10 @@ func TestMemoryHistoryHubMetaTTLPerChannel(t *testing.T) {
 	h.RLock()
 	require.Equal(t, int64(0), h.nextRemoveCheck)
 	h.RUnlock()
-	_, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second, HistoryMetaTTL: time.Second})
-	_, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second, HistoryMetaTTL: time.Second})
-	_, _, _ = h.add(ch2, pub, PublishOptions{HistorySize: 2, HistoryTTL: time.Second, HistoryMetaTTL: time.Second})
-	_, _, _ = h.add(ch2, pub, PublishOptions{HistorySize: 2, HistoryTTL: time.Second, HistoryMetaTTL: time.Second})
+	_, _, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second, HistoryMetaTTL: time.Second})
+	_, _, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second, HistoryMetaTTL: time.Second})
+	_, _, _, _ = h.add(ch2, pub, PublishOptions{HistorySize: 2, HistoryTTL: time.Second, HistoryMetaTTL: time.Second})
+	_, _, _, _ = h.add(ch2, pub, PublishOptions{HistorySize: 2, HistoryTTL: time.Second, HistoryMetaTTL: time.Second})
 	h.RLock()
 	require.True(t, h.nextRemoveCheck > 0)
 	require.Equal(t, 2, len(h.streams))
@@ -784,8 +784,8 @@ func TestMemoryHistoryHubPrevPub(t *testing.T) {
 	defer h.close()
 	ch1 := "channel1"
 	pub := newTestPublication()
-	_, prevPub, _ := h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second, UseDelta: true})
+	_, prevPub, _, _ := h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second, UseDelta: true})
 	require.Nil(t, prevPub)
-	_, prevPub, _ = h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second, UseDelta: true})
+	_, prevPub, _, _ = h.add(ch1, pub, PublishOptions{HistorySize: 1, HistoryTTL: time.Second, UseDelta: true})
 	require.NotNil(t, prevPub)
 }

--- a/broker_redis_test.go
+++ b/broker_redis_test.go
@@ -413,7 +413,7 @@ func TestRedisBrokerPublishSkipOldVersion(t *testing.T) {
 			channel2 := uuid.NewString()
 			// Test publish with history and with version and version epoch.
 			_, _, err = b.Publish(channel2, testPublicationData(), PublishOptions{
-				HistorySize:  1,
+				HistorySize:  2,
 				HistoryTTL:   5 * time.Second,
 				Version:      1,
 				VersionEpoch: "xyz",
@@ -421,7 +421,7 @@ func TestRedisBrokerPublishSkipOldVersion(t *testing.T) {
 			require.NoError(t, err)
 			// Publish with same version and epoch.
 			_, _, err = b.Publish(channel2, testPublicationData(), PublishOptions{
-				HistorySize:  1,
+				HistorySize:  2,
 				HistoryTTL:   5 * time.Second,
 				Version:      1,
 				VersionEpoch: "xyz",
@@ -436,7 +436,7 @@ func TestRedisBrokerPublishSkipOldVersion(t *testing.T) {
 			require.Equal(t, 1, len(pubs))
 			// Publish with same version and different epoch.
 			_, _, err = b.Publish(channel2, testPublicationData(), PublishOptions{
-				HistorySize:  1,
+				HistorySize:  2,
 				HistoryTTL:   time.Second,
 				Version:      1,
 				VersionEpoch: "aaa",

--- a/broker_redis_test.go
+++ b/broker_redis_test.go
@@ -377,6 +377,11 @@ func TestRedisBrokerPublishIdempotent(t *testing.T) {
 func TestRedisBrokerPublishSkipOldVersion(t *testing.T) {
 	for _, tt := range historyRedisTests {
 		t.Run(tt.Name, func(t *testing.T) {
+			if !tt.UseStreams {
+				// Does not work with lists.
+				t.Skip("Skip test for Redis lists - not implemented")
+			}
+
 			node := testNode(t)
 
 			b := newTestRedisBroker(t, node, tt.UseStreams, tt.UseCluster, tt.Port)
@@ -391,14 +396,12 @@ func TestRedisBrokerPublishSkipOldVersion(t *testing.T) {
 				Version:     1,
 			})
 			require.NoError(t, err)
-
 			_, _, err = b.Publish(channel, testPublicationData(), PublishOptions{
 				HistorySize: 2,
 				HistoryTTL:  5 * time.Second,
 				Version:     1,
 			})
 			require.NoError(t, err)
-
 			pubs, _, err := b.History(channel, HistoryOptions{
 				Filter: HistoryFilter{
 					Limit: -1,
@@ -406,6 +409,46 @@ func TestRedisBrokerPublishSkipOldVersion(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.Equal(t, 1, len(pubs))
+
+			channel2 := uuid.NewString()
+			// Test publish with history and with version and version epoch.
+			_, _, err = b.Publish(channel2, testPublicationData(), PublishOptions{
+				HistorySize:  1,
+				HistoryTTL:   5 * time.Second,
+				Version:      1,
+				VersionEpoch: "xyz",
+			})
+			require.NoError(t, err)
+			// Publish with same version and epoch.
+			_, _, err = b.Publish(channel2, testPublicationData(), PublishOptions{
+				HistorySize:  1,
+				HistoryTTL:   5 * time.Second,
+				Version:      1,
+				VersionEpoch: "xyz",
+			})
+			require.NoError(t, err)
+			pubs, _, err = b.History(channel2, HistoryOptions{
+				Filter: HistoryFilter{
+					Limit: -1,
+				},
+			})
+			require.NoError(t, err)
+			require.Equal(t, 1, len(pubs))
+			// Publish with same version and different epoch.
+			_, _, err = b.Publish(channel2, testPublicationData(), PublishOptions{
+				HistorySize:  1,
+				HistoryTTL:   time.Second,
+				Version:      1,
+				VersionEpoch: "aaa",
+			})
+			require.NoError(t, err)
+			pubs, _, err = b.History(channel2, HistoryOptions{
+				Filter: HistoryFilter{
+					Limit: -1,
+				},
+			})
+			require.NoError(t, err)
+			require.Equal(t, 2, len(pubs))
 		})
 	}
 }

--- a/internal/memstream/stream.go
+++ b/internal/memstream/stream.go
@@ -29,10 +29,10 @@ type Item struct {
 	Value  any
 }
 
-type AppStreamPosition struct {
-	// Offset is an incremental position number inside a history stream.
-	Offset uint64
-	// Epoch is a string that identifies the stream.
+type AppVersion struct {
+	// Version is an incremental version of state.
+	Version uint64
+	// Epoch is a string that identifies the epoch of version number.
 	Epoch string
 }
 
@@ -40,11 +40,11 @@ type AppStreamPosition struct {
 // maintains a stream of values limited by size and provides
 // methods to access a range of values from provided position.
 type Stream struct {
-	top    uint64
-	list   *list.List
-	index  map[uint64]*list.Element
-	epoch  string
-	appPos AppStreamPosition
+	top     uint64
+	list    *list.List
+	index   map[uint64]*list.Element
+	epoch   string
+	version AppVersion
 }
 
 // New creates new Stream.
@@ -57,7 +57,7 @@ func New() *Stream {
 }
 
 // Add item to stream.
-func (s *Stream) Add(v any, size int, appStreamPosition AppStreamPosition) (uint64, error) {
+func (s *Stream) Add(v any, size int, version uint64, versionEpoch string) (uint64, error) {
 	s.top++
 	item := Item{
 		Offset: s.top,
@@ -71,7 +71,10 @@ func (s *Stream) Add(v any, size int, appStreamPosition AppStreamPosition) (uint
 		s.list.Remove(el)
 		delete(s.index, item.Offset)
 	}
-	s.appPos = appStreamPosition
+	s.version = AppVersion{
+		Version: version,
+		Epoch:   versionEpoch,
+	}
 	return s.top, nil
 }
 
@@ -85,12 +88,12 @@ func (s *Stream) Epoch() string {
 	return s.epoch
 }
 
-func (s *Stream) AppTopOffset() uint64 {
-	return s.appPos.Offset
+func (s *Stream) TopVersion() uint64 {
+	return s.version.Version
 }
 
-func (s *Stream) AppEpoch() string {
-	return s.appPos.Epoch
+func (s *Stream) TopVersionEpoch() string {
+	return s.version.Epoch
 }
 
 // Reset stream.

--- a/internal/memstream/stream_test.go
+++ b/internal/memstream/stream_test.go
@@ -14,7 +14,7 @@ func TestStream(t *testing.T) {
 
 	// Fill stream with values.
 	for i := 0; i < streamSize; i++ {
-		seq, err := s.Add([]byte(strconv.Itoa(i+1)), streamSize)
+		seq, err := s.Add([]byte(strconv.Itoa(i+1)), streamSize, 0, "")
 		require.NoError(t, err)
 		require.Equal(t, uint64(i+1), seq)
 	}
@@ -57,7 +57,7 @@ func TestStream(t *testing.T) {
 	require.Equal(t, streamTop, uint64(5))
 	require.Equal(t, []Item{{1, []byte("1")}, {2, []byte("2")}}, items)
 
-	_, err = s.Add([]byte("6"), streamSize)
+	_, err = s.Add([]byte("6"), streamSize, 0, "")
 	require.NoError(t, err)
 
 	items, streamTop, err = s.Get(1, true, 2, false)
@@ -80,7 +80,7 @@ func TestStream(t *testing.T) {
 	require.Equal(t, streamTop, uint64(6))
 	require.Equal(t, []Item{{5, []byte("5")}, {4, []byte("4")}}, items)
 
-	_, err = s.Add([]byte("7"), streamSize)
+	_, err = s.Add([]byte("7"), streamSize, 0, "")
 	require.NoError(t, err)
 	_, streamTop, err = s.Get(5, true, 2, false)
 	require.NoError(t, err)
@@ -91,7 +91,7 @@ func TestStream(t *testing.T) {
 	require.Equal(t, uint64(0), s.Top())
 	require.Equal(t, 0, len(s.index))
 	require.Equal(t, 0, s.list.Len())
-	_, err = s.Add([]byte("8"), streamSize)
+	_, err = s.Add([]byte("8"), streamSize, 0, "")
 	require.NoError(t, err)
 }
 
@@ -101,7 +101,7 @@ func TestStreamGetAll(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), streamTop)
 	require.Nil(t, items)
-	_, err = s.Add([]byte("1"), 2)
+	_, err = s.Add([]byte("1"), 2, 0, "")
 	require.NoError(t, err)
 	items, _, err = s.Get(0, false, 200, false)
 	require.NoError(t, err)
@@ -111,7 +111,7 @@ func TestStreamGetAll(t *testing.T) {
 func TestStreamClear(t *testing.T) {
 	s := New()
 	const streamSize = 5
-	_, err := s.Add([]byte("1"), streamSize)
+	_, err := s.Add([]byte("1"), streamSize, 0, "")
 	require.NoError(t, err)
 	s.Clear()
 	require.NotZero(t, s.Top())
@@ -123,7 +123,7 @@ func TestStreamReset(t *testing.T) {
 	s := New()
 	epoch := s.Epoch()
 	const streamSize = 5
-	_, err := s.Add([]byte("1"), streamSize)
+	_, err := s.Add([]byte("1"), streamSize, 0, "")
 	require.NoError(t, err)
 	s.Reset()
 	require.Zero(t, s.Top())
@@ -136,7 +136,7 @@ func TestStreamOffset(t *testing.T) {
 	s := New()
 	const streamSize = 5
 	for i := 0; i < streamSize; i++ {
-		_, err := s.Add([]byte("elem"), streamSize)
+		_, err := s.Add([]byte("elem"), streamSize, 0, "")
 		require.NoError(t, err)
 	}
 	items, _, err := s.Get(0, true, 1, false)
@@ -154,7 +154,7 @@ func TestStreamOffsetReverseNonExistingOffset(t *testing.T) {
 	s := New()
 	const streamSize = 2
 	for i := 0; i < 10; i++ {
-		_, err := s.Add([]byte("elem"), streamSize)
+		_, err := s.Add([]byte("elem"), streamSize, 0, "")
 		require.NoError(t, err)
 	}
 	items, _, err := s.Get(4, true, 1, true)
@@ -166,7 +166,7 @@ func TestStreamNoLimitWithMiddle(t *testing.T) {
 	s := New()
 	const streamSize = 10
 	for i := 0; i < streamSize; i++ {
-		_, err := s.Add([]byte("elem"), streamSize)
+		_, err := s.Add([]byte("elem"), streamSize, 0, "")
 		require.NoError(t, err)
 	}
 	items, _, err := s.Get(5, true, -1, false)

--- a/internal/redis_lua/broker_history_add_stream.lua
+++ b/internal/redis_lua/broker_history_add_stream.lua
@@ -10,12 +10,14 @@ local new_epoch_if_empty = ARGV[6]
 local publish_command = ARGV[7]
 local result_key_expire = ARGV[8]
 local use_delta = ARGV[9]
+local version = ARGV[10]
+local version_epoch = ARGV[11]
 
 if result_key_expire ~= '' then
     local cached_result = redis.call("hmget", result_key, "e", "s")
     local result_epoch, result_offset = cached_result[1], cached_result[2]
     if result_epoch ~= false then
-        return { result_offset, result_epoch, "1" }
+        return { result_offset, result_epoch, "1", "0" }
     end
 end
 
@@ -29,6 +31,18 @@ local top_offset = redis.call("hincrby", meta_key, "s", 1)
 
 if meta_expire ~= '0' then
     redis.call("expire", meta_key, meta_expire)
+end
+
+if version ~= "0" then
+    local prev_version_values = redis.call("hmget", meta_key, "v", "ve")
+    local prev_version = prev_version_values[1]
+    local prev_version_epoch = prev_version_values[2]
+    if prev_version then
+        if (version_epoch == "" or version_epoch == prev_version_epoch) and (tonumber(prev_version) >= tonumber(version)) then
+            return { top_offset, current_epoch, "0", "1" }
+        end
+    end
+    redis.call("hset", meta_key, "v", version, "ve", version_epoch)
 end
 
 local prev_message_payload = ""
@@ -80,4 +94,4 @@ if result_key_expire ~= '' then
     redis.call("expire", result_key, result_key_expire)
 end
 
-return { top_offset, current_epoch, "0" }
+return { top_offset, current_epoch, "0", "0" }

--- a/options.go
+++ b/options.go
@@ -53,22 +53,28 @@ func WithTags(meta map[string]string) PublishOption {
 	}
 }
 
-// WithAppStreamPosition allows application to provide a tip for Centrifuge about
-// internal application stream position of Publication. This is helpful to drop
-// non-actual publications on Centrifuge Broker level. Publications may be non-actual
-// in case of unordered processing and message publication by the application.
-// This is mostly useful for scenarios when channel messages contain the entire state,
-// so skipping intermediary messages is safe and beneficial. This also means that
-// Centrifuge history will contain the most recent Publication, so the recovery will return
-// the proper state (and state will be eventually consistent in case of at least one delivery).
-// This option must be used only with channels that have history enabled. Note, this
-// StreamPosition is not used as Centrifuge channel stream position, it serves a different
-// purpose. Centrifuge still generates its own independent StreamPosition for each Publication
-// in channel streams with history, but for dropping non-actual publications it additionally
-// keeps Offset and Epoch from this application stream position.
-func WithAppStreamPosition(sp StreamPosition) PublishOption {
+// WithVersion allows application to provide a tip for Centrifuge about
+// internal application version of Publication. This is helpful to drop
+// non-actual publications on Centrifuge Broker level. Publications may be
+// non-actual in case of unordered publish calls from application side.
+// In some cases application may want Centrifuge to avoid delivery of these
+// publications.
+// This is mostly useful for scenarios when channel publications contain the
+// entire state, so skipping intermediary messages is safe and beneficial.
+// This also means that Centrifuge history will contain the most recent Publication,
+// so the recovery will return the proper state (and state should be eventually
+// consistent in case of at least one delivery).
+// This option must be used only with channels that have history enabled. Note,
+// these version and versionEpoch are not used as Centrifuge channel stream position.
+// Centrifuge still generates its own independent StreamPosition for each Publication
+// in channel streams with history, but it additionally starts keeping version and
+// versionEpoch provided here.
+// If versionEpoch is an empty string, then Centrifuge does not look at it when comparing
+// versions.
+func WithVersion(version uint64, versionEpoch string) PublishOption {
 	return func(opts *PublishOptions) {
-		opts.AppStreamPosition = &sp
+		opts.Version = version
+		opts.VersionEpoch = versionEpoch
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -53,6 +53,25 @@ func WithTags(meta map[string]string) PublishOption {
 	}
 }
 
+// WithAppStreamPosition allows application to provide a tip for Centrifuge about
+// internal application stream position of Publication. This is helpful to drop
+// non-actual publications on Centrifuge Broker level. Publications may be non-actual
+// in case of unordered processing and message publication by the application.
+// This is mostly useful for scenarios when channel messages contain the entire state,
+// so skipping intermediary messages is safe and beneficial. This also means that
+// Centrifuge history will contain the most recent Publication, so the recovery will return
+// the proper state (and state will be eventually consistent in case of at least one delivery).
+// This option must be used only with channels that have history enabled. Note, this
+// StreamPosition is not used as Centrifuge channel stream position, it serves a different
+// purpose. Centrifuge still generates its own independent StreamPosition for each Publication
+// in channel streams with history, but for dropping non-actual publications it additionally
+// keeps Offset and Epoch from this application stream position.
+func WithAppStreamPosition(sp StreamPosition) PublishOption {
+	return func(opts *PublishOptions) {
+		opts.AppStreamPosition = &sp
+	}
+}
+
 // SubscribeOptions define per-subscription options.
 type SubscribeOptions struct {
 	// ExpireAt defines time in future when subscription should expire,


### PR DESCRIPTION
Adding an option `WithVersion` for Publish op to keep in-app version inside Centrifuge history streams to drop non-actual messages (due to unordered processing) on Broker level.

This is mostly useful for channels where publications contain entire state, so loosing intermediary messages is safe and beneficial.   