### PR TITLE
- writer.go: add missing Unlock()

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -73,6 +73,7 @@ func (w *writer) waitSendMessage(maxMessagesInFrame int, writeDelay time.Duratio
 		if bufSize < 0 { // Unlimited, just use current length.
 			bufSize = w.messages.Len()
 			if bufSize == 0 {
+				w.mu.Unlock()
 				return true
 			}
 		}


### PR DESCRIPTION
Hey @FZambia,

Looks like I've accidentally\* found a potential deadlock in the writer: one of the early returns do not unlock the mutex. Please, take a look.

\* I'm working on a linter for identifying Go mutex deadlocks and I'm testing on various public codebases, include yours.  That's how I found it. Feel free to ignore/close if it's irrelevant 🙃.