### PR TITLE
Fix panic upon Client.Subscribe during Redis unavailability

### DIFF
--- a/client.go
+++ b/client.go
@@ -2702,6 +2702,10 @@ func (c *Client) Subscribe(channel string, opts ...SubscribeOption) error {
 	subCtx := c.subscribeCmd(subCmd, SubscribeReply{
 		Options: *subscribeOpts,
 	}, nil, true, time.Time{}, nil)
+	if subCtx.disconnect != nil {
+		c.onSubscribeError(subCmd.Channel)
+		return subCtx.disconnect
+	}
 	if subCtx.err != nil {
 		c.onSubscribeError(subCmd.Channel)
 		return subCtx.err


### PR DESCRIPTION
Reported in Discord:

```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x88 pc=0xcd9f7e]
#011/home/runner/go/pkg/mod/github.com/centrifugal/centrifuge@v0.34.5-0.20250305060328-dbb1a731fae9/hub.go:301 +0x2bc
github.com/centrifugal/centrifuge.(*Client).Subscribe(0xc0034f22c0, {0xc0043c2468, 0x14}, {0xc00580aa00, 0xa, 0x1c838?})
goroutine 20228 [running]:
created by github.com/centrifugal/centrifuge.(*connShard).subscribe in goroutine 20148
github.com/centrifugal/centrifuge.(*connShard).subscribe.func1(0xc00a5bf2d0?)
#011/home/runner/go/pkg/mod/github.com/centrifugal/centrifuge@v0.34.5-0.20250305060328-dbb1a731fae9/client.go:2675 +0x50b
github.com/centrifugal/centrifuge.(*Client).getSubscribePushReply(0xc0034f22c0, {0xc0043c2468, 0x14}, 0x0)
#011/home/runner/go/pkg/mod/github.com/centrifugal/centrifuge@v0.34.5-0.20250305060328-dbb1a731fae9/hub.go:303 +0x74
#011/home/runner/go/pkg/mod/github.com/centrifugal/centrifuge@v0.34.5-0.20250305060328-dbb1a731fae9/client.go:2695 +0xde
panic: runtime error: invalid memory address or nil pointer dereference
{"level":"error","error":"redis: pub/sub connection temporary unavailable","channel":"system:1938220980:94","client":"b7990f80-9759-403e-88db-697154e2d091","user":"qfe950299fd347d4b11633ff95065405","time":"2025-07-08T22:37:36Z","message":"error adding subscription"}
```