### PR TITLE
WebSocket frame ping/pong tweaks

### DIFF
--- a/handler_websocket_test.go
+++ b/handler_websocket_test.go
@@ -316,7 +316,7 @@ func TestWebsocketHandlerPing(t *testing.T) {
 
 func TestWebsocketHandler_FramePingPong(t *testing.T) {
 	t.Parallel()
-	framePingInterval = time.Second
+	defaultFramePingInterval = time.Second
 	n, _ := New(Config{})
 	require.NoError(t, n.Run())
 	defer func() { _ = n.Shutdown(context.Background()) }()


### PR DESCRIPTION
For native frame WebSocket ping/pong Inherit timeouts from WebSocket handler by default instead of using separate default and custom pong wait calculation.