### PR TITLE
Add history TTL configuration validation during message publishing 

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -109,4 +109,10 @@ var (
 		Code:    112,
 		Message: "unrecoverable position",
 	}
+	// ErrorIncorrectHistoryTTLConfiguration means that history meta TTL is less than history TTL.
+	// History meta TTL must be greater than or equal to history TTL to avoid stream inconsistencies.
+	ErrorIncorrectHistoryTTLConfiguration = &Error{
+		Code:    113,
+		Message: "history meta TTL must be greater than or equal to history TTL",
+	}
 )

--- a/node.go
+++ b/node.go
@@ -771,6 +771,18 @@ func (n *Node) publish(ch string, data []byte, opts ...PublishOption) (PublishRe
 	for _, opt := range opts {
 		opt(pubOpts)
 	}
+
+	// Validate history TTL configuration if history is enabled.
+	if pubOpts.HistorySize > 0 && pubOpts.HistoryTTL > 0 {
+		historyMetaTTL := pubOpts.HistoryMetaTTL
+		if historyMetaTTL == 0 {
+			historyMetaTTL = n.config.HistoryMetaTTL
+		}
+		if historyMetaTTL > 0 && historyMetaTTL < pubOpts.HistoryTTL {
+			return PublishResult{}, ErrorIncorrectHistoryTTLConfiguration
+		}
+	}
+
 	n.metrics.incMessagesSent("publication", ch)
 	streamPos, fromCache, err := n.getBroker(ch).Publish(ch, data, *pubOpts)
 	if err != nil {


### PR DESCRIPTION
## Summary

This PR implements history TTL configuration validation during message publishing to prevent runtime errors caused by incorrect TTL configurations.

## Background

This addresses #367, which was created in response to the Redis XADD errors reported in [centrifugal/centrifugo#768](https://github.com/centrifugal/centrifugo/issues/768)

Users encountered the following error when `history_ttl` was configured to be greater than `history_meta_ttl`:
