### PR TITLE
Make websocket package to not depend on centrifuge internal packages

### DIFF
--- a/internal/websocket/convert_safe.go
+++ b/internal/websocket/convert_safe.go
@@ -1,0 +1,7 @@
+//go:build appengine
+
+package websocket
+
+func stringToBytes(s string) []byte {
+	return []byte(s)
+}

--- a/internal/websocket/convert_unsafe.go
+++ b/internal/websocket/convert_unsafe.go
@@ -1,0 +1,10 @@
+//go:build !appengine
+
+package websocket
+
+import "unsafe"
+
+// StringToBytes converts string to byte slice.
+func stringToBytes(s string) []byte {
+	return unsafe.Slice(unsafe.StringData(s), len(s))
+}

--- a/internal/websocket/convert_unsafe_test.go
+++ b/internal/websocket/convert_unsafe_test.go
@@ -1,0 +1,17 @@
+package websocket
+
+import "testing"
+
+var tests = []string{
+	"abc",
+	"hello world",
+	"tests",
+}
+
+func TestStringToBytes(t *testing.T) {
+	for _, want := range tests {
+		if got := stringToBytes(want); string(got) != want {
+			t.Errorf("StringToBytes() = %s, want %s", got, want)
+		}
+	}
+}

--- a/internal/websocket/util.go
+++ b/internal/websocket/util.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 	"sync"
 	"unicode/utf8"
-
-	"github.com/centrifugal/centrifuge/internal/convert"
 )
 
 var keyGUID = []byte("258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
@@ -35,7 +33,7 @@ var acceptKeyBufferPool = sync.Pool{
 
 func encodeAcceptKey(challengeKey string, p []byte) []byte {
 	h := sha1.New()
-	h.Write(convert.StringToBytes(challengeKey))
+	h.Write(stringToBytes(challengeKey))
 	h.Write(keyGUID)
 
 	bufPtr := acceptKeyBufferPool.Get().(*[]byte)


### PR DESCRIPTION
There are thoughts to reuse this code for Centrifugo unidirectional websocket implementation. Most probably using copy of this package. Removing dependency on Centrifuge internal package.