### PR TITLE
Channel level batching: keep latest publication separate

### DIFF
--- a/broker_memory_test.go
+++ b/broker_memory_test.go
@@ -2,13 +2,13 @@ package centrifuge
 
 import (
 	"context"
-	"github.com/google/uuid"
 	"os"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/centrifugal/protocol"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 

--- a/client.go
+++ b/client.go
@@ -648,8 +648,8 @@ func (c *Client) writeEncodedPushData(data []byte, ch string, frameType protocol
 	if c.node.config.Metrics.GetChannelNamespaceLabel != nil {
 		item.Channel = ch
 	}
-	if ch != "" && (batchConfig.MaxSize > 0 || batchConfig.MaxDelay > 0) && (
-		item.FrameType == protocol.FrameTypePushPublication ||
+	if ch != "" && (batchConfig.MaxSize > 0 || batchConfig.MaxDelay > 0) &&
+		(item.FrameType == protocol.FrameTypePushPublication ||
 			item.FrameType == protocol.FrameTypePushJoin ||
 			item.FrameType == protocol.FrameTypePushLeave) {
 		// Per channel writer helps to batch messages on the channel level working as

--- a/client_experimental_test.go
+++ b/client_experimental_test.go
@@ -135,9 +135,9 @@ func TestClientSubscribeReceivePublication_ChannelBatching_FlushLatestOnly(t *te
 	node := defaultTestNode()
 	node.config.GetChannelBatchConfig = func(channel string) ChannelBatchConfig {
 		return ChannelBatchConfig{
-			MaxSize:     2,
-			MaxDelay:    0,
-			FlushLatest: true,
+			MaxSize:                0,
+			MaxDelay:               100 * time.Millisecond,
+			FlushLatestPublication: true,
 		}
 	}
 	defer func() { _ = node.Shutdown(context.Background()) }()


### PR DESCRIPTION
This PR makes a couple of things:

* Currently FlushLatest skips join/leave messages also, which does not make sense
* Keeping latest publication separate reduces memory overhead
* Rename `FlushLatest` to `FlushLatestPublication` to better reflect the behavior