### PR TITLE
Clear read deadline in http/2 ws case

### DIFF
--- a/internal/websocket/server.go
+++ b/internal/websocket/server.go
@@ -370,6 +370,10 @@ func (u *Upgrader) upgradeH2(w http.ResponseWriter, r *http.Request, responseHea
 	if err := rc.Flush(); err != nil {
 		return nil, "", err
 	}
+	err := rc.SetReadDeadline(time.Time{})
+	if err != nil {
+		return nil, "", err
+	}
 
 	stream := &http2Stream{
 		ReadCloser: r.Body,


### PR DESCRIPTION
Connection is under our control after that, so no need to inherit read deadline set by HTTP server (ReadTimeout) - otherwise connection is being closed upon deadline expiration. 