### PR TITLE
Method to get redis shard mode

### DIFF
--- a/broker_redis_test.go
+++ b/broker_redis_test.go
@@ -65,6 +65,7 @@ func NewTestRedisBroker(tb testing.TB, n *Node, prefix string, useStreams bool, 
 	redisConf := testSingleRedisConf(port)
 	s, err := NewRedisShard(n, redisConf)
 	require.NoError(tb, err)
+	require.Equal(tb, s.Mode(), RedisShardModeStandalone)
 	e, err := NewRedisBroker(n, RedisBrokerConfig{
 		Prefix:   prefix,
 		UseLists: !useStreams,
@@ -100,6 +101,7 @@ func NewTestRedisBrokerCluster(tb testing.TB, n *Node, prefix string, useStreams
 	}
 	s, err := NewRedisShard(n, redisConf)
 	require.NoError(tb, err)
+	require.Equal(tb, s.Mode(), RedisShardModeCluster)
 	brokerConfig := RedisBrokerConfig{
 		Prefix:   prefix,
 		UseLists: !useStreams,
@@ -134,6 +136,7 @@ func NewTestRedisBrokerSentinel(tb testing.TB) *RedisBroker {
 	}
 	s, err := NewRedisShard(n, redisConf)
 	require.NoError(tb, err)
+	require.Equal(tb, s.Mode(), RedisShardModeSentinel)
 	e, err := NewRedisBroker(n, RedisBrokerConfig{
 		Shards: []*RedisShard{s},
 	})

--- a/redis_shard.go
+++ b/redis_shard.go
@@ -32,6 +32,7 @@ type RedisShard struct {
 	closeCh       chan struct{}
 	closeOnce     sync.Once
 	isCluster     bool
+	isSentinel    bool
 	finalAddress  []string
 }
 
@@ -263,6 +264,7 @@ func NewRedisShard(_ *Node, conf RedisShardConfig) (*RedisShard, error) {
 	shard := &RedisShard{
 		config:       conf,
 		isCluster:    isCluster,
+		isSentinel:   isSentinel,
 		closeCh:      make(chan struct{}),
 		finalAddress: options.InitAddress,
 	}
@@ -352,6 +354,24 @@ type RedisShardConfig struct {
 	// be initialized with the same options as the main client but with ReplicaOnly option
 	// set to true.
 	ReplicaClientEnabled bool
+}
+
+type RedisShardMode string
+
+const (
+	RedisShardModeStandalone RedisShardMode = "standalone"
+	RedisShardModeCluster    RedisShardMode = "cluster"
+	RedisShardModeSentinel   RedisShardMode = "sentinel"
+)
+
+func (s *RedisShard) Mode() RedisShardMode {
+	if s.isSentinel {
+		return RedisShardModeSentinel
+	}
+	if s.isCluster {
+		return RedisShardModeCluster
+	}
+	return RedisShardModeStandalone
 }
 
 func (s *RedisShard) Close() {


### PR DESCRIPTION
Adding Mode method to RedisShard to get the mode of Redis setup: standalone, cluster or sentinel.