### PR TITLE
Fix single connection, avoid possible deadlock with node.Disconnect

### DIFF
--- a/node.go
+++ b/node.go
@@ -1147,13 +1147,13 @@ func (n *Node) Subscribe(userID string, channel string, opts ...SubscribeOption)
 	for _, opt := range opts {
 		opt(subscribeOpts)
 	}
-	// Subscribe on this node.
-	err := n.hub.subscribe(userID, channel, subscribeOpts.clientID, subscribeOpts.sessionID, opts...)
+	// Send subscribe control message to other nodes.
+	err := n.pubSubscribe(userID, channel, *subscribeOpts)
 	if err != nil {
 		return err
 	}
-	// Send subscribe control message to other nodes.
-	return n.pubSubscribe(userID, channel, *subscribeOpts)
+	// Subscribe on this node.
+	return n.hub.subscribe(userID, channel, subscribeOpts.clientID, subscribeOpts.sessionID, opts...)
 }
 
 // Unsubscribe unsubscribes user from a channel.
@@ -1167,14 +1167,13 @@ func (n *Node) Unsubscribe(userID string, channel string, opts ...UnsubscribeOpt
 	if unsubscribeOpts.unsubscribe != nil {
 		customUnsubscribe = *unsubscribeOpts.unsubscribe
 	}
-
-	// Unsubscribe on this node.
-	err := n.hub.unsubscribe(userID, channel, customUnsubscribe, unsubscribeOpts.clientID, unsubscribeOpts.sessionID)
+	// Send unsubscribe control message to other nodes.
+	err := n.pubUnsubscribe(userID, channel, customUnsubscribe, unsubscribeOpts.clientID, unsubscribeOpts.sessionID)
 	if err != nil {
 		return err
 	}
-	// Send unsubscribe control message to other nodes.
-	return n.pubUnsubscribe(userID, channel, customUnsubscribe, unsubscribeOpts.clientID, unsubscribeOpts.sessionID)
+	// Unsubscribe on this node.
+	return n.hub.unsubscribe(userID, channel, customUnsubscribe, unsubscribeOpts.clientID, unsubscribeOpts.sessionID)
 }
 
 // Disconnect allows closing all user connections on all nodes.
@@ -1188,12 +1187,13 @@ func (n *Node) Disconnect(userID string, opts ...DisconnectOption) error {
 	if disconnectOpts.Disconnect != nil {
 		customDisconnect = *disconnectOpts.Disconnect
 	}
-	err := n.hub.disconnect(userID, customDisconnect, disconnectOpts.clientID, disconnectOpts.sessionID, disconnectOpts.ClientWhitelist)
+	// Send disconnect control message to other nodes.
+	err := n.pubDisconnect(userID, customDisconnect, disconnectOpts.clientID, disconnectOpts.sessionID, disconnectOpts.ClientWhitelist)
 	if err != nil {
 		return err
 	}
-	// Send disconnect control message to other nodes
-	return n.pubDisconnect(userID, customDisconnect, disconnectOpts.clientID, disconnectOpts.sessionID, disconnectOpts.ClientWhitelist)
+	// Disconnect on this node.
+	return n.hub.disconnect(userID, customDisconnect, disconnectOpts.clientID, disconnectOpts.sessionID, disconnectOpts.ClientWhitelist)
 }
 
 // Refresh user connection.
@@ -1205,13 +1205,12 @@ func (n *Node) Refresh(userID string, opts ...RefreshOption) error {
 	for _, opt := range opts {
 		opt(refreshOpts)
 	}
-	// Refresh on this node.
-	err := n.hub.refresh(userID, refreshOpts.clientID, refreshOpts.sessionID, opts...)
+	err := n.pubRefresh(userID, *refreshOpts)
 	if err != nil {
 		return err
 	}
-	// Send refresh control message to other nodes.
-	return n.pubRefresh(userID, *refreshOpts)
+	// Refresh on this node.
+	return n.hub.refresh(userID, refreshOpts.clientID, refreshOpts.sessionID, opts...)
 }
 
 func (n *Node) getPresenceManager(ch string) PresenceManager {


### PR DESCRIPTION
Relates https://github.com/centrifugal/centrifugo/issues/1044

The deadlock may strike when calling node.Disconnect method inside OnConnect callback. Client.connectMu is acquired at that point, and concurrent connections which disconnect each other may result into deadlock path.

Also moving logic of single connection example to OnConnecting callback – it's actually more correct in general since happens before connection established, and in this case we avoid the situation when 2 concurrent connections may disconnect each other.