### PR TITLE
Feat: UpdatePresence using batch commit on addPresence

### DIFF
--- a/client.go
+++ b/client.go
@@ -828,7 +828,7 @@ func (c *Client) updatePresence() {
 	// legacy per-channel path instead (handled by the caller via config check).
 	batchSize := config.ClientPresenceUpdateBatchSize
 	if batchSize <= 0 {
-		batchSize = 500 // Default to 500 channels per batch.
+		batchSize = 1000 // Default to 1000 channels per batch.
 	}
 
 	// Convert the channel map to a slice so it can be split into fixed-size batches.

--- a/client.go
+++ b/client.go
@@ -828,7 +828,7 @@ func (c *Client) updatePresence() {
 	// legacy per-channel path instead (handled by the caller via config check).
 	batchSize := config.ClientPresenceUpdateBatchSize
 	if batchSize <= 0 {
-		batchSize = 10 // Default to 10 channels per batch.
+		batchSize = 500 // Default to 500 channels per batch.
 	}
 
 	// Convert the channel map to a slice so it can be split into fixed-size batches.

--- a/client.go
+++ b/client.go
@@ -702,6 +702,50 @@ func (c *Client) updateChannelPresence(ch string, chCtx ChannelContext) error {
 	})
 }
 
+// updateChannelPresenceBatch updates client presence info for multiple channels in batch,
+// reducing Redis network round trips. This is more efficient than calling updateChannelPresence
+// multiple times.
+func (c *Client) updateChannelPresenceBatch(channels map[string]ChannelContext) error {
+	if len(channels) == 0 {
+		return nil
+	}
+
+	// Collect channels that need presence update
+	presenceBatchItems := make([]PresenceBatchItem, 0, len(channels))
+
+	c.mu.RLock()
+	for ch, chCtx := range channels {
+		// Skip channels without presence emission
+		if !channelHasFlag(chCtx.flags, flagEmitPresence) {
+			continue
+		}
+
+		// Verify channel still exists
+		if _, ok := c.channels[ch]; !ok {
+			continue
+		}
+
+		presenceBatchItems = append(presenceBatchItems, PresenceBatchItem{
+			Channel:  ch,
+			ClientID: c.uid,
+			Info: &ClientInfo{
+				ClientID: c.uid,
+				UserID:   c.user,
+				ConnInfo: c.info,
+				ChanInfo: chCtx.info,
+			},
+		})
+	}
+	c.mu.RUnlock()
+
+	if len(presenceBatchItems) == 0 {
+		return nil
+	}
+
+	// Batch submit to Redis
+	return c.node.addPresenceBatch(presenceBatchItems)
+}
+
 // Context returns client Context. This context will be canceled
 // as soon as client connection closes.
 func (c *Client) Context() context.Context {
@@ -779,39 +823,97 @@ func (c *Client) updatePresence() {
 		c.eventHub.aliveHandler()
 	}
 
+	// Determine the maximum number of channels to process per batch.
+	// A non-positive value means the feature is disabled; fall back to the
+	// legacy per-channel path instead (handled by the caller via config check).
+	batchSize := config.ClientPresenceUpdateBatchSize
+	if batchSize <= 0 {
+		batchSize = 10 // Default to 10 channels per batch.
+	}
+
+	// Convert the channel map to a slice so it can be split into fixed-size batches.
+	type channelItem struct {
+		channel string
+		context ChannelContext
+	}
+	channelSlice := make([]channelItem, 0, len(channels))
 	for channel, channelContext := range channels {
-		err := c.updateChannelPresence(channel, channelContext)
-		if err != nil {
-			c.node.logger.log(newErrorLogEntry(err, "error updating presence for channel", map[string]any{"channel": channel, "user": c.user, "client": c.uid, "error": err.Error()}))
+		channelSlice = append(channelSlice, channelItem{
+			channel: channel,
+			context: channelContext,
+		})
+	}
+
+	// Process channels in batches to reduce Redis network round trips.
+	for i := 0; i < len(channelSlice); i += batchSize {
+		end := i + batchSize
+		if end > len(channelSlice) {
+			end = len(channelSlice)
+		}
+		batch := channelSlice[i:end]
+
+		// Re-build a map for the current batch to pass to updateChannelPresenceBatch.
+		batchChannels := make(map[string]ChannelContext, len(batch))
+		for _, item := range batch {
+			batchChannels[item.channel] = item.context
 		}
 
-		c.checkSubscriptionExpiration(channel, channelContext, config.ClientExpiredSubCloseDelay, func(result bool) {
-			if !result {
+		// Submit presence updates for this batch. The underlying PresenceManager
+		// may pipeline the commands to reduce network round trips. If the manager
+		// reports that batch operations are not supported (e.g. Redis Cluster mode),
+		// node.addPresenceBatch automatically falls back to individual AddPresence calls.
+		err := c.updateChannelPresenceBatch(batchChannels)
+		if err != nil {
+			c.node.logger.log(newErrorLogEntry(err, "error batch updating presence", map[string]any{"user": c.user, "client": c.uid, "batch_size": len(batchChannels), "error": err.Error()}))
+		}
+
+		// Run subscription expiration and position checks serially within each batch.
+		// checkSubscriptionExpiration may invoke the async subRefreshHandler; running
+		// these checks concurrently would make callback ordering non-deterministic and
+		// could lead to inconsistent state.
+		for _, item := range batch {
+			channel := item.channel
+			channelContext := item.context
+
+			// Check whether the subscription has expired.
+			c.checkSubscriptionExpiration(channel, channelContext, config.ClientExpiredSubCloseDelay, func(result bool) {
+				if !result {
+					serverSide := channelHasFlag(channelContext.flags, flagServerSide)
+					if c.isAsyncUnsubscribe(serverSide) {
+						go func(ch string) { c.handleAsyncUnsubscribe(ch, unsubscribeExpired) }(channel)
+					} else {
+						go func() { _ = c.close(DisconnectSubExpired) }()
+					}
+				}
+			})
+
+			// Check stream position integrity if a check delay is configured.
+			checkDelay := config.ClientChannelPositionCheckDelay
+			if checkDelay > 0 && !c.checkPosition(checkDelay, channel, channelContext) {
 				serverSide := channelHasFlag(channelContext.flags, flagServerSide)
+				if c.node.logger.enabled(LogLevelDebug) {
+					c.node.logger.log(newLogEntry(LogLevelDebug, "client insufficient state from periodic check", map[string]any{"channel": channel, "user": c.user, "client": c.uid}))
+				}
 				if c.isAsyncUnsubscribe(serverSide) {
-					go func(ch string) { c.handleAsyncUnsubscribe(ch, unsubscribeExpired) }(channel)
+					go func(ch string) { c.handleAsyncUnsubscribe(ch, unsubscribeInsufficientState) }(channel)
+					continue
 				} else {
-					go func() { _ = c.close(DisconnectSubExpired) }()
+					go func() { c.handleInsufficientStateDisconnect() }()
+					// No need to proceed after close.
+					return
 				}
 			}
-		})
-
-		checkDelay := config.ClientChannelPositionCheckDelay
-		if checkDelay > 0 && !c.checkPosition(checkDelay, channel, channelContext) {
-			serverSide := channelHasFlag(channelContext.flags, flagServerSide)
-			if c.node.logger.enabled(LogLevelDebug) {
-				c.node.logger.log(newLogEntry(LogLevelDebug, "client insufficient state from periodic check", map[string]any{"channel": channel, "user": c.user, "client": c.uid}))
-			}
-			if c.isAsyncUnsubscribe(serverSide) {
-				go func(ch string) { c.handleAsyncUnsubscribe(ch, unsubscribeInsufficientState) }(channel)
-				continue
-			} else {
-				go func() { c.handleInsufficientStateDisconnect() }()
-				// No need to proceed after close.
-				return
-			}
 		}
+
+		// If the client was closed during batch processing, stop immediately.
+		c.mu.Lock()
+		if c.status == statusClosed {
+			c.mu.Unlock()
+			return
+		}
+		c.mu.Unlock()
 	}
+
 	c.mu.Lock()
 	c.addPresenceUpdate(false, true)
 	c.mu.Unlock()

--- a/config.go
+++ b/config.go
@@ -135,6 +135,10 @@ type Config struct {
 	// ClientTimerScheduler if set will be used for scheduling client timers.
 	// This is an EXPERIMENTAL API.
 	ClientTimerScheduler TimerScheduler
+	// ClientPresenceUpdateBatchSize sets the number of channels to process in each batch
+	// during presence update. This helps to reduce latency when a client has many subscribed channels.
+	// Zero value means 10 channels per batch.
+	ClientPresenceUpdateBatchSize int
 }
 
 const (

--- a/config.go
+++ b/config.go
@@ -137,7 +137,7 @@ type Config struct {
 	ClientTimerScheduler TimerScheduler
 	// ClientPresenceUpdateBatchSize sets the number of channels to process in each batch
 	// during presence update. This helps to reduce latency when a client has many subscribed channels.
-	// Zero value means 10 channels per batch.
+	// Zero value means 500 channels per batch.
 	ClientPresenceUpdateBatchSize int
 }
 

--- a/config.go
+++ b/config.go
@@ -137,7 +137,7 @@ type Config struct {
 	ClientTimerScheduler TimerScheduler
 	// ClientPresenceUpdateBatchSize sets the number of channels to process in each batch
 	// during presence update. This helps to reduce latency when a client has many subscribed channels.
-	// Zero value means 500 channels per batch.
+	// Zero value means 1000 channels per batch.
 	ClientPresenceUpdateBatchSize int
 }
 

--- a/node.go
+++ b/node.go
@@ -142,7 +142,7 @@ func New(c Config) (*Node, error) {
 		c.HistoryMetaTTL = 30 * 24 * time.Hour // 30 days by default.
 	}
 	if c.ClientPresenceUpdateBatchSize == 0 {
-		c.ClientPresenceUpdateBatchSize = 500 // 500 channels by default.
+		c.ClientPresenceUpdateBatchSize = 1000 // 1000 channels by default.
 	}
 
 	uidObj, err := uuid.NewRandom()

--- a/node.go
+++ b/node.go
@@ -141,6 +141,9 @@ func New(c Config) (*Node, error) {
 	if c.HistoryMetaTTL == 0 {
 		c.HistoryMetaTTL = 30 * 24 * time.Hour // 30 days by default.
 	}
+	if c.ClientPresenceUpdateBatchSize == 0 {
+		c.ClientPresenceUpdateBatchSize = 10 // 10 channels by default.
+	}
 
 	uidObj, err := uuid.NewRandom()
 	if err != nil {
@@ -1253,6 +1256,50 @@ func (n *Node) addPresence(ch string, uid string, info *ClientInfo) error {
 	}
 	n.metrics.incActionCount("add_presence", ch)
 	return presenceManager.AddPresence(ch, uid, info)
+}
+
+// addPresenceBatch proxies batch presence adding to PresenceManager.
+// This is more efficient than calling addPresence multiple times as it can
+// reduce network round trips to Redis.
+func (n *Node) addPresenceBatch(items []PresenceBatchItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	// Group items by presence manager
+	managerGroups := make(map[PresenceManager][]PresenceBatchItem)
+	for _, item := range items {
+		presenceManager := n.getPresenceManager(item.Channel)
+		if presenceManager == nil {
+			continue
+		}
+		managerGroups[presenceManager] = append(managerGroups[presenceManager], item)
+		n.metrics.incActionCount("add_presence", item.Channel)
+	}
+
+	// Execute updates for each presence manager.
+	// SupportsBatchPresence is part of the PresenceManager interface; every
+	// implementation declares whether AddPresenceBatch is safe and efficient.
+	// When a manager returns false (e.g. RedisPresenceManager with Redis Cluster
+	// shards) we fall back to individual AddPresence calls, which are always safe
+	// regardless of the underlying topology.
+	for presenceManager, managerItems := range managerGroups {
+		if presenceManager.SupportsBatchPresence() {
+			if err := presenceManager.AddPresenceBatch(managerItems); err != nil {
+				return err
+			}
+		} else {
+			// Batch unsupported: issue one AddPresence call per item.
+			for _, item := range managerItems {
+				if err := presenceManager.AddPresence(item.Channel, item.ClientID, item.Info); err != nil {
+					return err
+				}
+			}
+		}
+
+	}
+
+	return nil
 }
 
 // removePresence proxies presence removing to PresenceManager.

--- a/node.go
+++ b/node.go
@@ -142,7 +142,7 @@ func New(c Config) (*Node, error) {
 		c.HistoryMetaTTL = 30 * 24 * time.Hour // 30 days by default.
 	}
 	if c.ClientPresenceUpdateBatchSize == 0 {
-		c.ClientPresenceUpdateBatchSize = 10 // 10 channels by default.
+		c.ClientPresenceUpdateBatchSize = 500 // 500 channels by default.
 	}
 
 	uidObj, err := uuid.NewRandom()

--- a/node_test.go
+++ b/node_test.go
@@ -136,10 +136,11 @@ func (e *TestBroker) RemoveHistory(_ string) error {
 }
 
 type TestPresenceManager struct {
-	errorOnPresence       bool
-	errorOnPresenceStats  bool
-	errorOnAddPresence    bool
-	errorOnRemovePresence bool
+	errorOnPresence         bool
+	errorOnPresenceStats    bool
+	errorOnAddPresence      bool
+	errorOnAddPresenceBatch bool
+	errorOnRemovePresence   bool
 }
 
 func NewTestPresenceManager() *TestPresenceManager {
@@ -151,6 +152,17 @@ func (e *TestPresenceManager) AddPresence(_ string, _ string, _ *ClientInfo) err
 		return errors.New("boom")
 	}
 	return nil
+}
+
+func (e *TestPresenceManager) AddPresenceBatch(_ []PresenceBatchItem) error {
+	if e.errorOnAddPresenceBatch {
+		return errors.New("boom")
+	}
+	return nil
+}
+
+func (e *TestPresenceManager) SupportsBatchPresence() bool {
+	return true
 }
 
 func (e *TestPresenceManager) RemovePresence(_ string, _ string, _ string) error {

--- a/presence.go
+++ b/presence.go
@@ -21,7 +21,36 @@ type PresenceManager interface {
 	// have a property to expire client information that was not updated
 	// (touched) after some configured time interval.
 	AddPresence(ch string, clientID string, info *ClientInfo) error
+	// AddPresenceBatch sets or updates presence information for multiple channels
+	// in a single batch operation. This is more efficient than calling AddPresence
+	// multiple times as it reduces network round trips (e.g. using Redis pipeline).
+	// The items slice contains channel, clientID, and info for each presence update.
+	AddPresenceBatch(items []PresenceBatchItem) error
 	// RemovePresence removes presence information for connection
 	// with specified client and user identifiers.
 	RemovePresence(ch string, clientID string, userID string) error
+	// SupportsBatchPresence reports whether this implementation can execute
+	// AddPresenceBatch correctly and efficiently.
+	//
+	// When false, the node skips AddPresenceBatch and falls back to
+	// calling AddPresence once per item. Implementations must return false
+	// whenever batch execution would be semantically incorrect or would offer
+	// no performance benefit. A typical example is Redis Cluster mode, where a
+	// pipelined batch whose EVALSHA commands reference keys in different hash
+	// slots is rejected by Redis with:
+	//
+	//	CROSSSLOT Keys in request don't hash to the same slot
+	//
+	// Because each presence update targets a distinct channel that may hash to a
+	// different slot, batch execution is fundamentally incompatible with Redis
+	// Cluster. See RedisPresenceManager.SupportsBatchPresence for the full list
+	// of cluster-specific constraints.
+	SupportsBatchPresence() bool
+}
+
+// PresenceBatchItem represents a single presence update in a batch operation.
+type PresenceBatchItem struct {
+	Channel  string
+	ClientID string
+	Info     *ClientInfo
 }

--- a/presence_memory.go
+++ b/presence_memory.go
@@ -41,6 +41,19 @@ func (m *MemoryPresenceManager) AddPresence(ch string, uid string, info *ClientI
 	return m.presenceHub.add(ch, uid, info)
 }
 
+// AddPresenceBatch - see PresenceManager interface description.
+func (m *MemoryPresenceManager) AddPresenceBatch(items []PresenceBatchItem) error {
+	return m.presenceHub.addBatch(items)
+}
+
+// SupportsBatchPresence - see PresenceManager interface description.
+// MemoryPresenceManager always returns true: in-process batch writes are
+// a single mutex-protected loop with no network overhead, so batching is
+// always both correct and efficient regardless of configuration.
+func (m *MemoryPresenceManager) SupportsBatchPresence() bool {
+	return true
+}
+
 // RemovePresence - see PresenceManager interface description.
 func (m *MemoryPresenceManager) RemovePresence(ch string, clientID string, _ string) error {
 	return m.presenceHub.remove(ch, clientID)
@@ -81,6 +94,20 @@ func (h *presenceHub) add(ch string, uid string, info *ClientInfo) error {
 		h.presence[ch] = make(map[string]*ClientInfo)
 	}
 	h.presence[ch][uid] = info
+	return nil
+}
+
+func (h *presenceHub) addBatch(items []PresenceBatchItem) error {
+	h.Lock()
+	defer h.Unlock()
+
+	for _, item := range items {
+		_, ok := h.presence[item.Channel]
+		if !ok {
+			h.presence[item.Channel] = make(map[string]*ClientInfo)
+		}
+		h.presence[item.Channel][item.ClientID] = item.Info
+	}
 	return nil
 }
 

--- a/presence_redis.go
+++ b/presence_redis.go
@@ -176,10 +176,10 @@ func (m *RedisPresenceManager) addPresenceScriptKeysArgs(s *RedisShard, ch strin
 	}
 
 	hashKey := m.presenceHashKey(s, ch)
-	//setKey := m.presenceSetKey(s, ch)
-	//userSetKey := m.userSetKey(s, ch)
-	//userHashKey := m.userHashKey(s, ch)
-	keys := []string{string(hashKey)}
+	setKey := m.presenceSetKey(s, ch)
+	userSetKey := m.userSetKey(s, ch)
+	userHashKey := m.userHashKey(s, ch)
+	keys := []string{string(setKey), string(hashKey), string(userSetKey), string(userHashKey)}
 
 	expireAt := time.Now().Unix() + int64(expire)
 	useUserMapping := m.useUserMappingArg(ch)

--- a/presence_redis.go
+++ b/presence_redis.go
@@ -132,6 +132,30 @@ func (m *RedisPresenceManager) Close(_ context.Context) error {
 	return nil
 }
 
+// SupportsBatchPresence implements the PresenceManager interface. It returns
+// false when any configured shard is operating in Redis Cluster mode.
+//
+// The primary reason is a hard Redis Cluster constraint: a pipeline (DoMulti)
+// that contains EVALSHA commands whose keys hash to different cluster slots is
+// rejected by Redis with:
+//
+//	CROSSSLOT Keys in request don't hash to the same slot
+//
+// Because each presence update targets a distinct channel, and channels are
+// intentionally distributed across slots for load-balancing, a single DoMulti
+// batch will almost always span multiple slots and trigger this error.
+//
+// When this method returns false the node falls back to calling AddPresence
+// individually for each item.
+func (m *RedisPresenceManager) SupportsBatchPresence() bool {
+	for _, s := range m.shards {
+		if s.isCluster {
+			return false
+		}
+	}
+	return true
+}
+
 func (m *RedisPresenceManager) getShard(channel string) *RedisShard {
 	if !m.sharding {
 		return m.shards[0]
@@ -151,11 +175,11 @@ func (m *RedisPresenceManager) addPresenceScriptKeysArgs(s *RedisShard, ch strin
 		return nil, nil, err
 	}
 
-	setKey := m.presenceSetKey(s, ch)
 	hashKey := m.presenceHashKey(s, ch)
-	userSetKey := m.userSetKey(s, ch)
-	userHashKey := m.userHashKey(s, ch)
-	keys := []string{string(setKey), string(hashKey), string(userSetKey), string(userHashKey)}
+	//setKey := m.presenceSetKey(s, ch)
+	//userSetKey := m.userSetKey(s, ch)
+	//userHashKey := m.userHashKey(s, ch)
+	keys := []string{string(hashKey)}
 
 	expireAt := time.Now().Unix() + int64(expire)
 	useUserMapping := m.useUserMappingArg(ch)
@@ -193,6 +217,93 @@ func (m *RedisPresenceManager) addPresence(s *RedisShard, ch string, uid string,
 		return nil
 	}
 	return resp.Error()
+}
+
+// AddPresenceBatch - see PresenceManager interface description.
+// Items are grouped by shard first; each shard's updates are then dispatched
+// in a single ExecMulti call, which pipelines all EVALSHA commands in one
+// network round trip instead of issuing one round trip per item.
+func (m *RedisPresenceManager) AddPresenceBatch(items []PresenceBatchItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	// Group items by shard so that each ExecMulti targets a single Redis instance.
+	shardGroups := make(map[*RedisShard][]PresenceBatchItem)
+	for _, item := range items {
+		shard := m.getShard(item.Channel)
+		shardGroups[shard] = append(shardGroups[shard], item)
+	}
+
+	ctx := context.Background()
+	for shard, shardItems := range shardGroups {
+		if err := m.addPresenceBatchForShard(ctx, shard, shardItems); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *RedisPresenceManager) addPresenceBatchForShard(ctx context.Context, shard *RedisShard, items []PresenceBatchItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	scriptCalls := make([]presenceScriptCall, 0, len(items))
+	for _, item := range items {
+		keys, args, err := m.addPresenceScriptKeysArgs(shard, item.Channel, item.ClientID, item.Info)
+		if err != nil {
+			continue
+		}
+		scriptCalls = append(scriptCalls, presenceScriptCall{
+			keys:    keys,
+			args:    args,
+			channel: item.Channel,
+		})
+	}
+
+	if len(scriptCalls) == 0 {
+		return nil
+	}
+
+	results := m.execScriptBatch(ctx, shard, scriptCalls)
+	return m.checkBatchResults(results, scriptCalls)
+}
+
+// checkBatchResults scans ExecMulti results and returns the first non-nil error.
+// A nil Redis reply (rueidis.IsRedisNil) is treated as success, consistent with
+// how addPresence handles the single-item path.
+func (m *RedisPresenceManager) checkBatchResults(results []rueidis.RedisResult, scriptCalls []presenceScriptCall) error {
+	for i, result := range results {
+		if result.Error() != nil && !rueidis.IsRedisNil(result.Error()) {
+			return fmt.Errorf("error adding presence for channel %s: %w", scriptCalls[i].channel, result.Error())
+		}
+	}
+	return nil
+}
+
+// presenceScriptCall holds the keys, args, and channel name for one Lua invocation.
+// The channel field is kept solely for error attribution in checkBatchResults.
+type presenceScriptCall struct {
+	keys    []string
+	args    []string
+	channel string
+}
+
+// execScriptBatch executes the add-presence Lua script for every call in the slice
+// using rueidis Lua.ExecMulti. ExecMulti issues a SCRIPT LOAD to every cluster node
+// before pipelining the EVALSHA commands, which avoids both the NOSCRIPT problem and
+// the need for any manual SHA1 management on our side.
+func (m *RedisPresenceManager) execScriptBatch(ctx context.Context, shard *RedisShard, calls []presenceScriptCall) []rueidis.RedisResult {
+	execs := make([]rueidis.LuaExec, 0, len(calls))
+	for _, call := range calls {
+		execs = append(execs, rueidis.LuaExec{
+			Keys: call.keys,
+			Args: call.args,
+		})
+	}
+	return m.addPresenceScript.ExecMulti(ctx, shard.client, execs...)
 }
 
 // RemovePresence - see PresenceManager interface description.

--- a/presence_redis_bench_test.go
+++ b/presence_redis_bench_test.go
@@ -1,0 +1,349 @@
+//go:build integration
+
+package centrifuge
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+)
+
+// BenchmarkRedisAddPresenceBatch benchmarks batch presence updates using ExecMulti
+// pipeline vs individual AddPresence calls. This measures the improvement from
+// commits eb91ac4 and b168872.
+//
+// Each sub-benchmark uses the naming convention:
+//   - "Individual" – calls AddPresence once per channel (old path).
+//   - "Batch"      – calls AddPresenceBatch for all channels at once (new path).
+//
+// The "numCh" suffix indicates the number of channels per operation.
+
+func BenchmarkRedisAddPresenceBatch_vs_Individual(b *testing.B) {
+	channelCounts := []int{1, 5, 10, 50, 100}
+
+	for _, tt := range excludeClusterPresenceTests(redisPresenceTests) {
+		for _, numCh := range channelCounts {
+			// --- Individual AddPresence (baseline) ---
+			b.Run(fmt.Sprintf("%s/Individual/numCh_%d", tt.Name, numCh), func(b *testing.B) {
+				node := benchNode(b)
+				pm := newTestRedisPresenceManager(b, node, tt.UseCluster, false, false, tt.Port)
+				defer func() { _ = node.Shutdown(context.Background()) }()
+				defer stopRedisPresenceManager(pm)
+
+				channels := make([]string, numCh)
+				for i := range channels {
+					channels[i] = "bench_ch_" + strconv.Itoa(i)
+				}
+
+				info := &ClientInfo{
+					ClientID: "uid-bench",
+					UserID:   "user-bench",
+				}
+
+				b.SetParallelism(getBenchParallelism())
+				b.ResetTimer()
+				b.RunParallel(func(pb *testing.PB) {
+					for pb.Next() {
+						for _, ch := range channels {
+							if err := pm.AddPresence(ch, "uid-bench", info); err != nil {
+								b.Fatal(err)
+							}
+						}
+					}
+				})
+			})
+
+			// --- Batch AddPresenceBatch (new path) ---
+			b.Run(fmt.Sprintf("%s/Batch/numCh_%d", tt.Name, numCh), func(b *testing.B) {
+				node := benchNode(b)
+				pm := newTestRedisPresenceManager(b, node, tt.UseCluster, false, false, tt.Port)
+				defer func() { _ = node.Shutdown(context.Background()) }()
+				defer stopRedisPresenceManager(pm)
+
+				items := make([]PresenceBatchItem, numCh)
+				for i := range items {
+					items[i] = PresenceBatchItem{
+						Channel:  "bench_ch_" + strconv.Itoa(i),
+						ClientID: "uid-bench",
+						Info: &ClientInfo{
+							ClientID: "uid-bench",
+							UserID:   "user-bench",
+						},
+					}
+				}
+
+				b.SetParallelism(getBenchParallelism())
+				b.ResetTimer()
+				b.RunParallel(func(pb *testing.PB) {
+					for pb.Next() {
+						if err := pm.AddPresenceBatch(items); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			})
+		}
+	}
+}
+
+// BenchmarkRedisAddPresenceBatch_Scalability benchmarks how batch performance
+// scales with increasing channel counts. Useful for profiling pipeline overhead.
+func BenchmarkRedisAddPresenceBatch_Scalability(b *testing.B) {
+	channelCounts := []int{10, 50, 100, 200, 500}
+
+	for _, tt := range excludeClusterPresenceTests(redisPresenceTests) {
+		for _, numCh := range channelCounts {
+			b.Run(fmt.Sprintf("%s/numCh_%d", tt.Name, numCh), func(b *testing.B) {
+				node := benchNode(b)
+				pm := newTestRedisPresenceManager(b, node, tt.UseCluster, false, false, tt.Port)
+				defer func() { _ = node.Shutdown(context.Background()) }()
+				defer stopRedisPresenceManager(pm)
+
+				items := make([]PresenceBatchItem, numCh)
+				for i := range items {
+					items[i] = PresenceBatchItem{
+						Channel:  "scale_ch_" + strconv.Itoa(i),
+						ClientID: "uid-scale",
+						Info: &ClientInfo{
+							ClientID: "uid-scale",
+							UserID:   "user-scale",
+						},
+					}
+				}
+
+				b.SetParallelism(getBenchParallelism())
+				b.ResetTimer()
+				b.RunParallel(func(pb *testing.PB) {
+					for pb.Next() {
+						if err := pm.AddPresenceBatch(items); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			})
+		}
+	}
+}
+
+// makePresenceBatchItems creates N PresenceBatchItem for benchmarking.
+func makePresenceBatchItems(n int, prefix string) []PresenceBatchItem {
+	items := make([]PresenceBatchItem, n)
+	for i := range items {
+		items[i] = PresenceBatchItem{
+			Channel:  prefix + strconv.Itoa(i),
+			ClientID: "uid-large",
+			Info: &ClientInfo{
+				ClientID: "uid-large",
+				UserID:   "user-large",
+			},
+		}
+	}
+	return items
+}
+
+// splitBatch divides items into chunks of batchSize, simulating
+// the ClientPresenceUpdateBatchSize splitting done in client.updatePresence.
+func splitBatch(items []PresenceBatchItem, batchSize int) [][]PresenceBatchItem {
+	var batches [][]PresenceBatchItem
+	for i := 0; i < len(items); i += batchSize {
+		end := i + batchSize
+		if end > len(items) {
+			end = len(items)
+		}
+		batches = append(batches, items[i:end])
+	}
+	return batches
+}
+
+// BenchmarkRedisLargeScale_Individual benchmarks the old per-channel AddPresence
+// path at large channel counts (1000 ~ 10000).
+func BenchmarkRedisLargeScale_Individual(b *testing.B) {
+	channelCounts := []int{500, 1000, 2000, 5000, 10000}
+
+	for _, tt := range excludeClusterPresenceTests(redisPresenceTests) {
+		if tt.Port != 6379 {
+			continue
+		}
+		for _, numCh := range channelCounts {
+			b.Run(fmt.Sprintf("%s/numCh_%d", tt.Name, numCh), func(b *testing.B) {
+				node := benchNode(b)
+				pm := newTestRedisPresenceManager(b, node, tt.UseCluster, false, false, tt.Port)
+				defer func() { _ = node.Shutdown(context.Background()) }()
+				defer stopRedisPresenceManager(pm)
+
+				channels := make([]string, numCh)
+				for i := range channels {
+					channels[i] = "large_ch_" + strconv.Itoa(i)
+				}
+				info := &ClientInfo{
+					ClientID: "uid-large",
+					UserID:   "user-large",
+				}
+
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					for _, ch := range channels {
+						if err := pm.AddPresence(ch, "uid-large", info); err != nil {
+							b.Fatal(err)
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkRedisLargeScale_BatchNoBatchSplit benchmarks AddPresenceBatch with
+// all channels in a single ExecMulti call (no splitting), at large channel counts.
+func BenchmarkRedisLargeScale_BatchNoBatchSplit(b *testing.B) {
+	channelCounts := []int{500, 1000, 2000, 5000, 10000}
+
+	for _, tt := range excludeClusterPresenceTests(redisPresenceTests) {
+		if tt.Port != 6379 {
+			continue
+		}
+		for _, numCh := range channelCounts {
+			b.Run(fmt.Sprintf("%s/numCh_%d", tt.Name, numCh), func(b *testing.B) {
+				node := benchNode(b)
+				pm := newTestRedisPresenceManager(b, node, tt.UseCluster, false, false, tt.Port)
+				defer func() { _ = node.Shutdown(context.Background()) }()
+				defer stopRedisPresenceManager(pm)
+
+				items := makePresenceBatchItems(numCh, "large_ch_")
+
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if err := pm.AddPresenceBatch(items); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkRedisLargeScale_BatchWithSplit benchmarks AddPresenceBatch with
+// batch splitting at various batchSize values, simulating how client.updatePresence
+// splits channels into fixed-size chunks before calling AddPresenceBatch.
+//
+// This reveals the optimal batchSize for a given total channel count.
+func BenchmarkRedisLargeScale_BatchWithSplit(b *testing.B) {
+	type testCase struct {
+		totalChannels int
+		batchSize     int
+	}
+
+	cases := []testCase{
+		// 1000 channels with various batch sizes
+		{1000, 10},
+		{1000, 50},
+		{1000, 100},
+		{1000, 200},
+		{1000, 500},
+		{1000, 1000},
+
+		// 5000 channels with various batch sizes
+		{5000, 50},
+		{5000, 100},
+		{5000, 200},
+		{5000, 500},
+		{5000, 1000},
+		{5000, 2500},
+		{5000, 5000},
+
+		// 10000 channels with various batch sizes
+		{10000, 100},
+		{10000, 500},
+		{10000, 1000},
+		{10000, 2500},
+		{10000, 5000},
+		{10000, 10000},
+	}
+
+	for _, tt := range excludeClusterPresenceTests(redisPresenceTests) {
+		if tt.Port != 6379 {
+			continue
+		}
+		for _, tc := range cases {
+			name := fmt.Sprintf("%s/total_%d/batch_%d", tt.Name, tc.totalChannels, tc.batchSize)
+			b.Run(name, func(b *testing.B) {
+				node := benchNode(b)
+				pm := newTestRedisPresenceManager(b, node, tt.UseCluster, false, false, tt.Port)
+				defer func() { _ = node.Shutdown(context.Background()) }()
+				defer stopRedisPresenceManager(pm)
+
+				allItems := makePresenceBatchItems(tc.totalChannels, "split_ch_")
+				batches := splitBatch(allItems, tc.batchSize)
+
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					for _, batch := range batches {
+						if err := pm.AddPresenceBatch(batch); err != nil {
+							b.Fatal(err)
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkMemoryAddPresenceBatch_vs_Individual benchmarks batch vs individual
+// presence updates using the in-memory presence manager. This provides a
+// baseline to isolate Redis network overhead from the batching logic itself.
+func BenchmarkMemoryAddPresenceBatch_vs_Individual(b *testing.B) {
+	channelCounts := []int{1, 10, 50, 100}
+
+	for _, numCh := range channelCounts {
+		// --- Individual ---
+		b.Run(fmt.Sprintf("Individual/numCh_%d", numCh), func(b *testing.B) {
+			m := testMemoryPresenceManager(b)
+			defer func() { _ = m.node.Shutdown(context.Background()) }()
+
+			channels := make([]string, numCh)
+			for i := range channels {
+				channels[i] = "bench_ch_" + strconv.Itoa(i)
+			}
+
+			info := &ClientInfo{
+				ClientID: "uid-bench",
+				UserID:   "user-bench",
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				for _, ch := range channels {
+					if err := m.AddPresence(ch, "uid-bench", info); err != nil {
+						b.Fatal(err)
+					}
+				}
+			}
+		})
+
+		// --- Batch ---
+		b.Run(fmt.Sprintf("Batch/numCh_%d", numCh), func(b *testing.B) {
+			m := testMemoryPresenceManager(b)
+			defer func() { _ = m.node.Shutdown(context.Background()) }()
+
+			items := make([]PresenceBatchItem, numCh)
+			for i := range items {
+				items[i] = PresenceBatchItem{
+					Channel:  "bench_ch_" + strconv.Itoa(i),
+					ClientID: "uid-bench",
+					Info: &ClientInfo{
+						ClientID: "uid-bench",
+						UserID:   "user-bench",
+					},
+				}
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := m.AddPresenceBatch(items); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/presence_redis_bench_test.go
+++ b/presence_redis_bench_test.go
@@ -289,6 +289,76 @@ func BenchmarkRedisLargeScale_BatchWithSplit(b *testing.B) {
 	}
 }
 
+// BenchmarkRedisLargeScale_Parallel benchmarks 10,000 channels under b.RunParallel,
+// comparing Individual (N sequential AddPresence per goroutine iteration) against
+// Batch with various batchSize splits. This simulates real-world concurrent clients
+// each updating presence for many channels simultaneously.
+func BenchmarkRedisLargeScale_Parallel(b *testing.B) {
+	const totalChannels = 10000
+
+	for _, tt := range excludeClusterPresenceTests(redisPresenceTests) {
+		if tt.Port != 6379 {
+			continue
+		}
+
+		// --- Individual: each parallel goroutine calls AddPresence 10,000 times ---
+		b.Run(fmt.Sprintf("%s/Individual/numCh_%d", tt.Name, totalChannels), func(b *testing.B) {
+			node := benchNode(b)
+			pm := newTestRedisPresenceManager(b, node, tt.UseCluster, false, false, tt.Port)
+			defer func() { _ = node.Shutdown(context.Background()) }()
+			defer stopRedisPresenceManager(pm)
+
+			channels := make([]string, totalChannels)
+			for i := range channels {
+				channels[i] = "par_ch_" + strconv.Itoa(i)
+			}
+			info := &ClientInfo{
+				ClientID: "uid-par",
+				UserID:   "user-par",
+			}
+
+			b.SetParallelism(getBenchParallelism())
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					for _, ch := range channels {
+						if err := pm.AddPresence(ch, "uid-par", info); err != nil {
+							b.Fatal(err)
+						}
+					}
+				}
+			})
+		})
+
+		// --- Batch with various batchSize splits ---
+		batchSizes := []int{10, 50, 100, 500, 1000, 2500, 5000, 10000}
+		for _, bs := range batchSizes {
+			bs := bs
+			b.Run(fmt.Sprintf("%s/Batch_bs%d/numCh_%d", tt.Name, bs, totalChannels), func(b *testing.B) {
+				node := benchNode(b)
+				pm := newTestRedisPresenceManager(b, node, tt.UseCluster, false, false, tt.Port)
+				defer func() { _ = node.Shutdown(context.Background()) }()
+				defer stopRedisPresenceManager(pm)
+
+				allItems := makePresenceBatchItems(totalChannels, "par_ch_")
+				batches := splitBatch(allItems, bs)
+
+				b.SetParallelism(getBenchParallelism())
+				b.ResetTimer()
+				b.RunParallel(func(pb *testing.PB) {
+					for pb.Next() {
+						for _, batch := range batches {
+							if err := pm.AddPresenceBatch(batch); err != nil {
+								b.Fatal(err)
+							}
+						}
+					}
+				})
+			})
+		}
+	}
+}
+
 // BenchmarkMemoryAddPresenceBatch_vs_Individual benchmarks batch vs individual
 // presence updates using the in-memory presence manager. This provides a
 // baseline to isolate Redis network overhead from the batching logic itself.


### PR DESCRIPTION
A new config field ClientPresenceUpdateBatchSize represents the batch size using, default by 1000. Since lua ExecMulti will failed on redis-cluster, it will be check before use, and falls back to original if presence manager is cluster. Should have some solid improvement in frequently sub/unsub situation.

# Benchmark：

**Feature:** Optimize Redis presence batch update with `AddPresenceBatch` + `ExecMulti`
**Environment:**

| Item | Value |
|------|-------|
| OS | macOS (Darwin 25.0.0, arm64) |
| CPU | Apple M5 (10 cores) |
| Go | 1.25.5 |
| Redis | 7-alpine (Docker, standalone, AOF/RDB off, maxmemory 512MB) |
| GOMAXPROCS | 10 |

---

## 1. Summary

Feature：Introduce `AddPresenceBatch`, which pipelines multiple Lua EVALSHA calls into a single `ExecMulti` round trip instead of issuing one network round trip per channel.

- The optimal batchSize lies in the **500 ~ 1000** range; larger values yield diminishing returns.
- At 10,000 channels: 
Serial:    **22.6x** faster.
Parallel: **5.7x** faster.

---

## 2. Large-Scale Parallel: 10,000 Channels

| Mode | batchSize | ms/op | vs Individual | B/op | allocs/op |
|------|----------:|------:|--------------:|---------:|----------:|
| Individual | - | 229.85 | baseline | 5,657,298 | 81,125 |
| Batch | 10 | 43.02 | **5.3x** | 9,345,332 | 100,471 |
| Batch | 50 | 40.77 | **5.6x** | 8,897,889 | 85,463 |
| Batch | 100 | 41.84 | **5.5x** | 8,825,383 | 83,494 |
| Batch | 500 | 42.53 | **5.4x** | 8,671,964 | 83,268 |
| Batch | 1000 | 40.49 | **5.7x** | 8,873,879 | 85,465 |
| Batch | 2500 | 41.59 | **5.5x** | 11,582,656 | 96,840 |
| Batch | 5000 | 46.16 | **5.0x** | 12,872,898 | 109,321 |
| Batch | 10000 | 44.48 | **5.2x** | 15,810,577 | 134,276 |


## 3. BatchSize Tuning: 10,000 Channels (Serial)

| batchSize | Batches | ms/op | vs Individual (1144ms) | B/op |
|----------:|--------:|------:|------------------------:|--------:|
| 100 | 100 | 80.10 | **14.3x** | 8,725,768 |
| 500 | 20 | 55.76 | **20.5x** | 8,386,328 |
| 1000 | 10 | 53.47 | **21.4x** | 8,315,624 |
| 2500 | 4 | 50.70 | **22.6x** | 9,016,848 |
| 5000 | 2 | 55.15 | **20.7x** | 9,049,708 |
| 10000 | 1 | 50.35 | **22.7x** | 9,486,396 |

> The optimal range is **batchSize=1000 ~ 2500**. At batchSize=5000 a slight regression appears (55ms vs 50ms), it came back at batchSize=10000 but 10000 is just too large for single time and it might cause redis's output buffer issue when processing other cmds.


## 4. Small-Scale Reference (Parallel)

| Channels | Individual (us/op) | Batch (us/op) |
|----------|-------------------:|--------------:|
| 1 | 5.4 | 13.0 |
| 5 | 49.0 | 46.6 |
| 10 | 47.7 | 52.1 |
| 50 | 262.9 | 198.0 |
| 100 | 444.9 | 397.2 |


## 5. Memory PresenceManager Baseline

In-memory presence manager, isolating pure data-structure cost from network overhead.

| Channels | Individual (ns/op) | Batch (ns/op) | Speedup |
|----------|-------------------:|--------------:|--------:|
| 1 | 23.35 | 23.19 | 1.0x |
| 10 | 318.4 | 238.3 | 1.3x |
| 50 | 1,624 | 1,188 | 1.4x |
| 100 | 3,532 | 2,311 | 1.5x |

> Batch is 25-35% faster even in-memory because it acquires the mutex once instead of N times.

---

## 6. Conclusions & Recommendations

1. **Batch could brings at least 5x faster**.

2. **Recommended batchSize: 500 above.**