### PR TITLE
Possibility to register custom client timer scheduler

### DIFF
--- a/client_experimental.go
+++ b/client_experimental.go
@@ -273,3 +273,17 @@ func (pcw *perChannelWriter) Add(item queue.Item, ch string, config ChannelBatch
 	w := pcw.getWriter(ch)
 	w.Add(item, config)
 }
+
+// TimerCanceler is the interface returned from ScheduleTimer which allows the task to be cancelled.
+// EXPERIMENTAL API.
+type TimerCanceler interface {
+	// Cancel the timer.
+	Cancel()
+}
+
+// TimerScheduler is the interface for scheduling timers.
+// EXPERIMENTAL API.
+type TimerScheduler interface {
+	// ScheduleTimer adds a callback for later execution. The TimerCanceler is returned.
+	ScheduleTimer(duration time.Duration, callback func()) TimerCanceler
+}

--- a/config.go
+++ b/config.go
@@ -132,6 +132,9 @@ type Config struct {
 	// not set then no batching is used on per-channel level. This function may be called in the hot
 	// broadcast path, so must be fast. This is an EXPERIMENTAL feature.
 	GetChannelBatchConfig func(channel string) ChannelBatchConfig
+	// ClientTimerScheduler if set will be used for scheduling client timers.
+	// This is an EXPERIMENTAL API.
+	ClientTimerScheduler TimerScheduler
 }
 
 const (

--- a/node.go
+++ b/node.go
@@ -88,6 +88,8 @@ type Node struct {
 
 	mediums     map[string]*channelMedium
 	mediumLocks map[int]*sync.Mutex // Sharded locks for mediums map.
+
+	timerScheduler TimerScheduler
 }
 
 const (
@@ -174,6 +176,7 @@ func New(c Config) (*Node, error) {
 		surveyRegistry: make(map[uint64]chan survey),
 		mediums:        map[string]*channelMedium{},
 		mediumLocks:    mediumLocks,
+		timerScheduler: c.ClientTimerScheduler,
 	}
 	n.emulationSurveyHandler = newEmulationSurveyHandler(n)
 


### PR DESCRIPTION
Experimental API for setting custom client timer scheduler. This opens a road to register non-stdlib custom timer implementations (for performance reasons).