### PR TITLE
Test stability and timing improvements

### DIFF
--- a/broker_memory_test.go
+++ b/broker_memory_test.go
@@ -130,10 +130,13 @@ func TestMemoryBrokerResultCacheExpires(t *testing.T) {
 	e.resultCacheMu.Lock()
 	require.Len(t, e.resultCache, 1)
 	e.resultCacheMu.Unlock()
-	time.Sleep(2 * time.Second)
-	e.resultCacheMu.Lock()
-	require.Len(t, e.resultCache, 0)
-	e.resultCacheMu.Unlock()
+	// Wait for the expire-cache goroutine to clean the entry. Its tick can
+	// stretch past 2s under -race; require.Eventually keeps polling.
+	require.Eventually(t, func() bool {
+		e.resultCacheMu.Lock()
+		defer e.resultCacheMu.Unlock()
+		return len(e.resultCache) == 0
+	}, 10*time.Second, 50*time.Millisecond, "result cache should expire after TTL")
 }
 
 func TestMemoryBrokerPublishIdempotent(t *testing.T) {
@@ -684,6 +687,20 @@ func TestClientSubscribeRecover(t *testing.T) {
 				}
 
 				time.Sleep(time.Duration(tt.Sleep) * time.Second)
+
+				// If the scenario expects history to be expired by now
+				// (Sleep > HistoryTTL), wait for the broker's periodic
+				// cleanup tick to actually clear it. Under -race the 1s
+				// cleanup tick can stretch past the configured Sleep,
+				// leaving stale state and causing flaky asserts.
+				if tt.HistoryTTLSeconds > 0 && tt.Sleep > tt.HistoryTTLSeconds {
+					require.Eventually(t, func() bool {
+						pubs, _, err := node.broker.History(channel, HistoryOptions{
+							Filter: HistoryFilter{Limit: -1},
+						})
+						return err == nil && len(pubs) == 0
+					}, 10*time.Second, 50*time.Millisecond, "expected history to be expired")
+				}
 
 				connectClientV2(t, client)
 

--- a/broker_memory_test.go
+++ b/broker_memory_test.go
@@ -52,6 +52,7 @@ func testPublicationData() []byte {
 }
 
 func TestMemoryBrokerPublishHistory(t *testing.T) {
+	t.Parallel()
 	e := testMemoryBroker()
 	defer func() { _ = e.node.Shutdown(context.Background()) }()
 
@@ -136,6 +137,7 @@ func TestMemoryBrokerResultCacheExpires(t *testing.T) {
 }
 
 func TestMemoryBrokerPublishIdempotent(t *testing.T) {
+	t.Parallel()
 	e := testMemoryBroker()
 	defer func() { _ = e.node.Shutdown(context.Background()) }()
 
@@ -164,6 +166,7 @@ func TestMemoryBrokerPublishIdempotent(t *testing.T) {
 }
 
 func TestMemoryBrokerPublishIdempotentWithHistory(t *testing.T) {
+	t.Parallel()
 	e := testMemoryBroker()
 	defer func() { _ = e.node.Shutdown(context.Background()) }()
 
@@ -216,6 +219,7 @@ func TestMemoryBrokerPublishIdempotentWithHistory(t *testing.T) {
 }
 
 func TestMemoryBrokerPublishSkipOldVersion(t *testing.T) {
+	t.Parallel()
 	e := testMemoryBroker()
 	defer func() { _ = e.node.Shutdown(context.Background()) }()
 
@@ -277,6 +281,7 @@ func TestMemoryBrokerPublishSkipOldVersion(t *testing.T) {
 }
 
 func TestMemoryBrokerSubscribeUnsubscribe(t *testing.T) {
+	t.Parallel()
 	e := testMemoryBroker()
 	defer func() { _ = e.node.Shutdown(context.Background()) }()
 	require.NoError(t, e.Subscribe("channel"))
@@ -447,6 +452,7 @@ func TestMemoryHistoryHubMetaTTLPerChannel(t *testing.T) {
 }
 
 func TestMemoryBrokerRecover(t *testing.T) {
+	t.Parallel()
 	e := testMemoryBroker()
 	defer func() { _ = e.node.Shutdown(context.Background()) }()
 
@@ -813,6 +819,7 @@ outer:
 }
 
 func TestMemoryBrokerHistoryIteration(t *testing.T) {
+	t.Parallel()
 	e := testMemoryBroker()
 	defer func() { _ = e.node.Shutdown(context.Background()) }()
 
@@ -822,6 +829,7 @@ func TestMemoryBrokerHistoryIteration(t *testing.T) {
 }
 
 func TestMemoryBrokerHistoryIterationReverse(t *testing.T) {
+	t.Parallel()
 	e := testMemoryBroker()
 	defer func() { _ = e.node.Shutdown(context.Background()) }()
 

--- a/broker_memory_test.go
+++ b/broker_memory_test.go
@@ -367,6 +367,7 @@ func TestMemoryHistoryHub(t *testing.T) {
 }
 
 func TestMemoryHistoryHubMetaTTL(t *testing.T) {
+	t.Parallel()
 	h := newHistoryHub(1*time.Second, make(chan struct{}))
 	h.runCleanups()
 
@@ -405,6 +406,7 @@ func TestMemoryHistoryHubMetaTTL(t *testing.T) {
 }
 
 func TestMemoryHistoryHubMetaTTLPerChannel(t *testing.T) {
+	t.Parallel()
 	h := newHistoryHub(300*time.Second, make(chan struct{}))
 	h.runCleanups()
 
@@ -650,6 +652,7 @@ func TestClientSubscribeRecover(t *testing.T) {
 	t.Parallel()
 	for _, tt := range clientRecoverTests {
 		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
 			node := defaultNodeNoHandlers()
 			node.config.RecoveryMaxPublicationLimit = tt.Limit
 			node.config.Metrics.EnableRecoveredPublicationsHistogram = true

--- a/broker_redis_test.go
+++ b/broker_redis_test.go
@@ -172,12 +172,14 @@ func stopRedisBroker(b *RedisBroker) {
 }
 
 func TestRedisBroker_NoShards(t *testing.T) {
+	t.Parallel()
 	n, _ := New(Config{})
 	_, err := NewRedisBroker(n, RedisBrokerConfig{})
 	require.Error(t, err)
 }
 
 func TestRedisBrokerSentinel(t *testing.T) {
+	t.Parallel()
 	b := NewTestRedisBrokerSentinel(t)
 	defer stopRedisBroker(b)
 	_, _, err := b.History("test", HistoryOptions{
@@ -252,6 +254,7 @@ func excludeNoHistoryClusterTests(tests []noHistoryRedisTest) []noHistoryRedisTe
 }
 
 func TestRedisBroker(t *testing.T) {
+	t.Parallel()
 	for _, tt := range historyRedisTests {
 		t.Run(tt.Name, func(t *testing.T) {
 			node := testNode(t)
@@ -340,6 +343,7 @@ func TestRedisBroker(t *testing.T) {
 }
 
 func TestRedisBrokerPublishNoPubSub(t *testing.T) {
+	t.Parallel()
 	node := testNode(t)
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -364,6 +368,7 @@ func TestRedisBrokerPublishNoPubSub(t *testing.T) {
 }
 
 func TestRedisBrokerPublishIdempotent(t *testing.T) {
+	t.Parallel()
 	for _, tt := range historyRedisTests {
 		t.Run(tt.Name, func(t *testing.T) {
 			node := testNode(t)
@@ -422,6 +427,7 @@ func TestRedisBrokerPublishIdempotent(t *testing.T) {
 }
 
 func TestRedisBrokerPublishSkipOldVersion(t *testing.T) {
+	t.Parallel()
 	for _, tt := range historyRedisTests {
 		t.Run(tt.Name, func(t *testing.T) {
 			if !tt.UseStreams {
@@ -501,6 +507,7 @@ func TestRedisBrokerPublishSkipOldVersion(t *testing.T) {
 }
 
 func TestRedisCurrentPosition(t *testing.T) {
+	t.Parallel()
 	for _, tt := range historyRedisTests {
 		t.Run(tt.Name, func(t *testing.T) {
 			node := testNode(t)
@@ -534,6 +541,7 @@ func TestRedisCurrentPosition(t *testing.T) {
 }
 
 func TestRedisBrokerRecover(t *testing.T) {
+	t.Parallel()
 	for _, tt := range historyRedisTests {
 		t.Run(tt.Name, func(t *testing.T) {
 			node := testNode(t)
@@ -611,6 +619,7 @@ func pubSubChannels(t *testing.T, e *RedisBroker) ([]string, error) {
 }
 
 func TestRedisBrokerSubscribeUnsubscribe(t *testing.T) {
+	t.Parallel()
 	for _, tt := range noHistoryRedisTests {
 		t.Run(tt.Name, func(t *testing.T) {
 			// Custom prefix to not collide with other tests.
@@ -795,6 +804,7 @@ func randString(n int) string {
 // We just expect +-equal distribution and keeping most of chans on
 // the same shard after resharding.
 func TestRedisConsistentIndex(t *testing.T) {
+	t.Parallel()
 	numChans := 10000
 	numShards := 10
 	chans := make([]string, numChans)
@@ -839,6 +849,7 @@ func TestRedisConsistentIndex(t *testing.T) {
 }
 
 func TestRedisBrokerHandlePubSubMessage(t *testing.T) {
+	t.Parallel()
 	for _, tt := range excludeNoHistoryClusterTests(noHistoryRedisTests) {
 		t.Run(tt.Name, func(t *testing.T) {
 			node := testNode(t)
@@ -922,6 +933,7 @@ func BenchmarkRedisExtractPushData(b *testing.B) {
 }
 
 func TestRedisExtractPushData(t *testing.T) {
+	t.Parallel()
 	data := []byte(`__p1:16901:xyz.123__\x12\nchat:index\x1aU\"\x0e{\"input\":\"__\"}*C\n\x0242\x12$37cb00a9-bcfa-4284-a1ae-607c7da3a8f4\x1a\x15{\"name\": \"Alexander\"}\"\x00`)
 	pushData, pushType, sp, _, _, ok := extractPushData(data)
 	require.True(t, ok)
@@ -961,6 +973,7 @@ func TestRedisExtractPushData(t *testing.T) {
 }
 
 func TestNode_OnSurvey_TwoNodes(t *testing.T) {
+	t.Parallel()
 	for _, tt := range excludeNoHistoryClusterTests(noHistoryRedisTests) {
 		t.Run(tt.Name, func(t *testing.T) {
 			redisConf := testSingleRedisConf(tt.Port)
@@ -1030,6 +1043,7 @@ func TestNode_OnSurvey_TwoNodes(t *testing.T) {
 }
 
 func TestNode_OnNotification_TwoNodes(t *testing.T) {
+	t.Parallel()
 	for _, tt := range excludeNoHistoryClusterTests(noHistoryRedisTests) {
 		t.Run(tt.Name, func(t *testing.T) {
 			redisConf := testSingleRedisConf(tt.Port)
@@ -1102,6 +1116,7 @@ func TestNode_OnNotification_TwoNodes(t *testing.T) {
 }
 
 func TestRedisPubSubTwoNodes(t *testing.T) {
+	t.Parallel()
 	for _, tt := range excludeNoHistoryClusterTests(noHistoryRedisTests) {
 		t.Run(tt.Name, func(t *testing.T) {
 			redisConf := testSingleRedisConf(tt.Port)
@@ -1210,6 +1225,7 @@ type testDeltaPublishHandle struct {
 }
 
 func TestRedisPubSubTwoNodesWithDelta(t *testing.T) {
+	t.Parallel()
 	// This is special because it actually uses history, but we re-use existing infrastructure.
 	for _, tt := range excludeNoHistoryClusterTests(noHistoryRedisTests) {
 		t.Run(tt.Name, func(t *testing.T) {
@@ -1299,6 +1315,7 @@ func TestRedisPubSubTwoNodesWithDelta(t *testing.T) {
 }
 
 func TestRedisClusterShardedPubSub(t *testing.T) {
+	t.Parallel()
 	redisConf := RedisShardConfig{
 		ClusterAddresses: []string{"localhost:7001", "localhost:7002", "localhost:7003"},
 		IOTimeout:        10 * time.Second,
@@ -1802,6 +1819,7 @@ var brokerRecoverTests = []recoverTest{
 }
 
 func TestRedisClientSubscribeRecover(t *testing.T) {
+	t.Parallel()
 	for _, tt := range historyRedisTests {
 		for _, rt := range brokerRecoverTests {
 			t.Run(tt.Name+"_"+rt.Name, func(t *testing.T) {
@@ -1814,6 +1832,7 @@ func TestRedisClientSubscribeRecover(t *testing.T) {
 }
 
 func TestRedisHistoryIteration(t *testing.T) {
+	t.Parallel()
 	for _, tt := range historyRedisTests {
 		t.Run(tt.Name, func(t *testing.T) {
 			node := testNode(t)
@@ -1828,6 +1847,7 @@ func TestRedisHistoryIteration(t *testing.T) {
 }
 
 func TestRedisHistoryReversedNoMetaYet(t *testing.T) {
+	t.Parallel()
 	for _, tt := range historyRedisTests {
 		t.Run(tt.Name, func(t *testing.T) {
 			node := testNode(t)
@@ -1860,6 +1880,7 @@ func TestRedisHistoryReversedNoMetaYet(t *testing.T) {
 }
 
 func TestRedisHistoryIterationReverse(t *testing.T) {
+	t.Parallel()
 	for _, tt := range historyRedisTests {
 		t.Run(tt.Name, func(t *testing.T) {
 			if !tt.UseStreams || tt.UseCluster {
@@ -2010,6 +2031,7 @@ type clusterFuncWrapper struct {
 
 // TestPreShardedSlots allows experimenting with Redis slots and its distribution.
 func TestPreShardedSlots(t *testing.T) {
+	t.Parallel()
 	t.Skip()
 	redisNodesChoices := []int{3, 5, 8, 16}
 	numShardsChoices := []int{32}
@@ -2058,6 +2080,7 @@ func TestPreShardedSlots(t *testing.T) {
 }
 
 func TestParseDeltaPush(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		input          string
@@ -2135,6 +2158,7 @@ func TestParseDeltaPush(t *testing.T) {
 // 1000 streams with 200 messages in each stream, each message 500 bytes => 121MB in Redis.
 // 1000 streams with 400 messages in each stream, each message 500 bytes => 242MB in Redis.
 func TestRedisMemoryUsage(t *testing.T) {
+	t.Parallel()
 	t.Skip()
 	numStreams := 1000
 	numMessagesInStream := 400
@@ -2162,6 +2186,7 @@ func TestRedisMemoryUsage(t *testing.T) {
 // See https://github.com/centrifugal/centrifugo/issues/925.
 // If there is a deadlock – test will hang.
 func TestRedisClientSubscribeRecoveryServerSubs(t *testing.T) {
+	t.Parallel()
 	isInTest = true
 	doneCh := make(chan struct{})
 	defer close(doneCh)
@@ -2246,6 +2271,7 @@ func waitGroupWithTimeout(t *testing.T, wg *sync.WaitGroup, timeout time.Duratio
 
 // Similar to TestRedisClientSubscribeRecoveryServerSubs test, but uses client-side subscriptions.
 func TestRedisClientSubscribeRecoveryClientSubs(t *testing.T) {
+	t.Parallel()
 	doneCh := make(chan struct{})
 	defer close(doneCh)
 	node := nodeWithRedisBroker(t, true, false, 6379)
@@ -2330,6 +2356,7 @@ func TestRedisClientSubscribeRecoveryClientSubs(t *testing.T) {
 }
 
 func TestRedisBroker_MessageChannelID_ClusterHashTags(t *testing.T) {
+	t.Parallel()
 	// Create mock shards
 	clusterShard := &RedisShard{isCluster: true}
 	nonClusterShard := &RedisShard{isCluster: false}
@@ -2449,6 +2476,7 @@ func TestRedisBroker_MessageChannelID_ClusterHashTags(t *testing.T) {
 }
 
 func TestRedisBroker_ClusterHashTags_Consistency(t *testing.T) {
+	t.Parallel()
 	// This test verifies that in cluster mode, channel names always use the same
 	// hash tag as their associated keys (history, result cache), ensuring they're
 	// in the same Redis Cluster slot. This is required for Lua scripts in serverless
@@ -2481,6 +2509,7 @@ func TestRedisBroker_ClusterHashTags_Consistency(t *testing.T) {
 }
 
 func TestRedisBroker_PubSubPartitionHashTag(t *testing.T) {
+	t.Parallel()
 	t.Run("default scheme returns bare integer", func(t *testing.T) {
 		broker := &RedisBroker{
 			config: RedisBrokerConfig{NumShardedPubSubPartitions: 16},
@@ -2508,6 +2537,7 @@ func TestRedisBroker_PubSubPartitionHashTag(t *testing.T) {
 // hash tag (not the bare partition index). This locks in that no builder
 // regresses to using strconv.Itoa(idx) directly.
 func TestRedisBroker_PrecomputedTags_KeyConsistency(t *testing.T) {
+	t.Parallel()
 	tags, err := redispartition.FindTags(16)
 	require.NoError(t, err)
 
@@ -2552,6 +2582,7 @@ func TestRedisBroker_PrecomputedTags_KeyConsistency(t *testing.T) {
 // live Redis Cluster. Requires a 3-node cluster on 7001-7003 with sharded
 // PUB/SUB support (Redis 7+); skipped otherwise.
 func TestRedisBroker_UsePrecomputedPartitionTags_ClusterE2E(t *testing.T) {
+	t.Parallel()
 	redisConf := RedisShardConfig{
 		ClusterAddresses: []string{"localhost:7001", "localhost:7002", "localhost:7003"},
 		IOTimeout:        10 * time.Second,
@@ -2637,6 +2668,7 @@ func TestRedisBroker_UsePrecomputedPartitionTags_ClusterE2E(t *testing.T) {
 // subscriber and publisher could end up on different nodes for the same
 // partition. Run for both tag schemes.
 func TestRedisBroker_PartitionSlotInvariant(t *testing.T) {
+	t.Parallel()
 	clusterShard := &RedisShard{isCluster: true}
 	const numPartitions = 16
 	const numPsShards = 2
@@ -2684,6 +2716,7 @@ func TestRedisBroker_PartitionSlotInvariant(t *testing.T) {
 }
 
 func TestRedisBroker_UsePrecomputedPartitionTags_Validation(t *testing.T) {
+	t.Parallel()
 	n, err := New(Config{LogHandler: func(LogEntry) {}})
 	require.NoError(t, err)
 
@@ -2719,6 +2752,7 @@ func TestRedisBroker_UsePrecomputedPartitionTags_Validation(t *testing.T) {
 }
 
 func TestRedisClusterMultipleChannelsTwoNodes(t *testing.T) {
+	t.Parallel()
 	redisConf := RedisShardConfig{
 		ClusterAddresses: []string{"localhost:7001", "localhost:7002", "localhost:7003"},
 		IOTimeout:        10 * time.Second,

--- a/broker_redis_test.go
+++ b/broker_redis_test.go
@@ -1760,13 +1760,11 @@ func nodeWithRedisBroker(tb testing.TB, useStreams bool, useCluster bool, port i
 	return n
 }
 
-func testRedisClientSubscribeRecover(t *testing.T, tt historyRedisTest, rt recoverTest) {
+func testRedisClientSubscribeRecover(t *testing.T, tt historyRedisTest, rt recoverTest, channel string) {
 	node := nodeWithRedisBroker(t, tt.UseStreams, tt.UseCluster, tt.Port)
 	node.config.RecoveryMaxPublicationLimit = rt.Limit
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	defer stopRedisBroker(node.broker.(*RedisBroker))
-
-	channel := "test_recovery_redis_" + tt.Name
 
 	for i := 1; i <= rt.NumPublications; i++ {
 		_, err := node.Publish(channel, []byte(`{"n": `+strconv.Itoa(i)+`}`), WithHistory(rt.HistorySize, time.Duration(rt.HistoryTTLSeconds)*time.Second))
@@ -1807,7 +1805,9 @@ func TestRedisClientSubscribeRecover(t *testing.T) {
 	for _, tt := range historyRedisTests {
 		for _, rt := range brokerRecoverTests {
 			t.Run(tt.Name+"_"+rt.Name, func(t *testing.T) {
-				testRedisClientSubscribeRecover(t, tt, rt)
+				t.Parallel()
+				channel := "test_recovery_redis_" + tt.Name + "_" + rt.Name
+				testRedisClientSubscribeRecover(t, tt, rt, channel)
 			})
 		}
 	}

--- a/channel_medium.go
+++ b/channel_medium.go
@@ -51,8 +51,6 @@ func (o ChannelMediumOptions) isMediumEnabled() bool {
 	return o.SharedPositionSync || o.KeepLatestPublication || o.enableQueue || o.broadcastDelay > 0
 }
 
-// Keep global to save 8 byte per-channel. Must be only changed by tests.
-var channelMediumTimeNow = time.Now
 
 // channelMedium is initialized when first subscriber comes into channel, and dropped as soon as last
 // subscriber leaves the channel on the Node.
@@ -73,6 +71,10 @@ type channelMedium struct {
 	latestPublication *Publication
 	// positionCheckTime is a time (Unix Nanoseconds) when last position check was performed.
 	positionCheckTime int64
+	// nowFn is the clock used by this medium. Defaults to time.Now in
+	// newChannelMedium; tests override it on the medium instance instead of
+	// mutating a package-level variable (which races with parallel readers).
+	nowFn func() time.Time
 }
 
 type nodeSubset interface {
@@ -86,12 +88,13 @@ func newChannelMedium(channel string, node nodeSubset, options ChannelMediumOpti
 		return nil, errors.New("broadcast delay can only be used with queue enabled")
 	}
 	c := &channelMedium{
-		channel:           channel,
-		node:              node,
-		options:           options,
-		closeCh:           make(chan struct{}),
-		positionCheckTime: channelMediumTimeNow().UnixNano(),
+		channel: channel,
+		node:    node,
+		options: options,
+		closeCh: make(chan struct{}),
+		nowFn:   time.Now,
 	}
+	c.positionCheckTime = c.nowFn().UnixNano()
 	if options.enableQueue {
 		c.messages = newPublicationQueue(2)
 		go c.writer()
@@ -112,7 +115,7 @@ const defaultChannelLayerQueueMaxSize = 16 * 1024 * 1024
 func (c *channelMedium) broadcastPublication(pub *Publication, sp StreamPosition, delta bool, prevPub *Publication) {
 	bp := queuedPub{pub: pub, sp: sp, prevPub: prevPub, delta: delta}
 	c.mu.Lock()
-	c.positionCheckTime = channelMediumTimeNow().UnixNano()
+	c.positionCheckTime = c.nowFn().UnixNano()
 	c.mu.Unlock()
 
 	if c.options.enableQueue {
@@ -134,7 +137,7 @@ func (c *channelMedium) broadcastPublication(pub *Publication, sp StreamPosition
 func (c *channelMedium) broadcastInsufficientState() {
 	bp := queuedPub{prevPub: nil, isInsufficientState: true}
 	c.mu.Lock()
-	c.positionCheckTime = channelMediumTimeNow().UnixNano()
+	c.positionCheckTime = c.nowFn().UnixNano()
 	c.mu.Unlock()
 	if c.options.enableQueue {
 		// TODO: possibly support c.messages.dropQueued() for this path ?
@@ -231,7 +234,7 @@ func (c *channelMedium) waitSendPub(delay time.Duration) bool {
 }
 
 func (c *channelMedium) CheckPosition(historyMetaTTL time.Duration, clientPosition StreamPosition, checkDelay time.Duration) bool {
-	nowUnixNano := channelMediumTimeNow().UnixNano()
+	nowUnixNano := c.nowFn().UnixNano()
 	c.mu.Lock()
 	needCheckPosition := nowUnixNano-c.positionCheckTime >= checkDelay.Nanoseconds()
 	if needCheckPosition {

--- a/channel_medium_test.go
+++ b/channel_medium_test.go
@@ -50,6 +50,7 @@ func (m *mockNode) mapStreamTop(ch string) (StreamPosition, error) {
 }
 
 func TestChannelMediumHandlePublication(t *testing.T) {
+	t.Parallel()
 	var testCases = []struct {
 		numPublications int
 		options         ChannelMediumOptions
@@ -118,6 +119,7 @@ func TestChannelMediumHandlePublication(t *testing.T) {
 }
 
 func TestChannelMediumInsufficientState(t *testing.T) {
+	t.Parallel()
 	options := ChannelMediumOptions{
 		enableQueue:           true,
 		KeepLatestPublication: true,
@@ -143,6 +145,7 @@ func TestChannelMediumInsufficientState(t *testing.T) {
 }
 
 func TestChannelMediumPositionSync(t *testing.T) {
+	t.Parallel()
 	options := ChannelMediumOptions{
 		SharedPositionSync: true,
 	}
@@ -170,6 +173,7 @@ func TestChannelMediumPositionSync(t *testing.T) {
 }
 
 func TestChannelMediumPositionSyncRetry(t *testing.T) {
+	t.Parallel()
 	options := ChannelMediumOptions{
 		SharedPositionSync: true,
 	}
@@ -202,6 +206,7 @@ func TestChannelMediumPositionSyncRetry(t *testing.T) {
 }
 
 func TestChannelMediumPositionSyncMap(t *testing.T) {
+	t.Parallel()
 	// Verify that SharedPositionSync for map channels calls mapStreamTop (not streamTop).
 	options := ChannelMediumOptions{
 		SharedPositionSync: true,
@@ -238,6 +243,7 @@ func TestChannelMediumPositionSyncMap(t *testing.T) {
 }
 
 func TestChannelMediumPositionSyncMapMismatch(t *testing.T) {
+	t.Parallel()
 	// Verify that SharedPositionSync for map channels detects position mismatch.
 	options := ChannelMediumOptions{
 		SharedPositionSync: true,
@@ -276,6 +282,7 @@ func TestChannelMediumPositionSyncMapMismatch(t *testing.T) {
 }
 
 func TestChannelMediumNoLocalPrevPubForMapSubs(t *testing.T) {
+	t.Parallel()
 	// Test that channel medium does NOT provide localPrevPub for map publications
 	// (pub.Key != ""). Map keys are independent streams — a single latestPublication
 	// can't serve as a correct delta base across different keys. Only non-map

--- a/channel_medium_test.go
+++ b/channel_medium_test.go
@@ -159,12 +159,8 @@ func TestChannelMediumPositionSync(t *testing.T) {
 			return StreamPosition{}, nil
 		},
 	})
-	originalGetter := channelMediumTimeNow
-	channelMediumTimeNow = func() time.Time {
-		return time.Now().Add(time.Hour)
-	}
+	medium.nowFn = func() time.Time { return time.Now().Add(time.Hour) }
 	medium.CheckPosition(time.Second, StreamPosition{Offset: 1, Epoch: "test"}, time.Second)
-	channelMediumTimeNow = originalGetter
 	select {
 	case <-doneCh:
 	case <-time.After(5 * time.Second):
@@ -192,12 +188,8 @@ func TestChannelMediumPositionSyncRetry(t *testing.T) {
 			return StreamPosition{}, nil
 		},
 	})
-	originalGetter := channelMediumTimeNow
-	channelMediumTimeNow = func() time.Time {
-		return time.Now().Add(time.Hour)
-	}
+	medium.nowFn = func() time.Time { return time.Now().Add(time.Hour) }
 	medium.CheckPosition(time.Second, StreamPosition{Offset: 1, Epoch: "test"}, time.Second)
-	channelMediumTimeNow = originalGetter
 	select {
 	case <-doneCh:
 	case <-time.After(5 * time.Second):
@@ -226,14 +218,9 @@ func TestChannelMediumPositionSyncMap(t *testing.T) {
 		},
 	})
 	medium.isMap = true
-
-	originalGetter := channelMediumTimeNow
-	channelMediumTimeNow = func() time.Time {
-		return time.Now().Add(time.Hour)
-	}
+	medium.nowFn = func() time.Time { return time.Now().Add(time.Hour) }
 	// Position matches — should return true.
 	valid := medium.CheckPosition(time.Second, StreamPosition{Offset: 5, Epoch: "abc"}, time.Second)
-	channelMediumTimeNow = originalGetter
 	require.True(t, valid)
 	select {
 	case <-mapStreamTopCalled:
@@ -265,14 +252,9 @@ func TestChannelMediumPositionSyncMapMismatch(t *testing.T) {
 		},
 	})
 	medium.isMap = true
-
-	originalGetter := channelMediumTimeNow
-	channelMediumTimeNow = func() time.Time {
-		return time.Now().Add(time.Hour)
-	}
+	medium.nowFn = func() time.Time { return time.Now().Add(time.Hour) }
 	// Client has stale position — should return false.
 	valid := medium.CheckPosition(time.Second, StreamPosition{Offset: 5, Epoch: "xyz"}, time.Second)
-	channelMediumTimeNow = originalGetter
 	require.False(t, valid)
 	select {
 	case <-insufficientCh:
@@ -489,21 +471,33 @@ func TestChannelMediumWithBroadcastDelayCoalesces(t *testing.T) {
 		)
 	}
 
-	deadline := time.After(2 * time.Second)
+	// Wait for first delivery — the 50ms broadcastDelay can stretch under -race
+	// load, so use Eventually rather than a fixed inner timeout that flakes.
 	var received []*Publication
-loop:
+	require.Eventually(t, func() bool {
+		select {
+		case p := <-delivered:
+			received = append(received, p)
+			return true
+		default:
+			return false
+		}
+	}, 5*time.Second, 10*time.Millisecond, "expected at least one coalesced delivery")
+
+	// Drain any follow-ups arriving shortly after the first delivery. Use a
+	// long enough quiet window that all coalesced publications have a chance
+	// to arrive even under -race contention.
+	drainTimeout := time.After(500 * time.Millisecond)
+drain:
 	for {
 		select {
 		case p := <-delivered:
 			received = append(received, p)
-			// After receiving the first batch, peek for follow-ups.
-		case <-time.After(150 * time.Millisecond):
-			break loop
-		case <-deadline:
-			break loop
+		case <-drainTimeout:
+			break drain
 		}
 	}
-	require.NotEmpty(t, received)
+
 	// Coalescing: at minimum we should receive far fewer than 5 publications.
 	require.Less(t, len(received), 5)
 	// The last delivered publication must be the highest offset queued.

--- a/client_experimental_test.go
+++ b/client_experimental_test.go
@@ -351,11 +351,18 @@ func TestClientLevelPingCustomTimerScheduler(t *testing.T) {
 	node.timerScheduler = &testTimerScheduler{}
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	done := make(chan struct{})
+	// Short ping/pong durations so the test finishes quickly. The first ping
+	// fires in [PingInterval/2, PingInterval], then PongTimeout starts before
+	// DisconnectNoPong; total ≤ PingInterval + PongTimeout. Test purpose
+	// (custom scheduler is invoked and disconnect fires after the window) is
+	// duration-agnostic.
+	pingInterval := 1 * time.Second
+	pongTimeout := 500 * time.Millisecond
 	node.OnConnecting(func(context.Context, ConnectEvent) (ConnectReply, error) {
 		return ConnectReply{
 			PingPongConfig: &PingPongConfig{
-				PingInterval: 5 * time.Second,
-				PongTimeout:  3 * time.Second,
+				PingInterval: pingInterval,
+				PongTimeout:  pongTimeout,
 			},
 		}, nil
 	})
@@ -373,7 +380,7 @@ func TestClientLevelPingCustomTimerScheduler(t *testing.T) {
 	connectClientV2(t, client)
 	select {
 	case <-done:
-	case <-time.After(9 * time.Second):
+	case <-time.After(pingInterval + pongTimeout + time.Second):
 		t.Fatal("no disconnect in timeout")
 	}
 }

--- a/client_keyed_test.go
+++ b/client_keyed_test.go
@@ -13,6 +13,7 @@ import (
 // encodeKeyedPush: JSON+bidi (already covered), JSON+uni, Protobuf+bidi,
 // Protobuf+uni.
 func TestEncodeKeyedPush_AllProtocols(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name  string
 		proto ProtocolType
@@ -47,6 +48,7 @@ func TestEncodeKeyedPush_AllProtocols(t *testing.T) {
 
 // TestKeyedTrack_NoTrackHandler covers the trackHandler == nil branch.
 func TestKeyedTrack_NoTrackHandler(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	// Subscribe handler only, no OnTrack.
 	node.OnConnect(func(client *Client) {
@@ -73,6 +75,7 @@ func TestKeyedTrack_NoTrackHandler(t *testing.T) {
 // TestKeyedTrack_TtlField covers the inner branch in handleTrack that sets
 // res.Ttl when reply.ExpireAt > now.
 func TestKeyedTrack_TtlField(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	node.OnConnect(func(client *Client) {
 		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
@@ -97,6 +100,7 @@ func TestKeyedTrack_TtlField(t *testing.T) {
 // TestKeyedUntrack_InvokesUntrackHandler covers the optional untrackHandler
 // invocation in handleUntrack and the minTrackExpireAt cleanup branch.
 func TestKeyedUntrack_InvokesUntrackHandler(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	called := make(chan UntrackEvent, 1)
 	node.OnConnect(func(client *Client) {
@@ -140,6 +144,7 @@ func TestKeyedUntrack_InvokesUntrackHandler(t *testing.T) {
 // TestCleanupKeyed_NoKeyedState covers the early-return branch in cleanupKeyed
 // when c.keyed is nil (client never tracked anything).
 func TestCleanupKeyed_NoKeyedState(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 	client := newTestClientV2(t, node, "user1")
@@ -158,6 +163,7 @@ func TestCleanupKeyed_NoKeyedState(t *testing.T) {
 // in checkTrackExpiration: no keyed state, no minExpire entry, and re-check
 // after acquiring write lock.
 func TestCheckTrackExpiration_EarlyReturns(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 	client := newTestClientV2(t, node, "user1")

--- a/client_map.go
+++ b/client_map.go
@@ -1339,29 +1339,25 @@ func (c *Client) sweepExpiredMapSubscribing(skipChannel string) {
 		c.mu.RUnlock()
 		return
 	}
-	type sweepCandidate struct {
-		ch    string
-		state *mapSubscribeState
-	}
-	candidates := make([]sweepCandidate, 0, n)
-	for ch, state := range c.mapSubscribing {
-		if ch == skipChannel {
-			continue
-		}
-		candidates = append(candidates, sweepCandidate{ch: ch, state: state})
-	}
-	c.mu.RUnlock()
-
-	// Resolve options + check expiry outside any lock.
 	type sweepExpired struct {
 		ch    string
 		state *mapSubscribeState
 	}
+	candidates := make([]sweepExpired, 0, n)
+	for ch, state := range c.mapSubscribing {
+		if ch == skipChannel {
+			continue
+		}
+		candidates = append(candidates, sweepExpired{ch: ch, state: state})
+	}
+	c.mu.RUnlock()
+
+	// Resolve options + check expiry outside any lock.
 	var expired []sweepExpired
 	for _, cand := range candidates {
 		sweepChOpts, _ := c.node.resolveMapChannelOptions(cand.ch)
 		if c.isMapCatchUpExpired(cand.state, sweepChOpts) {
-			expired = append(expired, sweepExpired{ch: cand.ch, state: cand.state})
+			expired = append(expired, cand)
 		}
 	}
 	if len(expired) == 0 {

--- a/client_map_test.go
+++ b/client_map_test.go
@@ -98,6 +98,7 @@ func subscribeMapClientExpectError(t testing.TB, client *Client, req *protocol.S
 }
 
 func TestMapSubscribe_StatePhase(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 
 	channel := "test_keyed"
@@ -150,6 +151,7 @@ func TestMapSubscribe_StatePhase(t *testing.T) {
 }
 
 func TestMapSubscribe_StatePagination(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 
 	channel := "test_map_pagination"
@@ -209,6 +211,7 @@ func TestMapSubscribe_StatePagination(t *testing.T) {
 }
 
 func TestMapSubscribe_StreamPhase(t *testing.T) {
+	t.Parallel()
 	// Test that STREAM phase is used when the stream advances too far during
 	// STATE pagination for state-to-live to kick in.
 	node, broker := newTestNodeWithMapBroker(t)
@@ -289,6 +292,7 @@ func TestMapSubscribe_StreamPhase(t *testing.T) {
 }
 
 func TestMapSubscribe_LivePhase(t *testing.T) {
+	t.Parallel()
 	// With always-on state-to-live, positioned mode STATE goes directly to LIVE
 	// on the last page when stream is close. Verify client is properly subscribed.
 	node, broker := newTestNodeWithMapBroker(t)
@@ -336,6 +340,7 @@ func TestMapSubscribe_LivePhase(t *testing.T) {
 }
 
 func TestMapSubscribe_DirectLive(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 
 	channel := "test_direct_live"
@@ -374,6 +379,7 @@ func TestMapSubscribe_DirectLive(t *testing.T) {
 }
 
 func TestMapSubscribe_FullTwoPhase(t *testing.T) {
+	t.Parallel()
 	// With always-on state-to-live, positioned mode STATE goes directly to LIVE
 	// on the last page when all entries fit. This effectively becomes a single step.
 	node, broker := newTestNodeWithMapBroker(t)
@@ -417,6 +423,7 @@ func TestMapSubscribe_FullTwoPhase(t *testing.T) {
 }
 
 func TestMapSubscribe_NotEnabled(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 
 	channel := "test_not_enabled"
@@ -448,6 +455,7 @@ func TestMapSubscribe_NotEnabled(t *testing.T) {
 }
 
 func TestMapSubscribe_AlreadySubscribed(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 
 	channel := "test_already_subscribed"
@@ -483,6 +491,7 @@ func TestMapSubscribe_AlreadySubscribed(t *testing.T) {
 }
 
 func TestMapSubscribe_WithPresence(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 
 	channel := "test_with_presence"
@@ -533,6 +542,7 @@ func TestMapSubscribe_WithPresence(t *testing.T) {
 }
 
 func TestMapSubscribe_PresenceCleanupOnUnsubscribe(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 
 	channel := "test_presence_cleanup"
@@ -581,6 +591,7 @@ func TestMapSubscribe_PresenceCleanupOnUnsubscribe(t *testing.T) {
 }
 
 func TestMapSubscribe_PresenceCleanupOnDisconnect(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 
 	channel := "test_presence_disconnect"
@@ -632,6 +643,7 @@ func TestMapSubscribe_PresenceCleanupOnDisconnect(t *testing.T) {
 }
 
 func TestMapSubscribe_CleanupOnUnsubscribe(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 
 	channel := "test_cleanup_on_unsub"
@@ -688,6 +700,7 @@ func TestMapSubscribe_CleanupOnUnsubscribe(t *testing.T) {
 }
 
 func TestMapSubscribe_CleanupOnDisconnect(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 
 	channel := "test_cleanup_on_disconnect"
@@ -746,6 +759,7 @@ func TestMapSubscribe_CleanupOnDisconnect(t *testing.T) {
 }
 
 func TestPresenceSubscribe_State(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 
 	ctx := context.Background()
@@ -787,6 +801,7 @@ func TestPresenceSubscribe_State(t *testing.T) {
 }
 
 func TestPresenceSubscribe_Live(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 
 	ctx := context.Background()
@@ -826,6 +841,7 @@ func TestPresenceSubscribe_Live(t *testing.T) {
 }
 
 func TestPresenceSubscribe_Positioned_TwoPhase(t *testing.T) {
+	t.Parallel()
 	// Presence subscriptions can also be positioned (EnablePositioning: true).
 	// With always-on state-to-live, positioned STATE goes directly to LIVE
 	// on the last page when stream is close.
@@ -871,6 +887,7 @@ func TestPresenceSubscribe_Positioned_TwoPhase(t *testing.T) {
 }
 
 func TestPresenceSubscribe_NotAllowed(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 
 	presenceChannel := "clients:test_presence_not_allowed"
@@ -897,6 +914,7 @@ func TestPresenceSubscribe_NotAllowed(t *testing.T) {
 }
 
 func TestPresenceSubscribe_NoHandler(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 
 	presenceChannel := "clients:test_presence_no_handler"
@@ -918,6 +936,7 @@ func TestPresenceSubscribe_NoHandler(t *testing.T) {
 }
 
 func TestPresenceSubscribe_AlreadySubscribed(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 
 	presenceChannel := "clients:test_presence_already_sub"
@@ -950,6 +969,7 @@ func TestPresenceSubscribe_AlreadySubscribed(t *testing.T) {
 }
 
 func TestMapPresenceTTL(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 
 	// Default ClientPresenceUpdateInterval is 27 seconds.
@@ -968,6 +988,7 @@ func TestMapPresenceTTL(t *testing.T) {
 }
 
 func TestMapSubscribe_WithKeyedClientAndUserPresence(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 
 	channel := "test_map_presence"
@@ -1031,6 +1052,7 @@ func TestMapSubscribe_WithKeyedClientAndUserPresence(t *testing.T) {
 }
 
 func TestMapSubscribePresenceCleanupOnDisconnect(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 
 	channel := "test_map_presence_cleanup"
@@ -1094,6 +1116,7 @@ func TestMapSubscribePresenceCleanupOnDisconnect(t *testing.T) {
 }
 
 func TestMapSubscribe_MultipleClientsPerUser(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 
 	channel := "test_multi_clients"
@@ -1167,6 +1190,7 @@ func TestMapSubscribe_MultipleClientsPerUser(t *testing.T) {
 
 // TestMapBroker_ReadStateByKey tests the Key filter for ReadState.
 func TestMapBroker_ReadStateByKey(t *testing.T) {
+	t.Parallel()
 	_, broker := newTestNodeWithMapBroker(t)
 	ctx := context.Background()
 	ch := "test_read_by_key"
@@ -1212,6 +1236,7 @@ func TestMapBroker_ReadStateByKey(t *testing.T) {
 
 // TestMapBroker_CASSuccess tests successful CAS update.
 func TestMapBroker_CASSuccess(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 	ctx := context.Background()
@@ -1252,6 +1277,7 @@ func TestMapBroker_CASSuccess(t *testing.T) {
 
 // TestMapBroker_CASConflict tests CAS conflict when position has changed.
 func TestMapBroker_CASConflict(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 	ctx := context.Background()
@@ -1310,6 +1336,7 @@ func TestMapBroker_CASConflict(t *testing.T) {
 
 // TestMapBroker_CASNonExistent tests CAS on a key that doesn't exist.
 func TestMapBroker_CASNonExistent(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 	ctx := context.Background()
@@ -1340,6 +1367,7 @@ func TestMapBroker_CASNonExistent(t *testing.T) {
 
 // TestMapBroker_CASWrongEpoch tests CAS with correct offset but wrong epoch.
 func TestMapBroker_CASWrongEpoch(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 	ctx := context.Background()
@@ -1385,6 +1413,7 @@ func TestMapBroker_CASWrongEpoch(t *testing.T) {
 // Tests for STATE→LIVE direct transition optimization.
 
 func TestMapSubscribe_StateToLive_DirectTransition(t *testing.T) {
+	t.Parallel()
 	// Test that when stream is close enough, server transitions directly
 	// from STATE to LIVE on the last state page.
 	node, err := New(Config{
@@ -1461,6 +1490,7 @@ func TestMapSubscribe_StateToLive_DirectTransition(t *testing.T) {
 }
 
 func TestMapSubscribe_StateToLive_WithStreamPublications(t *testing.T) {
+	t.Parallel()
 	// Test that STATE→LIVE transition includes stream publications when
 	// there are updates between state read and going live.
 	node, err := New(Config{
@@ -1531,6 +1561,7 @@ func TestMapSubscribe_StateToLive_WithStreamPublications(t *testing.T) {
 }
 
 func TestMapSubscribe_StateToLive_Pagination_LastPageGoesLive(t *testing.T) {
+	t.Parallel()
 	// Test that with pagination, only the LAST page can trigger STATE→LIVE.
 	// Earlier pages should return phase=2 (STATE) with cursor.
 	node, err := New(Config{
@@ -1617,6 +1648,7 @@ func TestMapSubscribe_StateToLive_Pagination_LastPageGoesLive(t *testing.T) {
 }
 
 func TestMapSubscribe_StateToLive_PublishDuringPagination(t *testing.T) {
+	t.Parallel()
 	// Regression test: publications made between STATE pages must not be lost
 	// when server transitions directly from STATE to LIVE.
 	//
@@ -1733,6 +1765,7 @@ func TestMapSubscribe_StateToLive_PublishDuringPagination(t *testing.T) {
 }
 
 func TestMapSubscribe_StateToLive_PublishDuringPagination_ManyPublishes(t *testing.T) {
+	t.Parallel()
 	// Regression test with publications happening at multiple points during
 	// multi-page pagination. Verifies the frozen offset stays consistent and
 	// ALL publications during the entire pagination are recovered.
@@ -1865,6 +1898,7 @@ func TestMapSubscribe_StateToLive_PublishDuringPagination_ManyPublishes(t *testi
 }
 
 func TestMapSubscribe_StreamPhaseRecovery(t *testing.T) {
+	t.Parallel()
 	// Test that a reconnecting client can use phase=1 (STREAM) with recover=true
 	// to catch up from its last known position without going through STATE phase.
 	// This simulates a client reconnection after disconnect.
@@ -1937,6 +1971,7 @@ func TestMapSubscribe_StreamPhaseRecovery(t *testing.T) {
 }
 
 func TestMapSubscribe_StreamPhaseRecovery_WithoutRecoverFlag(t *testing.T) {
+	t.Parallel()
 	// Test that phase=1 (STREAM) without recover=true and without prior STATE
 	// phase returns permission denied.
 	node, broker := newTestNodeWithMapBroker(t)
@@ -1979,6 +2014,7 @@ func TestMapSubscribe_StreamPhaseRecovery_WithoutRecoverFlag(t *testing.T) {
 }
 
 func TestMapSubscribe_StreamPhaseRecovery_LargeGap(t *testing.T) {
+	t.Parallel()
 	// Test stream phase recovery with a larger gap that requires multiple
 	// pagination rounds before going LIVE.
 	node, broker := newTestNodeWithMapBroker(t)
@@ -2060,6 +2096,7 @@ func TestMapSubscribe_StreamPhaseRecovery_LargeGap(t *testing.T) {
 }
 
 func TestMapSubscribe_LivePhaseRecovery(t *testing.T) {
+	t.Parallel()
 	// Test that a reconnecting client can use phase=0 (LIVE) with recover=true
 	// to catch up directly without any pagination.
 	node, broker := newTestNodeWithMapBroker(t)
@@ -2122,6 +2159,7 @@ func TestMapSubscribe_LivePhaseRecovery(t *testing.T) {
 
 // Streamless mode: phase=1 (STREAM) should be rejected with ErrorBadRequest.
 func TestMapSubscribe_Streamless_StreamPhaseRejected(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 
 	channel := "test_streamless_stream_rejected"
@@ -2162,6 +2200,7 @@ func TestMapSubscribe_Streamless_StreamPhaseRejected(t *testing.T) {
 
 // Streamless mode: reconnection uses STATE phase to re-sync full state.
 func TestMapSubscribe_Streamless_RecoveryUsesStatePhase(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 
 	channel := "test_streamless_recovery_state"
@@ -2207,6 +2246,7 @@ func TestMapSubscribe_Streamless_RecoveryUsesStatePhase(t *testing.T) {
 
 // Positioned mode: epoch mismatch during STREAM phase should return ErrorUnrecoverablePosition.
 func TestMapSubscribe_Positioned_StreamEpochMismatch(t *testing.T) {
+	t.Parallel()
 	// Test that STREAM phase with wrong epoch returns ErrorUnrecoverablePosition.
 	// We create a scenario where STATE doesn't go LIVE (large stream gap) so
 	// the client needs to use STREAM phase, and then send wrong epoch.
@@ -2287,6 +2327,7 @@ func TestMapSubscribe_Positioned_StreamEpochMismatch(t *testing.T) {
 
 // Positioned mode: concurrent pagination requests on the same channel should return ErrorConcurrentPagination.
 func TestMapSubscribe_ConcurrentPagination(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -2343,6 +2384,7 @@ func TestMapSubscribe_ConcurrentPagination(t *testing.T) {
 // When client is exactly at the limit, recovery should succeed.
 // When client is beyond the limit, should get ErrorUnrecoverablePosition.
 func TestMapSubscribe_RecoveryMaxPublicationLimit(t *testing.T) {
+	t.Parallel()
 	node, err := New(Config{
 		LogLevel:   LogLevelTrace,
 		LogHandler: func(entry LogEntry) {},
@@ -2426,6 +2468,7 @@ func TestMapSubscribe_RecoveryMaxPublicationLimit(t *testing.T) {
 // Positioned mode: State consistency filtering. Entries modified after the saved position
 // during pagination should be filtered out from later pages to prevent duplicates.
 func TestMapSubscribe_Positioned_StateConsistencyFiltering(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -2495,6 +2538,7 @@ func TestMapSubscribe_Positioned_StateConsistencyFiltering(t *testing.T) {
 
 // Positioned mode: multi-page state pagination followed by STREAM and LIVE phases.
 func TestMapSubscribe_Positioned_FullThreePhaseFlow(t *testing.T) {
+	t.Parallel()
 	// Test the full three-phase flow: STATE → STREAM → LIVE.
 	// This requires the stream to advance during STATE pagination so that
 	// state-to-live can't kick in on the last page.
@@ -2602,6 +2646,7 @@ func TestMapSubscribe_Positioned_FullThreePhaseFlow(t *testing.T) {
 
 // Positioned mode: LIVE recovery with epoch mismatch should return ErrorUnrecoverablePosition.
 func TestMapSubscribe_Positioned_LiveRecoveryEpochMismatch(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -2645,6 +2690,7 @@ func TestMapSubscribe_Positioned_LiveRecoveryEpochMismatch(t *testing.T) {
 
 // Streamless mode: STATE phase on last page transitions directly to LIVE with full state.
 func TestMapSubscribe_Streamless_StateToLive(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 
 	channel := "test_streamless_state_to_live"
@@ -2685,6 +2731,7 @@ func TestMapSubscribe_Streamless_StateToLive(t *testing.T) {
 
 // Positioned mode: STATE phase with small state transitions to LIVE with full state.
 func TestMapSubscribe_Positioned_StateToLive_SmallState(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -2730,6 +2777,7 @@ func TestMapSubscribe_Positioned_StateToLive_SmallState(t *testing.T) {
 // the last publication's offset (not stream.Top()), preventing the client
 // from jumping ahead and skipping publications in multi-page STREAM scenarios.
 func TestMapSubscribe_StreamPhaseOffset(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 	channel := "test_stream_offset"
@@ -2834,6 +2882,7 @@ func TestMapSubscribe_StreamPhaseOffset(t *testing.T) {
 // TestMapSubscribe_WasRecovering verifies that WasRecovering flag is set
 // correctly on recovery join responses.
 func TestMapSubscribe_CatchUpTimeout_StatePagination(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	// Set a very short timeout so we can trigger it without sleeping.
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
@@ -2896,6 +2945,7 @@ func TestMapSubscribe_CatchUpTimeout_StatePagination(t *testing.T) {
 }
 
 func TestMapSubscribe_CatchUpTimeout_PhaseTransition(t *testing.T) {
+	t.Parallel()
 	// Test that catch-up timeout fires when client takes too long between phases.
 	// We use multi-page STATE with stream advancing between pages so that
 	// state-to-live doesn't kick in, then manipulate startedAt before STREAM.
@@ -2981,6 +3031,7 @@ func TestMapSubscribe_CatchUpTimeout_PhaseTransition(t *testing.T) {
 }
 
 func TestMapSubscribe_CatchUpTimeout_Sweep(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3053,6 +3104,7 @@ func TestMapSubscribe_CatchUpTimeout_Sweep(t *testing.T) {
 }
 
 func TestMapSubscribe_CatchUpTimeout_Disabled(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	// Negative timeout disables the check.
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
@@ -3111,6 +3163,7 @@ func TestMapSubscribe_CatchUpTimeout_Disabled(t *testing.T) {
 }
 
 func TestMapSubscribe_WasRecovering(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 	channel := "test_was_recovering"
@@ -3183,6 +3236,7 @@ func TestMapSubscribe_WasRecovering(t *testing.T) {
 // epoch="" still trigger insufficient state on epoch mismatch
 // (tested in TestClientUnexpectedOffsetEpochClientV2 and below).
 func TestMapSubscribe_EmptyEpochAdoption(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -3332,6 +3386,7 @@ func TestEmptyEpochAdoption_AllChannelTypes(t *testing.T) {
 // real (non-empty) epoch triggers handleInsufficientState when a publication
 // arrives with a different epoch. The epoch adoption only applies to epoch="".
 func TestMapSubscribe_RealEpochMismatch(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -3394,6 +3449,7 @@ func TestMapSubscribe_RealEpochMismatch(t *testing.T) {
 // against stale state after a Clear event: the client SDK stores the epoch from
 // the subscribe response and never updates it from publication deliveries.
 func TestMapSubscribe_RecoveryEmptyEpochGuard(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -3437,6 +3493,7 @@ func TestMapSubscribe_RecoveryEmptyEpochGuard(t *testing.T) {
 // TestMapSubscribe_RecoveryEmptyEpochGuard_StreamPhase tests the same guard
 // via STREAM phase recovery (the default SDK recovery path).
 func TestMapSubscribe_RecoveryEmptyEpochGuard_StreamPhase(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -3482,6 +3539,7 @@ func TestMapSubscribe_RecoveryEmptyEpochGuard_StreamPhase(t *testing.T) {
 // (non-empty) matching epoch succeeds normally — the empty-epoch guard only
 // triggers when the client sends epoch="" but the server has a real epoch.
 func TestMapSubscribe_RecoveryMatchingEpoch(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -3525,6 +3583,7 @@ func TestMapSubscribe_RecoveryMatchingEpoch(t *testing.T) {
 // after MapClear (which deletes channel state) returns ErrorUnrecoverablePosition.
 // After Clear, ReadStream returns a new epoch — the guard must catch real→different mismatch.
 func TestMapSubscribe_RecoveryAfterClear(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -3578,6 +3637,7 @@ func TestMapSubscribe_RecoveryAfterClear(t *testing.T) {
 // would merge prior-epoch state with new-epoch live publications and silently
 // orphan any keys not republished in the new epoch.
 func TestMapSubscribe_StateToLive_EpochFlipDuringPagination(t *testing.T) {
+	t.Parallel()
 	node, err := New(Config{
 		LogLevel:   LogLevelTrace,
 		LogHandler: func(entry LogEntry) {},
@@ -3672,6 +3732,7 @@ func TestMapSubscribe_StateToLive_EpochFlipDuringPagination(t *testing.T) {
 // This allows the client SDK to learn the channel epoch from the first publication
 // without redundant epoch bytes in every message.
 func TestMapSubscribe_EpochInFirstPublication(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -3757,6 +3818,7 @@ func TestMapSubscribe_EpochInFirstPublication(t *testing.T) {
 // with MapClientPresenceChannel sets the right flags, stores presence in MapBroker,
 // and cleans up on unsubscribe. Covers Steps 4, 6, 7 of the plan.
 func TestStreamSubscribe_WithMapClientPresence(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 
 	presenceChannel := "clients:test_channel"
@@ -3799,6 +3861,7 @@ func TestStreamSubscribe_WithMapClientPresence(t *testing.T) {
 // TestStreamSubscribe_WithMapPresenceDisconnect verifies that disconnect cleans up
 // map client presence for stream subscriptions.
 func TestStreamSubscribe_WithMapPresenceDisconnect(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 
 	presenceChannel := "clients:test_channel"
@@ -3833,6 +3896,7 @@ func TestStreamSubscribe_WithMapPresenceDisconnect(t *testing.T) {
 // TestStreamSubscribe_WithMapUserPresence verifies that user presence is NOT removed
 // on unsubscribe (TTL-based expiry by design).
 func TestStreamSubscribe_WithMapUserPresence(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 
 	presenceChannel := "users:test_channel"
@@ -3868,6 +3932,7 @@ func TestStreamSubscribe_WithMapUserPresence(t *testing.T) {
 // TestStreamSubscribe_WithRegularAndMapPresence verifies that regular presence and
 // map client presence can coexist on a stream subscribe.
 func TestStreamSubscribe_WithRegularAndMapPresence(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 
 	presenceChannel := "clients:test_channel"
@@ -3910,6 +3975,7 @@ func TestStreamSubscribe_WithRegularAndMapPresence(t *testing.T) {
 // TestStreamSubscribe_MapPresencePeriodicUpdate verifies that updateChannelPresence
 // works for stream channels with map presence (Step 6: flagMap gate removed).
 func TestStreamSubscribe_MapPresencePeriodicUpdate(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 
 	presenceChannel := "clients:test_channel"
@@ -3944,6 +4010,7 @@ func TestStreamSubscribe_MapPresencePeriodicUpdate(t *testing.T) {
 // TestSharedPollSubscribe_WithMapPresence verifies that shared poll subscribe
 // with MapClientPresenceChannel sets up presence correctly.
 func TestSharedPollSubscribe_WithMapPresence(t *testing.T) {
+	t.Parallel()
 	presenceChannel := "clients:test_channel"
 
 	node, err := New(Config{
@@ -4031,6 +4098,7 @@ func TestSharedPollSubscribe_WithMapPresence(t *testing.T) {
 // TestSharedPollSubscribe_WithRegularPresence verifies that shared poll subscribe
 // with EmitPresence and EmitJoinLeave sets the right flags.
 func TestSharedPollSubscribe_WithRegularPresence(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 
 	node.OnConnecting(func(ctx context.Context, e ConnectEvent) (ConnectReply, error) {
@@ -4071,6 +4139,7 @@ func TestSharedPollSubscribe_WithRegularPresence(t *testing.T) {
 // with only EmitPresence (no map presence channels) still works correctly after
 // the unsubscribe refactoring (Step 7 regression test).
 func TestMapSubscribe_WithOnlyEmitPresence_Regression(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 
 	node.OnConnect(func(client *Client) {
@@ -4105,6 +4174,7 @@ func TestMapSubscribe_WithOnlyEmitPresence_Regression(t *testing.T) {
 }
 
 func TestMapSubscribe_ServerTagsFilter_StatePhase(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -4156,6 +4226,7 @@ func TestMapSubscribe_ServerTagsFilter_StatePhase(t *testing.T) {
 }
 
 func TestMapSubscribe_ServerTagsFilter_LiveDelivery(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -4231,6 +4302,7 @@ func TestMapSubscribe_ServerTagsFilter_LiveDelivery(t *testing.T) {
 }
 
 func TestMapSubscribe_ServerAndClientTagsFilter_AND(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -4289,6 +4361,7 @@ func TestMapSubscribe_ServerAndClientTagsFilter_AND(t *testing.T) {
 }
 
 func TestMapSubscribe_ServerTagsFilter_RemovalFiltering(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -4369,6 +4442,7 @@ func TestMapSubscribe_ServerTagsFilter_RemovalFiltering(t *testing.T) {
 }
 
 func TestSubRefresh_ServerTagsFilter_MapUnsubscribed(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -4433,6 +4507,7 @@ func TestSubRefresh_ServerTagsFilter_MapUnsubscribed(t *testing.T) {
 }
 
 func TestSubRefresh_ServerTagsFilter_SameFilterNoUnsubscribe(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -4500,6 +4575,7 @@ func TestSubRefresh_ServerTagsFilter_SameFilterNoUnsubscribe(t *testing.T) {
 }
 
 func TestSubRefresh_ServerTagsFilter_NilNoChange(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -4985,6 +5061,7 @@ func TestCleanupMapSubscribingAll(t *testing.T) {
 // TestMapSubscribe_InvalidPhase covers the default case in handleMapSubscribe
 // (invalid phase value).
 func TestMapSubscribe_InvalidPhase(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 
 	channel := "test_invalid_phase"
@@ -5014,6 +5091,7 @@ func TestMapSubscribe_InvalidPhase(t *testing.T) {
 // TestMapSubscribe_StreamPhase_ConcurrentPagination covers the
 // ErrorConcurrentPagination branch of handleMapStreamPhase.
 func TestMapSubscribe_StreamPhase_ConcurrentPagination(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -5067,6 +5145,7 @@ func TestMapSubscribe_StreamPhase_ConcurrentPagination(t *testing.T) {
 // TestMapSubscribe_LivePhase_NoMapBroker covers the `getMapBroker == nil`
 // branch in handleMapLivePhase.
 func TestMapSubscribe_LivePhase_NoMapBroker(t *testing.T) {
+	t.Parallel()
 	node, _ := newTestNodeWithMapBroker(t)
 
 	channel := "no_broker_channel"
@@ -5106,6 +5185,7 @@ func TestMapSubscribe_LivePhase_NoMapBroker(t *testing.T) {
 // branch in handleMapLivePhase when in-progress mapSubscribing state has a
 // captured epoch and the client sends a different one.
 func TestMapSubscribe_LivePhase_StateEpochMismatch(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -5175,6 +5255,7 @@ func TestMapSubscribe_LivePhase_StateEpochMismatch(t *testing.T) {
 // streamless-with-tags-filter branch in handleMapTransitionToLive
 // (allowStreamless==true && sub.tagsFilter != nil).
 func TestMapSubscribe_Streamless_StateToLive_ClientTagsFilter(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	// Ephemeral mode → streamless. Also enable AllowTagsFilter via reply options.
 
@@ -5220,6 +5301,7 @@ func TestMapSubscribe_Streamless_StateToLive_ClientTagsFilter(t *testing.T) {
 // the live transition. Uses STATE→LIVE flow so the state struct captures
 // both server and client filters and they apply to gap publications.
 func TestMapSubscribe_StateToLive_TagsFilter_OnRecoveredPubs(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -5299,6 +5381,7 @@ func TestMapSubscribe_StateToLive_TagsFilter_OnRecoveredPubs(t *testing.T) {
 // TestMapSubscribe_Recovery_FossilDelta covers the makeRecoveredMapPubsDeltaFossil
 // invocation inside handleMapTransitionToLive (deltaEnabled + Fossil).
 func TestMapSubscribe_Recovery_FossilDelta(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -5372,6 +5455,7 @@ func TestMapSubscribe_Recovery_FossilDelta(t *testing.T) {
 // TestMapSubscribe_StateToLive_PublishDebounce covers the PublishDebounce
 // branch in handleMapTransitionToLive.
 func TestMapSubscribe_StateToLive_PublishDebounce(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 
 	channel := "test_publish_debounce"
@@ -5407,6 +5491,7 @@ func TestMapSubscribe_StateToLive_PublishDebounce(t *testing.T) {
 // TestUpdateMapPresence_BothChannels exercises the client + user presence
 // branches of updateMapPresence (used by the periodic presence refresh).
 func TestUpdateMapPresence_BothChannels(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 
 	clientPresenceCh := "clients:room"
@@ -5437,6 +5522,7 @@ func TestUpdateMapPresence_BothChannels(t *testing.T) {
 // per-page tags-filter branch inside handleMapStreamPhase (intermediate
 // page path, not transition-to-live).
 func TestMapSubscribe_StreamPhase_TagsFilter_IntermediatePage(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 
@@ -5505,6 +5591,7 @@ func TestMapSubscribe_StreamPhase_TagsFilter_IntermediatePage(t *testing.T) {
 // reconnecting subscriber received publications that should have been filtered
 // out by the server-side RBAC filter.
 func TestMapSubscribe_DirectLiveRecovery_ServerTagsFilter(t *testing.T) {
+	t.Parallel()
 	node, broker := newTestNodeWithMapBroker(t)
 	setTestMapChannelOptionsConverging(node)
 

--- a/client_map_test.go
+++ b/client_map_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -5647,4 +5649,74 @@ func TestMapSubscribe_DirectLiveRecovery_ServerTagsFilter(t *testing.T) {
 		require.Equal(t, "eng", pub.Tags["team"],
 			"server filter team=eng must drop sales entries even on direct LIVE recovery")
 	}
+}
+
+// TestMapSubscribe_DisconnectRace_NoGhostSubscription stresses the race
+// between handleMapTransitionToLive's late c.channels[channel] write and
+// Client.close()'s c.channels snapshot. The fix re-checks c.status under
+// c.mu before writing channelContext — without it, a close() that runs
+// after addSubscription but before the channelContext write would snapshot
+// c.channels without our entry (no cleanup queued), and the late write
+// would leave a hub subscription with no cleanup path.
+//
+// Pattern: many short-lived clients subscribe to the same map channel and
+// Disconnect concurrently. After all activity drains the hub must show
+// zero subscribers — any ghost would persist forever.
+func TestMapSubscribe_DisconnectRace_NoGhostSubscription(t *testing.T) {
+	t.Parallel()
+	node, _ := newTestNodeWithMapBroker(t)
+	setTestMapChannelOptionsConverging(node)
+	node.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
+			cb(SubscribeReply{
+				Options: SubscribeOptions{Type: SubscriptionTypeMap},
+			}, nil)
+		})
+	})
+
+	channel := "test_map_disc_race"
+	const iterations = 300
+
+	rng := rand.New(rand.NewSource(1))
+	var jitterMu sync.Mutex
+	nextJitter := func() time.Duration {
+		jitterMu.Lock()
+		defer jitterMu.Unlock()
+		return time.Duration(rng.Intn(2000)) * time.Microsecond
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		jitter := nextJitter()
+		go func(i int, jitter time.Duration) {
+			defer wg.Done()
+			client := newTestClientV2(t, node, fmt.Sprintf("u%d", i))
+			connectClientV2(t, client)
+
+			// Spawn the disconnect with random jitter to land at varying
+			// points relative to addSubscription / the channelContext write.
+			go func() {
+				time.Sleep(jitter)
+				client.Disconnect(DisconnectForceNoReconnect)
+			}()
+
+			// Best-effort subscribe — may succeed, error, or be interrupted
+			// by the close. Any panic would surface via the test harness.
+			rwWrapper := testReplyWriterWrapper()
+			_ = client.handleSubscribe(&protocol.SubscribeRequest{
+				Channel: channel,
+				Type:    int32(SubscriptionTypeMap),
+				Phase:   MapPhaseState,
+				Limit:   100,
+			}, &protocol.Command{Id: 1}, time.Now(), rwWrapper.rw)
+		}(i, jitter)
+	}
+	wg.Wait()
+
+	// Hub must converge to zero subscribers — a ghost would never be cleaned.
+	require.Eventually(t, func() bool {
+		return node.hub.NumSubscribers(channel) == 0
+	}, 15*time.Second, 50*time.Millisecond,
+		"expected zero hub subscribers, got %d", node.hub.NumSubscribers(channel))
 }

--- a/client_shared_poll_test.go
+++ b/client_shared_poll_test.go
@@ -134,6 +134,7 @@ func untrackSharedPollClient(t testing.TB, client *Client, channel string, keys 
 // 1.1 Subscribe Tests
 
 func TestSharedPollSubscribe_Basic(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 	client := newTestClientV2(t, node, "user1")
@@ -149,6 +150,7 @@ func TestSharedPollSubscribe_Basic(t *testing.T) {
 }
 
 func TestSharedPollSubscribe_NotConfigured(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	setupSharedPollHandlers(node)
@@ -164,6 +166,7 @@ func TestSharedPollSubscribe_NotConfigured(t *testing.T) {
 }
 
 func TestSharedPollSubscribe_WrongType(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 	client := newTestClientV2(t, node, "user1")
@@ -179,6 +182,7 @@ func TestSharedPollSubscribe_WrongType(t *testing.T) {
 }
 
 func TestSharedPollSubscribe_OnSubscribeReject(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 
 	node.OnConnecting(func(ctx context.Context, e ConnectEvent) (ConnectReply, error) {
@@ -206,6 +210,7 @@ func TestSharedPollSubscribe_OnSubscribeReject(t *testing.T) {
 }
 
 func TestSharedPollSubscribe_FlagKeyed(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 	client := newTestClientV2(t, node, "user1")
@@ -223,6 +228,7 @@ func TestSharedPollSubscribe_FlagKeyed(t *testing.T) {
 }
 
 func TestSharedPollSubscribe_NoRecoveryFields(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 	client := newTestClientV2(t, node, "user1")
@@ -238,6 +244,7 @@ func TestSharedPollSubscribe_NoRecoveryFields(t *testing.T) {
 // 1.2 Track / Untrack Tests
 
 func TestSharedPollTrack_Basic(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 	client := newTestClientV2(t, node, "user1")
@@ -264,6 +271,7 @@ func TestSharedPollTrack_Basic(t *testing.T) {
 }
 
 func TestSharedPollTrack_SignatureRejected(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 
 	node.OnConnecting(func(ctx context.Context, e ConnectEvent) (ConnectReply, error) {
@@ -305,6 +313,7 @@ func TestSharedPollTrack_SignatureRejected(t *testing.T) {
 }
 
 func TestSharedPollTrack_MaxTrackedExceeded(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
 		MaxKeysPerConnection: 2,
@@ -338,6 +347,7 @@ func TestSharedPollTrack_MaxTrackedExceeded(t *testing.T) {
 // under the limit — earlier code wrote per-connection state before any
 // re-check and could bypass the limit.
 func TestSharedPollTrack_ConcurrentLimitNotBypassed(t *testing.T) {
+	t.Parallel()
 	const limit = 4
 	const goroutines = 16
 
@@ -443,6 +453,7 @@ func TestSharedPollTrack_ConcurrentLimitNotBypassed(t *testing.T) {
 }
 
 func TestSharedPollTrack_ItemIndexVersion0(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 	client := newTestClientV2(t, node, "user1")
@@ -466,6 +477,7 @@ func TestSharedPollTrack_ItemIndexVersion0(t *testing.T) {
 }
 
 func TestSharedPollTrack_MultipleClients(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 
@@ -493,6 +505,7 @@ func TestSharedPollTrack_MultipleClients(t *testing.T) {
 }
 
 func TestSharedPollUntrack_Basic(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 	client := newTestClientV2(t, node, "user1")
@@ -519,6 +532,7 @@ func TestSharedPollUntrack_Basic(t *testing.T) {
 }
 
 func TestSharedPollUntrack_NonexistentKey(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 	client := newTestClientV2(t, node, "user1")
@@ -530,6 +544,7 @@ func TestSharedPollUntrack_NonexistentKey(t *testing.T) {
 }
 
 func TestSharedPollTrack_EmptyItems(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 	client := newTestClientV2(t, node, "user1")
@@ -546,6 +561,7 @@ func TestSharedPollTrack_EmptyItems(t *testing.T) {
 }
 
 func TestSharedPollUntrack_EmptyKeys(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 	client := newTestClientV2(t, node, "user1")
@@ -564,6 +580,7 @@ func TestSharedPollUntrack_EmptyKeys(t *testing.T) {
 // 1.3 Refresh Worker Tests
 
 func TestSharedPollRefresh_BasicCycle(t *testing.T) {
+	t.Parallel()
 	var pollCalled atomic.Int32
 	var pollMu sync.Mutex
 	var pollItems []SharedPollItem
@@ -603,6 +620,7 @@ func TestSharedPollRefresh_BasicCycle(t *testing.T) {
 }
 
 func TestSharedPollRefresh_VersionIncreased(t *testing.T) {
+	t.Parallel()
 	var version atomic.Uint64
 	version.Store(1)
 
@@ -640,6 +658,7 @@ func TestSharedPollRefresh_VersionIncreased(t *testing.T) {
 }
 
 func TestSharedPollRefresh_VersionUnchanged(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	var callCount atomic.Int32
 
@@ -675,6 +694,7 @@ func TestSharedPollRefresh_VersionUnchanged(t *testing.T) {
 }
 
 func TestSharedPollRefresh_MaxPolicy(t *testing.T) {
+	t.Parallel()
 	var callCount atomic.Int32
 
 	node := newTestNodeWithSharedPoll(t)
@@ -718,6 +738,7 @@ func TestSharedPollRefresh_MaxPolicy(t *testing.T) {
 }
 
 func TestSharedPollRefresh_Batching(t *testing.T) {
+	t.Parallel()
 	var batchCalls atomic.Int32
 
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
@@ -750,6 +771,7 @@ func TestSharedPollRefresh_Batching(t *testing.T) {
 }
 
 func TestSharedPollRefresh_PublicationFields(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 
 	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
@@ -788,6 +810,7 @@ func TestSharedPollRefresh_PublicationFields(t *testing.T) {
 // 1.4 Item Removal Tests
 
 func TestSharedPollRefresh_ExplicitRemoval(t *testing.T) {
+	t.Parallel()
 	var callCount atomic.Int32
 
 	node := newTestNodeWithSharedPoll(t)
@@ -840,6 +863,7 @@ func TestSharedPollRefresh_ExplicitRemoval(t *testing.T) {
 // 1.5 Revocation Tests
 
 func TestSharedPollRevokeKeys_Basic(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 
 	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
@@ -872,6 +896,7 @@ func TestSharedPollRevokeKeys_Basic(t *testing.T) {
 }
 
 func TestSharedPollRevokeKeys_UserFilter(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 
 	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
@@ -911,6 +936,7 @@ func TestSharedPollRevokeKeys_UserFilter(t *testing.T) {
 // 1.7 Mode (Versioned)
 
 func TestSharedPollVersionedMode_VersionsInRequest(t *testing.T) {
+	t.Parallel()
 	var pollItems []SharedPollItem
 	var pollMu sync.Mutex
 	var callCount atomic.Int32
@@ -965,6 +991,7 @@ func TestSharedPollVersionedMode_VersionsInRequest(t *testing.T) {
 }
 
 func TestSharedPollVersionedMode_AlwaysSendsVersions(t *testing.T) {
+	t.Parallel()
 	var pollItems []SharedPollItem
 	var pollMu sync.Mutex
 	var callCount atomic.Int32
@@ -1017,6 +1044,7 @@ func TestSharedPollVersionedMode_AlwaysSendsVersions(t *testing.T) {
 // 1.8 Connection Lifecycle Tests
 
 func TestSharedPollDisconnect_Cleanup(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 
 	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
@@ -1046,6 +1074,7 @@ func TestSharedPollDisconnect_Cleanup(t *testing.T) {
 }
 
 func TestSharedPollUnsubscribe_Cleanup(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 
 	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
@@ -1077,6 +1106,7 @@ func TestSharedPollUnsubscribe_Cleanup(t *testing.T) {
 // 1.10 Concurrency Tests
 
 func TestSharedPollConcurrent_TrackUntrack(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      50 * time.Millisecond,
 		RefreshBatchSize:     100,
@@ -1125,6 +1155,7 @@ func TestSharedPollConcurrent_TrackUntrack(t *testing.T) {
 // 1.11 Config Defaults Tests
 
 func TestSharedPollConfig_Defaults(t *testing.T) {
+	t.Parallel()
 	opts := SharedPollChannelOptions{}
 	require.Equal(t, time.Duration(0), opts.RefreshInterval) // Zero → default 10s in worker
 	require.Equal(t, 0, opts.RefreshBatchSize)               // Zero → default 1000 in worker
@@ -1133,6 +1164,7 @@ func TestSharedPollConfig_Defaults(t *testing.T) {
 }
 
 func TestSharedPollConfig_ToKeyedChannelOptions(t *testing.T) {
+	t.Parallel()
 	opts := SharedPollChannelOptions{
 		MaxKeysPerConnection: 42,
 		RefreshInterval:      time.Second,
@@ -1144,6 +1176,7 @@ func TestSharedPollConfig_ToKeyedChannelOptions(t *testing.T) {
 // 1.12 Node Startup Validation
 
 func TestSharedPollNode_MissingOnSharedPoll(t *testing.T) {
+	t.Parallel()
 	node, err := New(Config{
 		LogLevel:   LogLevelTrace,
 		LogHandler: func(entry LogEntry) {},
@@ -1163,6 +1196,7 @@ func TestSharedPollNode_MissingOnSharedPoll(t *testing.T) {
 // --- 1.1 Subscribe (additional) ---
 
 func TestSharedPollSubscribe_AlreadySubscribed(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 
@@ -1181,6 +1215,7 @@ func TestSharedPollSubscribe_AlreadySubscribed(t *testing.T) {
 // --- 1.2 Track/Untrack (additional) ---
 
 func TestSharedPollTrack_PerConnectionVersions(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 
@@ -1210,6 +1245,7 @@ func TestSharedPollTrack_PerConnectionVersions(t *testing.T) {
 }
 
 func TestSharedPollTrack_AdditionalBatch(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 
@@ -1239,6 +1275,7 @@ func TestSharedPollTrack_AdditionalBatch(t *testing.T) {
 }
 
 func TestSharedPollUntrack_NoSignature(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 
@@ -1260,6 +1297,7 @@ func TestSharedPollUntrack_NoSignature(t *testing.T) {
 }
 
 func TestSharedPollUntrack_LastSubscriber(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 
@@ -1290,6 +1328,7 @@ func TestSharedPollUntrack_LastSubscriber(t *testing.T) {
 }
 
 func TestSharedPollUntrack_OtherSubscribersRemain(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 
@@ -1327,6 +1366,7 @@ func TestSharedPollUntrack_OtherSubscribersRemain(t *testing.T) {
 // --- 1.3 Refresh Worker (additional) ---
 
 func TestSharedPollRefresh_MultipleItems(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 
 	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
@@ -1368,6 +1408,7 @@ func TestSharedPollRefresh_MultipleItems(t *testing.T) {
 }
 
 func TestSharedPollRefresh_PerConnectionFilter(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 
 	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
@@ -1399,6 +1440,7 @@ func TestSharedPollRefresh_PerConnectionFilter(t *testing.T) {
 }
 
 func TestSharedPollRefresh_PerConnectionDelivery(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 
 	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
@@ -1429,6 +1471,7 @@ func TestSharedPollRefresh_PerConnectionDelivery(t *testing.T) {
 }
 
 func TestSharedPollRefresh_TwoClientsOverlap(t *testing.T) {
+	t.Parallel()
 	var version atomic.Uint64
 	version.Store(5) // First call returns 6, then 7, etc.
 
@@ -1482,6 +1525,7 @@ func TestSharedPollRefresh_TwoClientsOverlap(t *testing.T) {
 }
 
 func TestSharedPollRefresh_BatchingConcurrency(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
 		RefreshBatchSize:     100,
@@ -1534,6 +1578,7 @@ func TestSharedPollRefresh_BatchingConcurrency(t *testing.T) {
 // --- 1.5 Revocation (additional) ---
 
 func TestSharedPollRevokeKeys_ExcludeUsers(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 
 	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
@@ -1574,6 +1619,7 @@ func TestSharedPollRevokeKeys_ExcludeUsers(t *testing.T) {
 }
 
 func TestSharedPollRevokeKeys_NonexistentKey(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 
@@ -1595,6 +1641,7 @@ func TestSharedPollRevokeKeys_NonexistentKey(t *testing.T) {
 // --- 1.6 KeepLatestData ---
 
 func TestSharedPollKeepLatestData_DataStored(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
 		RefreshBatchSize:     100,
@@ -1642,6 +1689,7 @@ func TestSharedPollKeepLatestData_DataStored(t *testing.T) {
 }
 
 func TestSharedPollKeepLatestData_NoDataWithout(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t) // KeepLatestData=false by default.
 
 	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
@@ -1686,6 +1734,7 @@ func TestSharedPollKeepLatestData_NoDataWithout(t *testing.T) {
 // --- 1.8 Connection Lifecycle (additional) ---
 
 func TestSharedPollChannelShutdown_Immediate(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
 		RefreshBatchSize:     100,
@@ -1711,6 +1760,7 @@ func TestSharedPollChannelShutdown_Immediate(t *testing.T) {
 }
 
 func TestSharedPollChannelShutdown_Delay(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
 		RefreshBatchSize:     100,
@@ -1793,6 +1843,7 @@ func setupSharedPollDeltaHandlers(node *Node) {
 }
 
 func TestSharedPollDelta_NegotiationEnabled(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollDeltaHandlers(node)
 
@@ -1811,6 +1862,7 @@ func TestSharedPollDelta_NegotiationEnabled(t *testing.T) {
 }
 
 func TestSharedPollDelta_NegotiationDisabled(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	// Use default handlers (no AllowedDeltaTypes).
 	setupSharedPollHandlers(node)
@@ -1828,6 +1880,7 @@ func TestSharedPollDelta_NegotiationDisabled(t *testing.T) {
 }
 
 func TestSharedPollDelta_FirstPubIsFull(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
 		RefreshBatchSize:     100,
@@ -1897,6 +1950,7 @@ func TestSharedPollDelta_FirstPubIsFull(t *testing.T) {
 }
 
 func TestSharedPollDelta_SubsequentPubIsDelta(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
 		RefreshBatchSize:     100,
@@ -1974,6 +2028,7 @@ func TestSharedPollDelta_SubsequentPubIsDelta(t *testing.T) {
 }
 
 func TestSharedPollDelta_MultipleKeysIndependent(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
 		RefreshBatchSize:     100,
@@ -2035,6 +2090,7 @@ func TestSharedPollDelta_MultipleKeysIndependent(t *testing.T) {
 }
 
 func TestSharedPollDelta_NoDeltaWithoutKeepLatestData(t *testing.T) {
+	t.Parallel()
 	// Without KeepLatestData, no prevData is captured → no delta.
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
@@ -2101,6 +2157,7 @@ done:
 }
 
 func TestSharedPollDelta_DeltaApplicable(t *testing.T) {
+	t.Parallel()
 	// Verify the delta patch is actually a valid fossil delta.
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
@@ -2200,6 +2257,7 @@ gotFirst:
 }
 
 func TestBuildPreparedPollData_NoPrevData(t *testing.T) {
+	t.Parallel()
 	pub := &protocol.Publication{Data: []byte(`test`)}
 	prep := buildPreparedPollData(pub, nil)
 	require.False(t, prep.deltaSub)
@@ -2207,6 +2265,7 @@ func TestBuildPreparedPollData_NoPrevData(t *testing.T) {
 }
 
 func TestBuildPreparedPollData_WithPrevData(t *testing.T) {
+	t.Parallel()
 	// Use sufficiently large data so fossil delta overhead is smaller than full payload.
 	prevData := []byte(`{"value":"this is a longer string so delta overhead is worth it","count":1}`)
 	newData := []byte(`{"value":"this is a longer string so delta overhead is worth it","count":2}`)
@@ -2223,6 +2282,7 @@ func TestBuildPreparedPollData_WithPrevData(t *testing.T) {
 }
 
 func TestBuildPreparedPollData_LargePatch(t *testing.T) {
+	t.Parallel()
 	// When new data is completely different and small, patch may be >= full size.
 	prevData := []byte(`a`)
 	newData := []byte(`completely different data here`)
@@ -2260,6 +2320,7 @@ func setupSharedPollHandlersWithExpiry(node *Node, expireAt int64) {
 }
 
 func TestSharedPollTrackExpiry_NoRefresh(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	trackExpireAt := int64(100)
 	setupSharedPollHandlersWithExpiry(node, trackExpireAt)
@@ -2296,6 +2357,7 @@ func TestSharedPollTrackExpiry_NoRefresh(t *testing.T) {
 }
 
 func TestSharedPollTrackExpiry_RefreshResetsExpiry(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	trackExpireAt := int64(100)
 	setupSharedPollHandlersWithExpiry(node, trackExpireAt)
@@ -2348,6 +2410,7 @@ func TestSharedPollTrackExpiry_RefreshResetsExpiry(t *testing.T) {
 }
 
 func TestSharedPollTrackExpiry_PartialRefresh(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	trackExpireAt := int64(100)
 	setupSharedPollHandlersWithExpiry(node, trackExpireAt)
@@ -2407,6 +2470,7 @@ func TestSharedPollTrackExpiry_PartialRefresh(t *testing.T) {
 }
 
 func TestSharedPollTrackExpiry_NoExpiry(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	// ExpireAt=0 means no expiry.
 	setupSharedPollHandlersWithExpiry(node, 0)
@@ -2436,6 +2500,7 @@ func TestSharedPollTrackExpiry_NoExpiry(t *testing.T) {
 }
 
 func TestSharedPollTrackExpiry_NotExpiredYet(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	trackExpireAt := int64(100)
 	setupSharedPollHandlersWithExpiry(node, trackExpireAt)
@@ -2467,6 +2532,7 @@ func TestSharedPollTrackExpiry_NotExpiredYet(t *testing.T) {
 // --- Cached Data on Track Tests ---
 
 func TestSharedPollCachedData_ReturnedOnTrack(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
 		RefreshBatchSize:     100,
@@ -2523,6 +2589,7 @@ func TestSharedPollCachedData_ReturnedOnTrack(t *testing.T) {
 }
 
 func TestSharedPollCachedData_NotReturnedWhenVersionCurrent(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
 		RefreshBatchSize:     100,
@@ -2574,6 +2641,7 @@ func TestSharedPollCachedData_NotReturnedWhenVersionCurrent(t *testing.T) {
 }
 
 func TestSharedPollCachedData_NotReturnedWithoutKeepLatestData(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
 		RefreshBatchSize:     100,
@@ -2625,6 +2693,7 @@ func TestSharedPollCachedData_NotReturnedWithoutKeepLatestData(t *testing.T) {
 }
 
 func TestSharedPollCachedData_VersionUpdatedNoDuplicate(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      10 * time.Second, // long interval to avoid timer poll interference
 		RefreshBatchSize:     100,
@@ -2683,6 +2752,7 @@ func TestSharedPollCachedData_VersionUpdatedNoDuplicate(t *testing.T) {
 }
 
 func TestSharedPollCachedData_MultipleKeys(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
 		RefreshBatchSize:     100,
@@ -2753,6 +2823,7 @@ func TestSharedPollCachedData_MultipleKeys(t *testing.T) {
 }
 
 func TestSharedPollCachedData_PartialVersionMatch(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
 		RefreshBatchSize:     100,
@@ -2812,6 +2883,7 @@ func TestSharedPollCachedData_PartialVersionMatch(t *testing.T) {
 // --- Auto-Notify Cold Key Tests ---
 
 func TestSharedPollAutoNotify_ColdKey(t *testing.T) {
+	t.Parallel()
 	var pollCalled atomic.Int32
 	var pollMu sync.Mutex
 	var pollKeys []string
@@ -2858,6 +2930,7 @@ func TestSharedPollAutoNotify_ColdKey(t *testing.T) {
 }
 
 func TestSharedPollAutoNotify_ExistingKeyNoNotify(t *testing.T) {
+	t.Parallel()
 	callCh := make(chan SharedPollEvent, 10)
 
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
@@ -2927,6 +3000,7 @@ func TestSharedPollAutoNotify_ExistingKeyNoNotify(t *testing.T) {
 }
 
 func TestSharedPollAutoNotify_MultipleClientsSameColdKey(t *testing.T) {
+	t.Parallel()
 	var pollCalled atomic.Int32
 
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
@@ -2993,6 +3067,7 @@ func TestSharedPollAutoNotify_MultipleClientsSameColdKey(t *testing.T) {
 }
 
 func TestSharedPollAutoNotify_ColdKeyNonZeroVersionNoNotify(t *testing.T) {
+	t.Parallel()
 	// When a client tracks a cold key with version > 0, auto-notify should NOT
 	// fire. The client already has data — the regular poll cycle will deliver
 	// any newer data.
@@ -3030,6 +3105,7 @@ func TestSharedPollAutoNotify_ColdKeyNonZeroVersionNoNotify(t *testing.T) {
 }
 
 func TestSharedPollAutoNotify_ColdKeyVersionZeroTriggersNotify(t *testing.T) {
+	t.Parallel()
 	// When a client tracks a cold key with version 0, auto-notify SHOULD fire.
 	// Contrast with TestSharedPollAutoNotify_ColdKeyNonZeroVersionNoNotify.
 	var pollCalled atomic.Int32
@@ -3067,6 +3143,7 @@ func TestSharedPollAutoNotify_ColdKeyVersionZeroTriggersNotify(t *testing.T) {
 }
 
 func TestSharedPollCachedData_DeltaReadyAfterCache(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:           30 * time.Second,
 		RefreshBatchSize:          100,
@@ -3179,6 +3256,7 @@ func TestSharedPollCachedData_DeltaReadyAfterCache(t *testing.T) {
 }
 
 func TestSharedPollCachedData_DeltaReadyPartialKeys(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
 		RefreshBatchSize:     100,
@@ -3248,6 +3326,7 @@ func TestSharedPollCachedData_DeltaReadyPartialKeys(t *testing.T) {
 }
 
 func TestSharedPoll_PrevDataNotUsedWhenKeepLatestData(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:           30 * time.Second,
 		RefreshBatchSize:          100,
@@ -3417,6 +3496,7 @@ gotV10:
 }
 
 func TestSharedPoll_VersionlessPerConnectionDedup(t *testing.T) {
+	t.Parallel()
 	// Two clients tracking same key in versionless mode.
 	// Both should receive exactly once per change.
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
@@ -3503,6 +3583,7 @@ func TestSharedPoll_VersionlessPerConnectionDedup(t *testing.T) {
 }
 
 func TestSharedPoll_VersionlessReconnect(t *testing.T) {
+	t.Parallel()
 	// In versionless mode, wire version is always 0.
 	// When a client reconnects and re-tracks with v=0, a new data change
 	// must be delivered (pubVersion > keyState.version=0).
@@ -3580,6 +3661,7 @@ func TestSharedPoll_VersionlessReconnect(t *testing.T) {
 }
 
 func TestSharedPollEpoch_VersionlessSubscribeReplyHasEpoch(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 	client := newTestClientV2(t, node, "user1")
@@ -3591,6 +3673,7 @@ func TestSharedPollEpoch_VersionlessSubscribeReplyHasEpoch(t *testing.T) {
 }
 
 func TestSharedPollEpoch_VersionedModeEmptyEpoch(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		Mode:                 SharedPollModeVersioned,
 		RefreshInterval:      100 * time.Millisecond,
@@ -3606,6 +3689,7 @@ func TestSharedPollEpoch_VersionedModeEmptyEpoch(t *testing.T) {
 }
 
 func TestSharedPollEpoch_VersionlessSendsSyntheticVersion(t *testing.T) {
+	t.Parallel()
 	// Versionless mode: publications should carry synthetic version on wire (not 0).
 	// We verify by checking the per-connection version which is set from the wire version.
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
@@ -3675,6 +3759,7 @@ func containsNonZeroKeyedVersion(data []byte) bool {
 }
 
 func TestSharedPollEpoch_ChangesOnChannelStateRecreation(t *testing.T) {
+	t.Parallel()
 	// Versionless mode: when channel state is cleaned up (all keys untracked,
 	// shutdown delay fires) and recreated, the epoch must change. Otherwise
 	// reconnecting clients keep stale synthetic versions and miss updates
@@ -3766,6 +3851,7 @@ func setEpochAwareSharedPollHandler(node *Node, initial string) func(string) {
 // it AFTER the publish. The handler then captures the post-publish epoch and
 // applyRefreshResponse becomes a no-op flip (epochA → epochA).
 func TestSharedPollEpoch_VersionedInitialEmpty(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, versionedSharedPollOpts())
 	setupSharedPollHandlers(node)
 
@@ -3809,6 +3895,7 @@ func TestSharedPollEpoch_VersionedInitialEmpty(t *testing.T) {
 // TestSharedPollEpoch_SameEpochVersionCompare: same epoch + monotonic
 // versions = standard accept-fresh / skip-stale behavior.
 func TestSharedPollEpoch_SameEpochVersionCompare(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, versionedSharedPollOpts())
 	setupSharedPollHandlers(node)
 	setEpochAwareSharedPollHandler(node, "epochA")
@@ -3833,6 +3920,7 @@ func TestSharedPollEpoch_SameEpochVersionCompare(t *testing.T) {
 // TestSharedPollEpoch_FlipUnsubscribesClient: a publish with a different
 // epoch unsubscribes existing subscribers with insufficient-state code.
 func TestSharedPollEpoch_FlipUnsubscribesClient(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, versionedSharedPollOpts())
 	setupSharedPollHandlers(node)
 
@@ -3886,6 +3974,7 @@ func TestSharedPollEpoch_FlipUnsubscribesClient(t *testing.T) {
 // state — a publish with version=1 under the new epoch is accepted even when
 // the previous epoch had reached version=1000.
 func TestSharedPollEpoch_FlipResetsEntries(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, versionedSharedPollOpts())
 	setupSharedPollHandlers(node)
 	setPublisherEpoch := setEpochAwareSharedPollHandler(node, "epochA")
@@ -3934,6 +4023,7 @@ func TestSharedPollEpoch_FlipResetsEntries(t *testing.T) {
 // This avoids an extra unsub-resub cycle for the first subscriber to a quiet
 // node.
 func TestSharedPollEpoch_FlipOnUntrackedKey(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, versionedSharedPollOpts())
 	setupSharedPollHandlers(node)
 	setEpochAwareSharedPollHandler(node, "epochX")
@@ -3957,6 +4047,7 @@ func TestSharedPollEpoch_FlipOnUntrackedKey(t *testing.T) {
 // epoch when stored is also empty performs pure version comparison — no
 // flip, no unsubscribe.
 func TestSharedPollEpoch_EmptyEpochUnchangedBehavior(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, versionedSharedPollOpts())
 	setupSharedPollHandlers(node)
 
@@ -3985,6 +4076,7 @@ func TestSharedPollEpoch_EmptyEpochUnchangedBehavior(t *testing.T) {
 // versioned channel returns the current channel epoch. Clients use it to
 // detect mid-session flips on resubscribe.
 func TestSharedPollEpoch_SubscribeReplyCarriesEpoch(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, versionedSharedPollOpts())
 	setupSharedPollHandlers(node)
 	setEpochAwareSharedPollHandler(node, "epochA")
@@ -4080,6 +4172,7 @@ func TestKeyedWriteRemoval_EarlyReturns(t *testing.T) {
 // TestSharedPollSubscribe_ExpireAtPast covers the ttl <= 0 branch which
 // returns ErrorExpired during the OnSubscribe callback.
 func TestSharedPollSubscribe_ExpireAtPast(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	node.OnConnect(func(client *Client) {
 		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
@@ -4107,6 +4200,7 @@ func TestSharedPollSubscribe_ExpireAtPast(t *testing.T) {
 // subscribeSharedPollClient helper because it pre-registers the channel,
 // which would itself trip the limit on the first call.
 func TestSharedPollSubscribe_ChannelLimitExceeded(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	node.config.ClientChannelLimit = 1
 	setupSharedPollHandlers(node)
@@ -4133,6 +4227,7 @@ func TestSharedPollSubscribe_ChannelLimitExceeded(t *testing.T) {
 // (PushJoinLeave + MapClientPresenceChannel + MapUserPresenceChannel) in
 // handleSharedPollSubscribe.
 func TestSharedPollSubscribe_PresenceFlags(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	node.OnConnect(func(client *Client) {
 		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {

--- a/client_shared_poll_test.go
+++ b/client_shared_poll_test.go
@@ -681,10 +681,11 @@ func TestSharedPollRefresh_VersionUnchanged(t *testing.T) {
 		{Key: "key1", Version: 5},
 	})
 
-	// Wait for several refresh cycles.
+	// Wait for several refresh cycles. 100 ms RefreshInterval × 3 = 300 ms
+	// in theory; under -race -count=N scheduling stretch we give 5 s slack.
 	require.Eventually(t, func() bool {
 		return callCount.Load() >= 3
-	}, 2*time.Second, 10*time.Millisecond)
+	}, 5*time.Second, 10*time.Millisecond)
 
 	// Per-connection version should remain 5 (broadcastToKey skips: 5 <= 5).
 	client.mu.RLock()
@@ -840,24 +841,22 @@ func TestSharedPollRefresh_ExplicitRemoval(t *testing.T) {
 		{Key: "key1", Version: 0},
 	})
 
-	// Wait for removal to be processed.
+	// Wait for removal to propagate into itemIndex.
 	require.Eventually(t, func() bool {
-		return callCount.Load() >= 2
-	}, 2*time.Second, 10*time.Millisecond)
-
-	// Give time for removal to process.
-	time.Sleep(50 * time.Millisecond)
-
-	// Item should be removed from itemIndex.
-	node.sharedPollManager.mu.RLock()
-	s, ok := node.sharedPollManager.channels["test:channel"]
-	node.sharedPollManager.mu.RUnlock()
-	if ok {
+		if callCount.Load() < 2 {
+			return false
+		}
+		node.sharedPollManager.mu.RLock()
+		s, ok := node.sharedPollManager.channels["test:channel"]
+		node.sharedPollManager.mu.RUnlock()
+		if !ok {
+			return true
+		}
 		s.mu.Lock()
 		_, hasKey := s.itemIndex["key1"]
 		s.mu.Unlock()
-		require.False(t, hasKey)
-	}
+		return !hasKey
+	}, 2*time.Second, 10*time.Millisecond)
 }
 
 // 1.5 Revocation Tests
@@ -1787,11 +1786,14 @@ func TestSharedPollChannelShutdown_Delay(t *testing.T) {
 		{Key: "key2", Version: 0},
 	})
 
-	// Wait longer than the delay.
-	time.Sleep(700 * time.Millisecond)
-
-	// Channel should still exist because we re-tracked.
-	require.True(t, node.sharedPollManager.hasChannel("test:channel"), "channel should survive after re-track")
+	// Channel must survive past the original shutdown delay because we
+	// re-tracked. require.Never keeps asserting over a window longer than
+	// the 500 ms delay; if shutdown were not cancelled the channel would
+	// disappear within that window.
+	require.Never(t, func() bool {
+		return !node.sharedPollManager.hasChannel("test:channel")
+	}, 800*time.Millisecond, 50*time.Millisecond,
+		"channel must survive after re-track cancels shutdown")
 }
 
 // --- Delta compression tests ---
@@ -2931,7 +2933,7 @@ func TestSharedPollAutoNotify_ColdKey(t *testing.T) {
 
 func TestSharedPollAutoNotify_ExistingKeyNoNotify(t *testing.T) {
 	t.Parallel()
-	callCh := make(chan SharedPollEvent, 10)
+	var callCount atomic.Int32
 
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      10 * time.Second, // Long interval.
@@ -2941,7 +2943,7 @@ func TestSharedPollAutoNotify_ExistingKeyNoNotify(t *testing.T) {
 	})
 
 	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
-		callCh <- event
+		callCount.Add(1)
 		return SharedPollResult{
 			Items: []SharedPollRefreshItem{
 				{Key: "key1", Data: []byte(`data`), Version: 1},
@@ -2951,38 +2953,32 @@ func TestSharedPollAutoNotify_ExistingKeyNoNotify(t *testing.T) {
 
 	setupSharedPollHandlers(node)
 
-	// Client1 tracks key1 → cold key → auto-notify.
+	// Client1 tracks key1 → cold key → auto-notify (call #1).
 	client1 := newTestClientV2(t, node, "user1")
 	connectClientV2(t, client1)
 	subscribeSharedPollClient(t, client1, "test:channel")
 	trackSharedPollClient(t, client1, "test:channel", []*protocol.KeyedItem{
 		{Key: "key1", Version: 0},
 	})
-
-	// Drain the auto-notify event.
-	select {
-	case <-callCh:
-	case <-time.After(500 * time.Millisecond):
-	}
+	require.Eventually(t, func() bool { return callCount.Load() >= 1 },
+		5*time.Second, 10*time.Millisecond,
+		"expected cold-key auto-poll to fire")
 
 	// Client2 tracks the same key with version=0 → warm key → triggers
-	// notify for near-immediate delivery (version=0 means "I have no data").
+	// notify for near-immediate delivery (call #2). version=0 means
+	// "I have no data" so the server re-broadcasts.
 	client2 := newTestClientV2(t, node, "user2")
 	connectClientV2(t, client2)
 	subscribeSharedPollClient(t, client2, "test:channel")
 	trackSharedPollClient(t, client2, "test:channel", []*protocol.KeyedItem{
 		{Key: "key1", Version: 0},
 	})
-
-	// Should trigger one additional backend call for the warm key.
-	select {
-	case <-callCh:
-		// Expected — warm key with version=0 triggers notify.
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("expected notify for warm key with version=0")
-	}
+	require.Eventually(t, func() bool { return callCount.Load() >= 2 },
+		5*time.Second, 10*time.Millisecond,
+		"expected notify for warm key with version=0")
 
 	// Client3 tracks the same key with version > 0 → no notify (has data).
+	beforeC3 := callCount.Load()
 	client3 := newTestClientV2(t, node, "user3")
 	connectClientV2(t, client3)
 	subscribeSharedPollClient(t, client3, "test:channel")
@@ -2990,13 +2986,11 @@ func TestSharedPollAutoNotify_ExistingKeyNoNotify(t *testing.T) {
 		{Key: "key1", Version: 1},
 	})
 
-	// No additional backend call — client already has data.
-	select {
-	case <-callCh:
-		t.Fatal("should not notify for warm key with version > 0")
-	case <-time.After(300 * time.Millisecond):
-		// Expected — no extra call.
-	}
+	// No additional backend call — client already has data. require.Never
+	// keeps polling for a window to detect any late notify.
+	require.Never(t, func() bool { return callCount.Load() > beforeC3 },
+		500*time.Millisecond, 25*time.Millisecond,
+		"should not notify for warm key with version > 0")
 }
 
 func TestSharedPollAutoNotify_MultipleClientsSameColdKey(t *testing.T) {
@@ -3838,6 +3832,35 @@ func setEpochAwareSharedPollHandler(node *Node, initial string) func(string) {
 	}
 }
 
+// setEpochAwareSharedPollHandlerBlocking is the deterministic variant: the
+// FIRST handler call (the cold-key auto-poll triggered by track) blocks
+// until the test calls release(); subsequent calls run unblocked. This
+// eliminates a race where the auto-poll's response — captured before the
+// test sets up its initial epoch — lands AFTER the test flips to a new
+// epoch and reverts state back. Use whenever the test plans to do a
+// setPublisherEpoch(...) after the initial setup.
+//
+// Returns (setEpoch, release). Typical usage:
+//
+//	setPub, release := setEpochAwareSharedPollHandlerBlocking(node, "epochA")
+//	subscribe + track
+//	SharedPollPublish(... "epochA" ...)
+//	release()                       // now the auto-poll's response is safe
+//	setPub("epochB"); SharedPollPublish(... "epochB" ...)
+func setEpochAwareSharedPollHandlerBlocking(node *Node, initial string) (func(string), func()) {
+	var epoch atomic.Pointer[string]
+	epoch.Store(&initial)
+	released := make(chan struct{})
+	var pollOnce sync.Once
+	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
+		pollOnce.Do(func() { <-released })
+		return SharedPollResult{Epoch: *epoch.Load()}, nil
+	})
+	setEpoch := func(s string) { epoch.Store(&s) }
+	release := func() { close(released) }
+	return setEpoch, release
+}
+
 // TestSharedPollEpoch_VersionedInitialEmpty: a versioned channel starts with
 // empty epoch. The first publish carrying a non-empty epoch flips state.
 //
@@ -3924,10 +3947,11 @@ func TestSharedPollEpoch_FlipUnsubscribesClient(t *testing.T) {
 	node := newTestNodeWithSharedPoll(t, versionedSharedPollOpts())
 	setupSharedPollHandlers(node)
 
-	// Refresh handler returns the same epoch as direct publishes — models a
-	// well-behaved publisher; otherwise cold-key auto-poll's empty-epoch
-	// response races with the publish and flips state back to "".
-	setPublisherEpoch := setEpochAwareSharedPollHandler(node, "epochA")
+	// Use the blocking-handler variant: track()'s cold-key auto-poll reads
+	// the epoch atomic synchronously but applies its response asynchronously.
+	// Without blocking, the response (captured before "epochA" was even set)
+	// can land AFTER we flip to "epochB" and silently revert state back.
+	setPublisherEpoch, releaseAutoPoll := setEpochAwareSharedPollHandlerBlocking(node, "epochA")
 
 	client := newTestClientV2(t, node, "user1")
 	connectClientV2(t, client)
@@ -3950,6 +3974,9 @@ func TestSharedPollEpoch_FlipUnsubscribesClient(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return node.sharedPollManager.Epoch("test:channel", false) == "epochA"
 	}, time.Second, 10*time.Millisecond)
+
+	// Release the cold-key auto-poll. Its response carries "epochA" (no flip).
+	releaseAutoPoll()
 
 	// Flip with new epoch — update the refresh handler in lockstep so the
 	// publisher stays consistent across both paths.
@@ -3977,25 +4004,24 @@ func TestSharedPollEpoch_FlipResetsEntries(t *testing.T) {
 	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, versionedSharedPollOpts())
 	setupSharedPollHandlers(node)
-	setPublisherEpoch := setEpochAwareSharedPollHandler(node, "epochA")
+	// Blocking variant: the cold-key auto-poll's response (carrying "epochA")
+	// must land before we flip to "epochB", otherwise the late apply reverts
+	// the channel epoch back to "epochA". See helper docs.
+	setPublisherEpoch, releaseAutoPoll := setEpochAwareSharedPollHandlerBlocking(node, "epochA")
 
 	client := newTestClientV2(t, node, "user1")
 	connectClientV2(t, client)
 	subscribeSharedPollClient(t, client, "test:channel")
 	trackSharedPollClient(t, client, "test:channel", []*protocol.KeyedItem{{Key: "k1", Version: 0}})
 
-	// track() triggers a cold-key auto-poll that reads the publisher epoch
-	// atomic synchronously but applies the response asynchronously. Wait for
-	// that poll to flip the channel epoch to "epochA" before changing the
-	// publisher epoch — otherwise an in-flight response carrying the old
-	// "epochA" can land after the publish below flips to "epochB" and
-	// flip the state back, breaking the test.
+	ctx := context.Background()
+	require.NoError(t, node.SharedPollPublish(ctx, "test:channel", "k1", 1000, "epochA", []byte(`{"v":1000}`)))
 	require.Eventually(t, func() bool {
 		return node.sharedPollManager.Epoch("test:channel", false) == "epochA"
 	}, time.Second, 10*time.Millisecond)
 
-	ctx := context.Background()
-	require.NoError(t, node.SharedPollPublish(ctx, "test:channel", "k1", 1000, "epochA", []byte(`{"v":1000}`)))
+	// Release the cold-key auto-poll. Its response carries "epochA" (no flip).
+	releaseAutoPoll()
 
 	// New epoch with low version: must be accepted (entries reset on flip).
 	setPublisherEpoch("epochB")
@@ -4221,6 +4247,159 @@ func TestSharedPollSubscribe_ChannelLimitExceeded(t *testing.T) {
 		Type:    int32(SubscriptionTypeSharedPoll),
 	}, &protocol.Command{Id: 2}, time.Now(), rw2.rw)
 	require.Equal(t, ErrorLimitExceeded, err)
+}
+
+// pollHandlerCounter wraps an OnSharedPoll handler with an atomic counter
+// over invocations. The cold-key auto-poll fired by track() runs the
+// handler asynchronously, so tests that need to observe its completion can
+// install this wrapper and call waitForPolls before subsequent assertions.
+//
+// Caveat: applyRefreshResponse runs AFTER the handler returns. The counter
+// is incremented at the END of the handler call (just before return), so
+// count >= N proves the handler has been invoked N times but does NOT
+// prove all N responses have been applied. Tests that depend on the
+// applied state should additionally assert a state predicate (e.g.
+// require.Eventually on Epoch == "...") that the apply step would set.
+type pollHandlerCounter struct {
+	count atomic.Int64
+}
+
+// installPollHandlerCounter replaces the node's OnSharedPoll with a counter
+// that delegates to `inner`. If inner is nil, the wrapper returns an empty
+// SharedPollResult.
+func installPollHandlerCounter(node *Node, inner func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error)) *pollHandlerCounter {
+	c := &pollHandlerCounter{}
+	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
+		var res SharedPollResult
+		var err error
+		if inner != nil {
+			res, err = inner(ctx, event)
+		}
+		c.count.Add(1)
+		return res, err
+	})
+	return c
+}
+
+// waitForPolls blocks until the counter has observed at least `target`
+// handler invocations or the deadline expires.
+func (c *pollHandlerCounter) waitForPolls(t testing.TB, target int64) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return c.count.Load() >= target
+	}, 5*time.Second, 10*time.Millisecond,
+		"expected >= %d OnSharedPoll handler invocations, got %d", target, c.count.Load())
+}
+
+// TestSharedPoll_ColdKeyAutoPoll_Synchronization demonstrates the
+// pollHandlerCounter helper: after trackSharedPollClient, callers can
+// wait for the cold-key auto-poll handler to have been invoked before
+// asserting downstream state. This makes ordering deterministic instead
+// of relying on a fixed time.Sleep.
+func TestSharedPoll_ColdKeyAutoPoll_Synchronization(t *testing.T) {
+	t.Parallel()
+	node := newTestNodeWithSharedPoll(t, versionedSharedPollOpts())
+	setupSharedPollHandlers(node)
+
+	counter := installPollHandlerCounter(node, func(_ context.Context, _ SharedPollEvent) (SharedPollResult, error) {
+		return SharedPollResult{Epoch: "epoch1"}, nil
+	})
+
+	client := newTestClientV2(t, node, "user1")
+	connectClientV2(t, client)
+	subscribeSharedPollClient(t, client, "test:autopoll_sync")
+	trackSharedPollClient(t, client, "test:autopoll_sync",
+		[]*protocol.KeyedItem{{Key: "k1", Version: 0}})
+
+	// The cold-key auto-poll runs OnSharedPoll once.
+	counter.waitForPolls(t, 1)
+
+	// Channel epoch reflects what the auto-poll returned.
+	require.Eventually(t, func() bool {
+		return node.sharedPollManager.Epoch("test:autopoll_sync", false) == "epoch1"
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+// TestSharedPollEpoch_FlipStorm_NoPanic_NoLeak: a publisher alternates
+// epochs rapidly while subscribers track and re-track. The system must
+// remain panic-free and converge to a final epoch matching the last
+// publish. Goroutine-leak surrogate: after activity drains, the manager
+// has at most one state for the channel and that state's worker is
+// running or has exited cleanly (verified by Close in t.Cleanup
+// completing within reasonable time).
+func TestSharedPollEpoch_FlipStorm_NoPanic_NoLeak(t *testing.T) {
+	t.Parallel()
+	opts := versionedSharedPollOpts()
+	node := newTestNodeWithSharedPoll(t, opts)
+	setupSharedPollHandlers(node)
+
+	// Publisher epoch atomic — handler reads it on each invocation. Models
+	// a well-behaved publisher whose direct publishes and refresh responses
+	// stay in lockstep.
+	var currentEpoch atomic.Pointer[string]
+	initial := "epochA"
+	currentEpoch.Store(&initial)
+	node.OnSharedPoll(func(_ context.Context, _ SharedPollEvent) (SharedPollResult, error) {
+		return SharedPollResult{Epoch: *currentEpoch.Load()}, nil
+	})
+
+	channel := "test:flip_storm"
+
+	// Subscribe a small set of clients — enough for the epoch-flip
+	// unsubscribe path to fire on each flip but not so many that the
+	// test bogs down under -race.
+	const numClients = 4
+	clients := make([]*Client, numClients)
+	for i := 0; i < numClients; i++ {
+		clients[i] = newTestClientV2(t, node, "u"+string(rune('A'+i)))
+		connectClientV2(t, clients[i])
+		subscribeSharedPollClient(t, clients[i], channel)
+		trackSharedPollClient(t, clients[i], channel,
+			[]*protocol.KeyedItem{{Key: "k", Version: 0}})
+	}
+
+	ctx := context.Background()
+	epochA := "epochA"
+	epochB := "epochB"
+
+	const flips = 200
+	for i := 0; i < flips; i++ {
+		var e string
+		if i%2 == 0 {
+			e = epochA
+		} else {
+			e = epochB
+		}
+		currentEpoch.Store(&e)
+		// Publish with the same epoch the handler currently returns.
+		// Pre-flip: subscribers get unsubscribed; re-subscribe path is
+		// not exercised here — we just want robustness of the flip path.
+		require.NoError(t, node.SharedPollPublish(ctx, channel, "k", uint64(i+1), e, []byte(`{}`)))
+	}
+
+	// Final state: channel epoch matches one of the two values used.
+	require.Eventually(t, func() bool {
+		e := node.sharedPollManager.Epoch(channel, false)
+		return e == epochA || e == epochB
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+// TestSharedPollEncodeFailureRollback_TODO documents that audit finding 5
+// (keyState.version rollback on subscribe-reply encode failure) is not
+// covered by an explicit test because the test transport / protocol pool
+// does not currently support injecting a reply-encode error.
+// getSubRefreshCommandReply unconditionally returns nil error (it acquires
+// from a pool), so the rollback branch in handleTrack is unreachable from
+// tests without production-side changes. Coverage of the rollback path
+// would require either:
+//   - exposing an encoder hook on the test transport, or
+//   - making getSubRefreshCommandReply fallible (e.g. via a marshal hook).
+//
+// Left as a TODO so the regression risk is visible. The fix is in
+// client_keyed.go handleTrack, lines 334-350 (rollback step on encode
+// error).
+func TestSharedPollEncodeFailureRollback_TODO(t *testing.T) {
+	t.Skip("encode failure cannot be injected without production hooks; see comment")
 }
 
 // TestSharedPollSubscribe_PresenceFlags covers the presence-flag branches

--- a/client_test.go
+++ b/client_test.go
@@ -231,9 +231,11 @@ func TestClientV2DisconnectNoPong(t *testing.T) {
 	transport.setPing(pingInterval, pongTimeout)
 	client := newTestClientCustomTransport(t, ctx, node, transport, "42")
 	connectClientV2(t, client)
+	// Disconnect should fire after pingInterval+pongTimeout=1.5s. Use a
+	// wide deadline so -race -count=N scheduler stretch doesn't flake.
 	select {
 	case <-done:
-	case <-time.After(pingInterval + pongTimeout + time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("no disconnect in timeout")
 	}
 }
@@ -2629,9 +2631,12 @@ func TestClientCloseExpired(t *testing.T) {
 	client.mu.RLock()
 	require.False(t, client.status == statusClosed)
 	client.mu.RUnlock()
+	// ExpireAt=+2s, but under -race -count=N scheduler stretch can push the
+	// close past 5s; use a wider deadline so we measure the right invariant
+	// (eventual close) without flaking on timing.
 	select {
 	case <-client.Context().Done():
-	case <-time.After(5 * time.Second):
+	case <-time.After(15 * time.Second):
 		require.Fail(t, "client not closed")
 	}
 	client.mu.RLock()
@@ -2990,8 +2995,10 @@ func TestServerSideRefresh(t *testing.T) {
 
 	connectClientV2(t, client)
 
+	// ExpireAt is +1s — refresh handler should fire shortly after expiry.
+	// Use a wider deadline so -race -count=N scheduler stretch doesn't flake.
 	select {
-	case <-time.After(5 * time.Second):
+	case <-time.After(15 * time.Second):
 		require.Fail(t, "timeout waiting for work done")
 	case <-done:
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -57,6 +57,7 @@ func newTestSubscribedClientWithTransport(t *testing.T, ctx context.Context, n *
 }
 
 func TestConnectRequestToProto(t *testing.T) {
+	t.Parallel()
 	r := ConnectRequest{
 		Token: "token",
 		Subs: map[string]SubscribeRequest{
@@ -74,6 +75,7 @@ func TestConnectRequestToProto(t *testing.T) {
 }
 
 func TestSetCredentials(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	newCtx := SetCredentials(ctx, &Credentials{})
 	val := newCtx.Value(credentialsContextKey).(*Credentials)
@@ -81,6 +83,7 @@ func TestSetCredentials(t *testing.T) {
 }
 
 func TestNewClient(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	transport := newTestTransport(func() {})
 	client, err := newClient(context.Background(), node, transport)
@@ -89,6 +92,7 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestClientInitialState(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	transport := newTestTransport(func() {})
@@ -103,6 +107,7 @@ func TestClientInitialState(t *testing.T) {
 }
 
 func TestClientClosedState(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	transport := newTestTransport(func() {})
@@ -113,6 +118,7 @@ func TestClientClosedState(t *testing.T) {
 }
 
 func TestClientTimer(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	node.config.ClientStaleCloseDelay = 25 * time.Second
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -125,6 +131,7 @@ func TestClientTimer(t *testing.T) {
 }
 
 func TestClientOnTimerOpClosedClient(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	client := newTestClient(t, node, "42")
@@ -135,6 +142,7 @@ func TestClientOnTimerOpClosedClient(t *testing.T) {
 }
 
 func TestClientUnsubscribeClosedClient(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	client := newTestClient(t, node, "42")
@@ -146,6 +154,7 @@ func TestClientUnsubscribeClosedClient(t *testing.T) {
 }
 
 func TestClientTimerSchedule(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	transport := newTestTransport(func() {})
@@ -164,6 +173,7 @@ func TestClientTimerSchedule(t *testing.T) {
 }
 
 func TestClientGetPingData(t *testing.T) {
+	t.Parallel()
 	data := getPingData(true, ProtocolTypeJSON)
 	require.Equal(t, jsonPingPush, data)
 	data = getPingData(false, ProtocolTypeJSON)
@@ -175,6 +185,7 @@ func TestClientGetPingData(t *testing.T) {
 }
 
 func TestClientV2TimerSchedule(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	client := newTestClientV2(t, node, "42")
@@ -212,15 +223,17 @@ func TestClientV2DisconnectNoPong(t *testing.T) {
 			close(done)
 		})
 	})
+	pingInterval := 1 * time.Second
+	pongTimeout := 500 * time.Millisecond
 	ctx, cancelFn := context.WithCancel(context.Background())
 	transport := newTestTransport(cancelFn)
 	transport.setProtocolVersion(ProtocolVersion2)
-	transport.setPing(2*time.Second, time.Second)
+	transport.setPing(pingInterval, pongTimeout)
 	client := newTestClientCustomTransport(t, ctx, node, transport, "42")
 	connectClientV2(t, client)
 	select {
 	case <-done:
-	case <-time.After(5 * time.Second):
+	case <-time.After(pingInterval + pongTimeout + time.Second):
 		t.Fatal("no disconnect in timeout")
 	}
 }
@@ -235,10 +248,12 @@ func TestClientV2PingPong(t *testing.T) {
 			close(done)
 		})
 	})
+	pingInterval := 1 * time.Second
+	pongTimeout := 500 * time.Millisecond
 	ctx, cancelFn := context.WithCancel(context.Background())
 	transport := newTestTransport(cancelFn)
 	transport.setProtocolVersion(ProtocolVersion2)
-	transport.setPing(2*time.Second, time.Second)
+	transport.setPing(pingInterval, pongTimeout)
 	messages := make(chan []byte)
 	transport.setSink(messages)
 	client := newTestClientCustomTransport(t, ctx, node, transport, "42")
@@ -251,10 +266,12 @@ func TestClientV2PingPong(t *testing.T) {
 		}
 	}()
 	connectClientV2(t, client)
+	// Wait at least one full ping-pong cycle so LatestPingPongLatency is set,
+	// then assert that no disconnect happened during that window.
 	select {
 	case <-done:
 		t.Fatal("unexpected disconnect, client must receive pong")
-	case <-time.After(4 * time.Second):
+	case <-time.After(pingInterval + pongTimeout + time.Second):
 	}
 	lat, ok := client.LatestPingPongLatency()
 	require.True(t, ok)
@@ -262,6 +279,7 @@ func TestClientV2PingPong(t *testing.T) {
 }
 
 func TestClientConnectNoCredentialsNoToken(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	transport := newTestTransport(func() {})
@@ -272,6 +290,7 @@ func TestClientConnectNoCredentialsNoToken(t *testing.T) {
 }
 
 func TestClientConnectContextCredentials(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	node.config.ClientConnectIncludeServerTime = true
@@ -296,6 +315,7 @@ func TestClientConnectContextCredentials(t *testing.T) {
 }
 
 func TestClientRefreshHandlerClosingExpiredClient(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -324,6 +344,7 @@ func TestClientRefreshHandlerClosingExpiredClient(t *testing.T) {
 }
 
 func TestClientRefreshHandlerProlongsClientSession(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -354,6 +375,7 @@ func TestClientRefreshHandlerProlongsClientSession(t *testing.T) {
 }
 
 func TestClientConnectWithExpiredContextCredentials(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -395,6 +417,7 @@ func subscribeClientV2(t testing.TB, client *Client, ch string) *protocol.Subscr
 }
 
 func TestClientSubscribe(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -524,6 +547,7 @@ func TestClientSubscribeBrokerErrorOnStreamTop(t *testing.T) {
 }
 
 func TestClientSubscribeUnrecoverablePosition(t *testing.T) {
+	t.Parallel()
 	broker := NewTestBroker()
 	node := nodeWithBroker(broker)
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -556,6 +580,7 @@ func TestClientSubscribeUnrecoverablePosition(t *testing.T) {
 }
 
 func TestClientSubscribeRejectUnrecovered(t *testing.T) {
+	t.Parallel()
 	// When the client sets subscriptionFlagRejectUnrecovered, the server
 	// should return ErrorUnrecoverablePosition instead of subscribing
 	// with recovered=false.
@@ -602,6 +627,7 @@ func TestClientSubscribeRejectUnrecovered(t *testing.T) {
 }
 
 func TestClientSubscribeRejectUnrecovered_SuccessfulRecovery(t *testing.T) {
+	t.Parallel()
 	// When recovery succeeds, the flag should not interfere — normal result.
 	node := nodeWithTestBroker()
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -682,6 +708,7 @@ func TestClientSubscribePositionedError(t *testing.T) {
 }
 
 func TestClientSubscribePositioned(t *testing.T) {
+	t.Parallel()
 	node := nodeWithTestBroker()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -745,6 +772,7 @@ func TestClientSubscribeBrokerErrorOnRecoverHistory(t *testing.T) {
 }
 
 func TestClientSubscribeDeltaNotAllowed(t *testing.T) {
+	t.Parallel()
 	n := defaultTestNode()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -767,6 +795,7 @@ func TestClientSubscribeDeltaNotAllowed(t *testing.T) {
 }
 
 func TestClientSubscribeUnknownDelta(t *testing.T) {
+	t.Parallel()
 	n := deltaTestNode()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -826,6 +855,7 @@ func testUnexpectedOffsetEpochProtocolV2(t *testing.T, offset uint64, epoch stri
 }
 
 func TestClientUnexpectedOffsetEpochClientV2(t *testing.T) {
+	// Helper testUnexpectedOffsetEpochProtocolV2 calls t.Parallel() itself.
 	// Only wrong_offset triggers insufficient state. The "wrong_epoch" case
 	// (channel epoch="" + pub epoch="xyz") now adopts the epoch instead of
 	// disconnecting — this supports subscribing via a lagging read replica
@@ -835,6 +865,7 @@ func TestClientUnexpectedOffsetEpochClientV2(t *testing.T) {
 }
 
 func TestClientSubscribeValidateErrors(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	node.config.ClientChannelLimit = 1
 	node.config.ChannelMaxLength = 10
@@ -1002,6 +1033,7 @@ func TestClientSubscribeReceivePublicationWithOffset(t *testing.T) {
 }
 
 func TestUserConnectionLimit(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	node.config.UserConnectionLimit = 1
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -1362,6 +1394,7 @@ func TestClientRefreshExpireAtInThePast(t *testing.T) {
 }
 
 func TestClient_IsSubscribed(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1378,6 +1411,7 @@ func TestClient_IsSubscribed(t *testing.T) {
 }
 
 func TestClientSubscribeLast(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1699,6 +1733,7 @@ func testReplyWriterWrapper() *sliceReplyWriter {
 }
 
 func TestClientRefreshNotAvailable(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	client := newTestClient(t, node, "42")
@@ -1711,6 +1746,7 @@ func TestClientRefreshNotAvailable(t *testing.T) {
 }
 
 func TestClientRefreshEmptyToken(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1736,6 +1772,7 @@ func TestClientRefreshEmptyToken(t *testing.T) {
 }
 
 func TestClientRefreshUnexpected(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1761,6 +1798,7 @@ func TestClientRefreshUnexpected(t *testing.T) {
 }
 
 func TestClientPublishNotAvailable(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	client := newTestClient(t, node, "42")
@@ -1912,6 +1950,7 @@ func TestClientPublishHandler(t *testing.T) {
 }
 
 func TestClientPublishError(t *testing.T) {
+	t.Parallel()
 	broker := NewTestBroker()
 	broker.errorOnPublish = true
 	node := nodeWithBroker(broker)
@@ -1938,6 +1977,7 @@ func TestClientPublishError(t *testing.T) {
 }
 
 func TestClientPing(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	client := newTestClient(t, node, "42")
@@ -1950,6 +1990,7 @@ func TestClientPing(t *testing.T) {
 }
 
 func TestClientPresence(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2002,6 +2043,7 @@ func TestClientPresence(t *testing.T) {
 }
 
 func TestClientPresenceTakeover(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2049,6 +2091,7 @@ func TestClientPresenceTakeover(t *testing.T) {
 }
 
 func TestClientPresenceError(t *testing.T) {
+	t.Parallel()
 	presenceManager := NewTestPresenceManager()
 	presenceManager.errorOnPresence = true
 	node := nodeWithPresenceManager(presenceManager)
@@ -2073,6 +2116,7 @@ func TestClientPresenceError(t *testing.T) {
 }
 
 func TestClientPresenceNotAvailable(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2089,6 +2133,7 @@ func TestClientPresenceNotAvailable(t *testing.T) {
 }
 
 func TestClientSubscribeNotAvailable(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2104,6 +2149,7 @@ func TestClientSubscribeNotAvailable(t *testing.T) {
 }
 
 func TestClientPresenceStatsNotAvailable(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2120,6 +2166,7 @@ func TestClientPresenceStatsNotAvailable(t *testing.T) {
 }
 
 func TestClientPresenceStatsError(t *testing.T) {
+	t.Parallel()
 	presenceManager := NewTestPresenceManager()
 	presenceManager.errorOnPresenceStats = true
 	node := nodeWithPresenceManager(presenceManager)
@@ -2144,6 +2191,7 @@ func TestClientPresenceStatsError(t *testing.T) {
 }
 
 func TestClientHistoryNoFilter(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2182,6 +2230,7 @@ func TestClientHistoryNoFilter(t *testing.T) {
 }
 
 func TestClientHistoryWithLimit(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2215,6 +2264,7 @@ func TestClientHistoryWithLimit(t *testing.T) {
 }
 
 func TestClientHistoryWithSinceAndLimit(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2254,6 +2304,7 @@ func TestClientHistoryWithSinceAndLimit(t *testing.T) {
 }
 
 func TestClientHistoryTakeover(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	node.config.HistoryMaxPublicationLimit = 2
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -2293,6 +2344,7 @@ func TestClientHistoryTakeover(t *testing.T) {
 }
 
 func TestClientHistoryUnrecoverablePositionEpoch(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2330,6 +2382,7 @@ func TestClientHistoryUnrecoverablePositionEpoch(t *testing.T) {
 }
 
 func TestClientHistoryBrokerError(t *testing.T) {
+	t.Parallel()
 	broker := NewTestBroker()
 	broker.errorOnHistory = true
 	node := nodeWithBroker(broker)
@@ -2354,6 +2407,7 @@ func TestClientHistoryBrokerError(t *testing.T) {
 }
 
 func TestClientHistoryNotAvailable(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2468,6 +2522,7 @@ func TestClientHandleCommandNotAuthenticated(t *testing.T) {
 }
 
 func TestClientHandleUnknownMethod(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2525,6 +2580,7 @@ func TestClientHandleCommandWithoutID(t *testing.T) {
 }
 
 func TestErrorDisconnectContext(t *testing.T) {
+	t.Parallel()
 	ctx := errorDisconnectContext(nil, &DisconnectForceReconnect)
 	require.Nil(t, ctx.err)
 	require.Equal(t, DisconnectForceReconnect.Code, ctx.disconnect.Code)
@@ -2534,6 +2590,7 @@ func TestErrorDisconnectContext(t *testing.T) {
 }
 
 func TestToClientError(t *testing.T) {
+	t.Parallel()
 	require.Equal(t, ErrorInternal, toClientErr(errors.New("boom")))
 	require.Equal(t, ErrorLimitExceeded, toClientErr(ErrorLimitExceeded))
 }
@@ -2583,6 +2640,7 @@ func TestClientCloseExpired(t *testing.T) {
 }
 
 func TestClientInfo(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2598,6 +2656,7 @@ func TestClientInfo(t *testing.T) {
 }
 
 func TestClientConnectExpiredError(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2613,6 +2672,7 @@ func TestClientConnectExpiredError(t *testing.T) {
 }
 
 func TestClientPresenceUpdate(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2677,6 +2737,7 @@ func TestClientSubExpired(t *testing.T) {
 }
 
 func TestClientSend(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2696,6 +2757,7 @@ func TestClientSend(t *testing.T) {
 }
 
 func TestClientClose(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2709,6 +2771,7 @@ func TestClientClose(t *testing.T) {
 }
 
 func TestClientHandleRPCNotAvailable(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2724,6 +2787,7 @@ func TestClientHandleRPCNotAvailable(t *testing.T) {
 }
 
 func TestClientHandleRPC(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2753,6 +2817,7 @@ func TestClientHandleRPC(t *testing.T) {
 }
 
 func TestClientHandleSendNoHandlerSet(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	client := newTestClient(t, node, "42")
@@ -2764,6 +2829,7 @@ func TestClientHandleSendNoHandlerSet(t *testing.T) {
 }
 
 func TestClientHandleSend(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2786,6 +2852,7 @@ func TestClientHandleSend(t *testing.T) {
 }
 
 func TestClientHandlePublishNotAllowed(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2810,6 +2877,7 @@ func TestClientHandlePublishNotAllowed(t *testing.T) {
 }
 
 func TestClientHandlePublish(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -2843,6 +2911,7 @@ func TestClientHandlePublish(t *testing.T) {
 }
 
 func TestClientSideRefresh(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -3036,6 +3105,7 @@ func TestServerSideRefreshCustomError(t *testing.T) {
 }
 
 func TestClientSideSubRefresh(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -3114,6 +3184,7 @@ func TestClientSideSubRefresh(t *testing.T) {
 }
 
 func TestClientSideSubRefreshUnexpected(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -3185,6 +3256,7 @@ func TestCloseNoRace(t *testing.T) {
 }
 
 func TestClientCheckSubscriptionExpiration(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -3273,6 +3345,7 @@ func TestClientCheckSubscriptionExpiration(t *testing.T) {
 }
 
 func TestClientCheckPosition(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -3309,6 +3382,7 @@ func TestClientCheckPosition(t *testing.T) {
 }
 
 func TestErrLogLevel(t *testing.T) {
+	t.Parallel()
 	require.Equal(t, LogLevelInfo, errLogLevel(ErrorNotAvailable))
 	require.Equal(t, LogLevelError, errLogLevel(errors.New("boom")))
 }
@@ -3392,16 +3466,19 @@ func TestClientTransportWriteError(t *testing.T) {
 }
 
 func TestFlagExists(t *testing.T) {
+	t.Parallel()
 	flags := PushFlagDisconnect
 	require.True(t, hasFlag(flags, PushFlagDisconnect))
 }
 
 func TestFlagNotExists(t *testing.T) {
+	t.Parallel()
 	var flags uint64
 	require.False(t, hasFlag(flags, PushFlagDisconnect))
 }
 
 func TestConcurrentSameChannelSubscribe(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -3484,6 +3561,7 @@ func (b *slowHistoryBroker) History(ch string, opts HistoryOptions) ([]*Publicat
 }
 
 func TestSubscribeWithBufferedPublications(t *testing.T) {
+	t.Parallel()
 	node, err := New(Config{
 		LogLevel:   LogLevelTrace,
 		LogHandler: func(entry LogEntry) {},
@@ -3538,6 +3616,7 @@ func TestSubscribeWithBufferedPublications(t *testing.T) {
 }
 
 func TestClientChannelsWhileSubscribing(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -3572,6 +3651,7 @@ func TestClientChannelsWhileSubscribing(t *testing.T) {
 }
 
 func TestClientChannelsCleanupOnSubscribeError(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -3593,6 +3673,7 @@ func TestClientChannelsCleanupOnSubscribeError(t *testing.T) {
 }
 
 func TestClientChannelsCleanupOnSubscribeDisconnect(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -3614,6 +3695,7 @@ func TestClientChannelsCleanupOnSubscribeDisconnect(t *testing.T) {
 }
 
 func TestClientSubscribingChannelsCleanupOnClientClose(t *testing.T) {
+	t.Parallel()
 	node, err := New(Config{
 		LogLevel:   LogLevelTrace,
 		LogHandler: func(entry LogEntry) {},
@@ -3664,6 +3746,7 @@ func TestClientSubscribingChannelsCleanupOnClientClose(t *testing.T) {
 }
 
 func TestClientSubscribingChannelsCleanupOnHistoryError(t *testing.T) {
+	t.Parallel()
 	node, err := New(Config{
 		LogLevel:   LogLevelTrace,
 		LogHandler: func(entry LogEntry) {},
@@ -3706,6 +3789,7 @@ func TestClientSubscribingChannelsCleanupOnHistoryError(t *testing.T) {
 }
 
 func TestClientOnStateSnapshot(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -3750,6 +3834,7 @@ func decodeReply(t *testing.T, protoType protocol.Type, data []byte) *protocol.R
 }
 
 func TestClientV2ReplyConstruction(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	clientV2 := newTestClientV2(t, node, "42")
@@ -3820,6 +3905,7 @@ func TestClientV2ReplyConstruction(t *testing.T) {
 }
 
 func TestClient_HandleCommandV2_UnnecessaryPong(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	clientV2 := newTestClientV2(t, node, "42")
@@ -3832,6 +3918,7 @@ func TestClient_HandleCommandV2_UnnecessaryPong(t *testing.T) {
 }
 
 func TestClient_HandleCommandV2_Pong(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	clientV2 := newTestClientV2(t, node, "42")
@@ -3847,6 +3934,7 @@ func TestClient_HandleCommandV2_Pong(t *testing.T) {
 }
 
 func TestClient_HandleCommandV2_NonAuthenticated(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	clientV2 := newTestClientV2(t, node, "42")
@@ -3863,11 +3951,17 @@ func TestClientLevelPing(t *testing.T) {
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	done := make(chan struct{})
+	// Short ping/pong durations so the test finishes quickly. First ping fires
+	// in [PingInterval/2, PingInterval], then PongTimeout starts before
+	// DisconnectNoPong. The test purpose (disconnect after ping+pong window
+	// when no pong arrives) is duration-agnostic.
+	pingInterval := 1 * time.Second
+	pongTimeout := 500 * time.Millisecond
 	node.OnConnecting(func(context.Context, ConnectEvent) (ConnectReply, error) {
 		return ConnectReply{
 			PingPongConfig: &PingPongConfig{
-				PingInterval: 5 * time.Second,
-				PongTimeout:  3 * time.Second,
+				PingInterval: pingInterval,
+				PongTimeout:  pongTimeout,
 			},
 		}, nil
 	})
@@ -3885,7 +3979,7 @@ func TestClientLevelPing(t *testing.T) {
 	connectClientV2(t, client)
 	select {
 	case <-done:
-	case <-time.After(9 * time.Second):
+	case <-time.After(pingInterval + pongTimeout + time.Second):
 		t.Fatal("no disconnect in timeout")
 	}
 }
@@ -3919,6 +4013,7 @@ func TestNoClientLevelPing(t *testing.T) {
 }
 
 func TestClient_HandleCommandV2(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -4266,6 +4361,7 @@ func TestClientConnect(t *testing.T) {
 }
 
 func TestRedactCommand(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    *protocol.Command
@@ -4340,6 +4436,7 @@ func TestRedactCommand(t *testing.T) {
 }
 
 func TestWrappedDisconnect(t *testing.T) {
+	t.Parallel()
 	t.Run("Pointer to Disconnect no wrap", func(t *testing.T) {
 		originalDisconnect := &Disconnect{
 			Code:   1001,
@@ -4444,12 +4541,14 @@ func BenchmarkClientRPC(b *testing.B) {
 }
 
 func TestMaxTTLSeconds(t *testing.T) {
+	t.Parallel()
 	// Test that maxTTLSeconds is correctly set to 1 year
 	expectedMaxTTL := 365 * 24 * 3600
 	require.Equal(t, expectedMaxTTL, maxTTLSeconds)
 }
 
 func TestClientExpireTTLCapping(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -4484,6 +4583,7 @@ func TestClientExpireTTLCapping(t *testing.T) {
 }
 
 func TestConnectTTLCapping(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -4517,6 +4617,7 @@ func TestConnectTTLCapping(t *testing.T) {
 }
 
 func TestTagsFilter_SubscribeValidation(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -4624,6 +4725,7 @@ func TestTagsFilter_SubscribeValidation(t *testing.T) {
 }
 
 func TestTagsFilter_EndToEndFiltering(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -4698,6 +4800,7 @@ func TestTagsFilter_EndToEndFiltering(t *testing.T) {
 }
 
 func TestTagsFilter_RecoverCache(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -4767,6 +4870,7 @@ func TestTagsFilter_RecoverCache(t *testing.T) {
 }
 
 func TestTagsFilter_RecoverStream(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -4846,6 +4950,7 @@ func TestTagsFilter_RecoverStream(t *testing.T) {
 }
 
 func TestClient_RecoverCache(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 

--- a/client_test.go
+++ b/client_test.go
@@ -3907,10 +3907,14 @@ func TestNoClientLevelPing(t *testing.T) {
 	transport.setPing(-1, 0)
 	client := newTestClientCustomTransport(t, ctx, node, transport, "42")
 	connectClientV2(t, client)
+	// Wait must exceed defaultPingInterval+defaultPongTimeout so a regression
+	// where the -1 disable falls through to defaults would still produce a
+	// disconnect within the window. Test-init shrinks the defaults to a few
+	// hundred ms (see config_test.go); production keeps 25s/10s.
 	select {
 	case <-done:
 		t.Fatal("should not disconnect when ping is disabled")
-	case <-time.After(36 * time.Second):
+	case <-time.After(defaultPingInterval + defaultPongTimeout + 200*time.Millisecond):
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -412,18 +412,27 @@ type PingPongConfig struct {
 	PongTimeout time.Duration
 }
 
+// Defaults applied by getPingPongPeriodValues when callers pass a zero value
+// (the "use library default" sentinel). Declared as vars rather than inline
+// constants so test binaries can override them in an init() hook to keep the
+// test suite fast — production behavior is unchanged.
+var (
+	defaultPingInterval = 25 * time.Second
+	defaultPongTimeout  = 10 * time.Second
+)
+
 func getPingPongPeriodValues(config PingPongConfig) (time.Duration, time.Duration) {
 	pingInterval := config.PingInterval
 	if pingInterval < 0 {
 		pingInterval = 0
 	} else if pingInterval == 0 {
-		pingInterval = 25 * time.Second
+		pingInterval = defaultPingInterval
 	}
 	pongTimeout := config.PongTimeout
 	if pongTimeout < 0 {
 		pongTimeout = 0
 	} else if pongTimeout == 0 {
-		pongTimeout = 10 * time.Second
+		pongTimeout = defaultPongTimeout
 	}
 	return pingInterval, pongTimeout
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,16 @@
+package centrifuge
+
+import "time"
+
+// init shrinks the ping/pong defaults to test-friendly values so tests that
+// pay the "wait past the default disconnect window" tax (e.g. verifying that
+// PingPongConfig{-1, 0} actually disables pings rather than silently falling
+// back to 25s) finish in milliseconds instead of tens of seconds.
+//
+// Production builds use the literals defined in config.go (25s / 10s). This
+// override applies only to the test binary because _test.go files are not
+// included in non-test builds.
+func init() {
+	defaultPingInterval = 1000 * time.Millisecond
+	defaultPongTimeout = 500 * time.Millisecond
+}

--- a/handler_websocket_test.go
+++ b/handler_websocket_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestWebsocketHandler(t *testing.T) {
+	t.Parallel()
 	n, _ := New(Config{})
 	require.NoError(t, n.Run())
 	defer func() { _ = n.Shutdown(context.Background()) }()
@@ -48,6 +49,7 @@ func TestWebsocketHandler(t *testing.T) {
 }
 
 func TestWebsocketHandlerProtocolV2(t *testing.T) {
+	t.Parallel()
 	n, _ := New(Config{})
 	require.NoError(t, n.Run())
 	defer func() { _ = n.Shutdown(context.Background()) }()
@@ -73,6 +75,7 @@ func TestWebsocketHandlerProtocolV2(t *testing.T) {
 }
 
 func TestWebsocketHandlerSubprotocol(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -104,6 +107,7 @@ func TestWebsocketHandlerSubprotocol(t *testing.T) {
 }
 
 func TestWebsocketHandlerURLParams(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -136,6 +140,7 @@ func TestWebsocketHandlerURLParams(t *testing.T) {
 }
 
 func TestWebsocketTransportWrite(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -175,6 +180,7 @@ func TestWebsocketTransportWrite(t *testing.T) {
 }
 
 func TestWebsocketTransportWriteMany(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -235,6 +241,7 @@ func waitWithTimeout(t *testing.T, ch chan struct{}) {
 }
 
 func TestWebsocketHandlerProtobuf(t *testing.T) {
+	t.Parallel()
 	n, _ := New(Config{})
 	require.NoError(t, n.Run())
 	defer func() { _ = n.Shutdown(context.Background()) }()
@@ -259,6 +266,7 @@ func TestWebsocketHandlerProtobuf(t *testing.T) {
 }
 
 func TestWebsocketHandlerPing(t *testing.T) {
+	t.Parallel()
 	n, _ := New(Config{})
 	require.NoError(t, n.Run())
 	defer func() { _ = n.Shutdown(context.Background()) }()
@@ -373,6 +381,7 @@ func TestWebsocketHandler_FramePingPong(t *testing.T) {
 }
 
 func TestWebsocketHandlerCustomDisconnect(t *testing.T) {
+	t.Parallel()
 	n, _ := New(Config{})
 	require.NoError(t, n.Run())
 	defer func() { _ = n.Shutdown(context.Background()) }()
@@ -431,6 +440,7 @@ func testAuthMiddleware(h http.Handler) http.Handler {
 // TestWebsocketHandlerConcurrentConnections allows catching errors related
 // to invalid buffer pool usages.
 func TestWebsocketHandlerConcurrentConnections(t *testing.T) {
+	t.Parallel()
 	n := defaultTestNode()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -506,6 +516,7 @@ func TestWebsocketHandlerConcurrentConnections(t *testing.T) {
 }
 
 func TestWebsocketHandlerConnectionsBroadcast(t *testing.T) {
+	t.Parallel()
 	n := defaultTestNode()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -802,6 +813,7 @@ func BenchmarkWsPubSub(b *testing.B) {
 }
 
 func TestWsBroadcastCompressionCache(t *testing.T) {
+	t.Parallel()
 	n := defaultTestNode()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 

--- a/handler_websocket_test.go
+++ b/handler_websocket_test.go
@@ -443,6 +443,15 @@ func TestWebsocketHandlerConcurrentConnections(t *testing.T) {
 	t.Parallel()
 	n := defaultTestNode()
 	defer func() { _ = n.Shutdown(context.Background()) }()
+	// This test stresses the buffer pool with 100 concurrent connections; the
+	// default test-init pong timeout (500ms) is too tight when -race + parallel
+	// suite contention stretches read scheduling. Disable pings/pongs entirely
+	// — they are unrelated to the buffer-pool invariant under test.
+	n.OnConnecting(func(_ context.Context, _ ConnectEvent) (ConnectReply, error) {
+		return ConnectReply{
+			PingPongConfig: &PingPongConfig{PingInterval: -1},
+		}, nil
+	})
 
 	mux := http.NewServeMux()
 	mux.Handle("/connection/websocket", testAuthMiddleware(NewWebsocketHandler(n, WebsocketConfig{
@@ -519,6 +528,15 @@ func TestWebsocketHandlerConnectionsBroadcast(t *testing.T) {
 	t.Parallel()
 	n := defaultTestNode()
 	defer func() { _ = n.Shutdown(context.Background()) }()
+	// Same rationale as TestWebsocketHandlerConcurrentConnections: 100
+	// concurrent connections under -race stretch read scheduling past
+	// the test-init 500 ms pong timeout. The test asserts buffer-pool
+	// invariants, not ping/pong behavior, so disable pings for this run.
+	n.OnConnecting(func(_ context.Context, _ ConnectEvent) (ConnectReply, error) {
+		return ConnectReply{
+			PingPongConfig: &PingPongConfig{PingInterval: -1},
+		}, nil
+	})
 
 	mux := http.NewServeMux()
 	mux.Handle("/connection/websocket", testAuthMiddleware(NewWebsocketHandler(n, WebsocketConfig{

--- a/hub_test.go
+++ b/hub_test.go
@@ -157,6 +157,7 @@ func (t *testTransport) Close(disconnect Disconnect) error {
 }
 
 func TestHub(t *testing.T) {
+	t.Parallel()
 	m, err := newMetricsRegistry(MetricsConfig{
 		MetricsNamespace: "test",
 	})
@@ -187,6 +188,7 @@ func TestHub(t *testing.T) {
 }
 
 func TestHubUnsubscribe(t *testing.T) {
+	t.Parallel()
 	n := defaultTestNode()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -219,6 +221,7 @@ LOOP:
 }
 
 func TestHubDisconnect(t *testing.T) {
+	t.Parallel()
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -283,6 +286,7 @@ func TestHubDisconnect(t *testing.T) {
 }
 
 func TestHubDisconnect_ClientWhitelist(t *testing.T) {
+	t.Parallel()
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -451,6 +455,7 @@ func TestHubOperationsWithSessionID(t *testing.T) {
 }
 
 func TestHubBroadcastPublication(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name            string
 		protocolType    ProtocolType
@@ -565,6 +570,7 @@ func subscribeClientDelta(t testing.TB, client *Client, ch string, deltaType Del
 }
 
 func TestHubBroadcastPublicationDelta(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name            string
 		protocolType    ProtocolType
@@ -646,6 +652,7 @@ func TestHubBroadcastPublicationDelta(t *testing.T) {
 }
 
 func TestHubBroadcastPublicationDeltaAtMostOnce(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name            string
 		protocolType    ProtocolType
@@ -726,6 +733,7 @@ func TestHubBroadcastPublicationDeltaAtMostOnce(t *testing.T) {
 }
 
 func TestHubBroadcastPublicationDeltaAtMostOnceNoOffset(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name            string
 		protocolType    ProtocolType
@@ -804,6 +812,7 @@ func TestHubBroadcastPublicationDeltaAtMostOnceNoOffset(t *testing.T) {
 }
 
 func TestHubBroadcastJoin(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name            string
 		protocolType    ProtocolType
@@ -855,6 +864,7 @@ func TestHubBroadcastJoin(t *testing.T) {
 }
 
 func TestHubBroadcastLeave(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name            string
 		protocolType    ProtocolType
@@ -906,6 +916,7 @@ func TestHubBroadcastLeave(t *testing.T) {
 }
 
 func TestHubShutdown(t *testing.T) {
+	t.Parallel()
 	m, err := newMetricsRegistry(MetricsConfig{
 		MetricsNamespace: "test",
 	})
@@ -928,6 +939,7 @@ func TestHubShutdown(t *testing.T) {
 }
 
 func TestHubSubscriptions(t *testing.T) {
+	t.Parallel()
 	m, err := newMetricsRegistry(MetricsConfig{
 		MetricsNamespace: "test",
 	})
@@ -973,6 +985,7 @@ func TestHubSubscriptions(t *testing.T) {
 }
 
 func TestUserConnections(t *testing.T) {
+	t.Parallel()
 	m, err := newMetricsRegistry(MetricsConfig{
 		MetricsNamespace: "test",
 	})
@@ -987,6 +1000,7 @@ func TestUserConnections(t *testing.T) {
 }
 
 func TestHubSharding(t *testing.T) {
+	t.Parallel()
 	numUsers := numHubShards * 10
 	numChannels := numHubShards * 10
 
@@ -1128,6 +1142,7 @@ func BenchmarkHub_MassiveBroadcast(b *testing.B) {
 }
 
 func TestHubBroadcastInappropriateProtocol_Publication(t *testing.T) {
+	t.Parallel()
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -1157,6 +1172,7 @@ func TestHubBroadcastInappropriateProtocol_Publication(t *testing.T) {
 }
 
 func TestHubBroadcastInappropriateProtocol_Join(t *testing.T) {
+	t.Parallel()
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -1186,6 +1202,7 @@ func TestHubBroadcastInappropriateProtocol_Join(t *testing.T) {
 }
 
 func TestHubBroadcastInappropriateProtocol_Leave(t *testing.T) {
+	t.Parallel()
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -1300,6 +1317,7 @@ var testNewJsonData = []byte(`{
 }`)
 
 func TestJsonStringEncode(t *testing.T) {
+	t.Parallel()
 	testBenchmarkDeltaFossilPatch = fdelta.Create(testJsonData, testNewJsonData)
 	if len(testBenchmarkDeltaFossilPatch) == 0 {
 		t.Fatal("empty fossil patch")
@@ -1336,6 +1354,7 @@ func BenchmarkDeltaFossil(b *testing.B) {
 }
 
 func TestSubIDUniquenessAcrossShards(t *testing.T) {
+	t.Parallel()
 	m, err := newMetricsRegistry(MetricsConfig{
 		MetricsNamespace: "test",
 	})
@@ -1418,6 +1437,7 @@ func TestSubIDUniquenessAcrossShards(t *testing.T) {
 }
 
 func TestSubIDShardDistribution(t *testing.T) {
+	t.Parallel()
 	m, err := newMetricsRegistry(MetricsConfig{
 		MetricsNamespace: "test",
 	})
@@ -1480,6 +1500,7 @@ func TestSubIDShardDistribution(t *testing.T) {
 }
 
 func TestCompressedChannelBroadcast(t *testing.T) {
+	t.Parallel()
 	n := defaultTestNode()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -1537,6 +1558,7 @@ func TestCompressedChannelBroadcast(t *testing.T) {
 }
 
 func TestUseIDSubscribersSameMessages(t *testing.T) {
+	t.Parallel()
 	n := defaultTestNode()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -1625,6 +1647,7 @@ OUTER2:
 }
 
 func TestUseIDSubscribersDifferentMessages(t *testing.T) {
+	t.Parallel()
 	n := defaultTestNode()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -1714,6 +1737,7 @@ OUTER2:
 }
 
 func TestDeltaPublicationsWithCompressedChannels(t *testing.T) {
+	t.Parallel()
 	n := defaultTestNode()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -1822,6 +1846,7 @@ OUTER2:
 }
 
 func TestGetDeltaPubPreservesMapFields(t *testing.T) {
+	t.Parallel()
 	fullPub := &protocol.Publication{
 		Offset:  10,
 		Data:    []byte(`{"name":"alice"}`),
@@ -1884,6 +1909,7 @@ func TestGetDeltaPubPreservesMapFields(t *testing.T) {
 }
 
 func TestEscapeStateForDelta(t *testing.T) {
+	t.Parallel()
 	pubs := []*protocol.Publication{
 		{Offset: 1, Key: "a", Data: []byte(`{"x":1}`), Score: 10},
 		{Offset: 2, Key: "b", Data: []byte(`{"y":2}`), Score: 20, Removed: true},
@@ -1921,6 +1947,7 @@ func TestEscapeStateForDelta(t *testing.T) {
 }
 
 func TestBroadcastMapPublicationDelta(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		name            string
 		protocolType    ProtocolType
@@ -2066,6 +2093,7 @@ func TestBroadcastMapPublicationDelta(t *testing.T) {
 }
 
 func TestCompressedJoinMessages(t *testing.T) {
+	t.Parallel()
 	n := defaultTestNode()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -2180,6 +2208,7 @@ OUTER2:
 }
 
 func TestCompressedLeaveMessages(t *testing.T) {
+	t.Parallel()
 	n := defaultTestNode()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 

--- a/internal/readerpool/pool.go
+++ b/internal/readerpool/pool.go
@@ -10,7 +10,7 @@ var stringReaderPool sync.Pool
 
 // GetStringReader from pool.
 func GetStringReader(data string) *strings.Reader {
-	r := bytesReaderPool.Get()
+	r := stringReaderPool.Get()
 	if r == nil {
 		return strings.NewReader(data)
 	}

--- a/keyed_hub_test.go
+++ b/keyed_hub_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestKeyedHub_AddRemoveSubscriber(t *testing.T) {
+	t.Parallel()
 	hub := newKeyedHub()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -25,6 +26,7 @@ func TestKeyedHub_AddRemoveSubscriber(t *testing.T) {
 }
 
 func TestKeyedHub_MultipleKeys(t *testing.T) {
+	t.Parallel()
 	hub := newKeyedHub()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -45,6 +47,7 @@ func TestKeyedHub_MultipleKeys(t *testing.T) {
 }
 
 func TestKeyedHub_MultipleSubscribers(t *testing.T) {
+	t.Parallel()
 	hub := newKeyedHub()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -69,6 +72,7 @@ func TestKeyedHub_MultipleSubscribers(t *testing.T) {
 }
 
 func TestKeyedHub_SubscriberCount(t *testing.T) {
+	t.Parallel()
 	hub := newKeyedHub()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -81,6 +85,7 @@ func TestKeyedHub_SubscriberCount(t *testing.T) {
 }
 
 func TestKeyedHub_AllKeys(t *testing.T) {
+	t.Parallel()
 	hub := newKeyedHub()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -98,6 +103,7 @@ func TestKeyedHub_AllKeys(t *testing.T) {
 }
 
 func TestKeyedHub_RemoveAllSubscribers(t *testing.T) {
+	t.Parallel()
 	hub := newKeyedHub()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -115,6 +121,7 @@ func TestKeyedHub_RemoveAllSubscribers(t *testing.T) {
 }
 
 func TestKeyedHub_Subscribers(t *testing.T) {
+	t.Parallel()
 	hub := newKeyedHub()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -132,6 +139,7 @@ func TestKeyedHub_Subscribers(t *testing.T) {
 }
 
 func TestKeyedHub_NumKeys(t *testing.T) {
+	t.Parallel()
 	hub := newKeyedHub()
 	require.Equal(t, 0, hub.numKeys())
 
@@ -148,6 +156,7 @@ func TestKeyedHub_NumKeys(t *testing.T) {
 }
 
 func TestKeyedHub_BroadcastRemovalToUsers(t *testing.T) {
+	t.Parallel()
 	hub := newKeyedHub()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -176,6 +185,7 @@ func TestKeyedHub_BroadcastRemovalToUsers(t *testing.T) {
 }
 
 func TestKeyedHub_RemoveSubscribersForUsers_Exclude(t *testing.T) {
+	t.Parallel()
 	hub := newKeyedHub()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -206,6 +216,7 @@ func TestKeyedHub_RemoveSubscribersForUsers_Exclude(t *testing.T) {
 // TestKeyedHub_RemoveSubscribersForUsers_MissingKey covers the early-return
 // branch when the requested key has no subscribers in the hub.
 func TestKeyedHub_RemoveSubscribersForUsers_MissingKey(t *testing.T) {
+	t.Parallel()
 	hub := newKeyedHub()
 	// No-op against a hub that has no entry for "missing-key".
 	require.NotPanics(t, func() {
@@ -216,6 +227,7 @@ func TestKeyedHub_RemoveSubscribersForUsers_MissingKey(t *testing.T) {
 // TestKeyedHub_RemoveSubscribersForUsers_DeletesEmptyKey covers the branch
 // where every subscriber is removed and the key entry itself is deleted.
 func TestKeyedHub_RemoveSubscribersForUsers_DeletesEmptyKey(t *testing.T) {
+	t.Parallel()
 	hub := newKeyedHub()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -237,6 +249,7 @@ func TestKeyedHub_RemoveSubscribersForUsers_DeletesEmptyKey(t *testing.T) {
 // TestKeyedHub_BroadcastRemovalToUsers_NoTargets covers the early-return when
 // the key has no subscribers at all.
 func TestKeyedHub_BroadcastRemovalToUsers_NoTargets(t *testing.T) {
+	t.Parallel()
 	hub := newKeyedHub()
 	require.NotPanics(t, func() {
 		hub.broadcastRemovalToUsers("ch", "k", []string{"user1"}, nil)
@@ -247,6 +260,7 @@ func TestKeyedHub_BroadcastRemovalToUsers_NoTargets(t *testing.T) {
 // allKeys when the same client is registered under multiple keys — each unique
 // client-id should appear once in the returned set.
 func TestKeyedHub_AllKeys_DedupsAcrossKeys(t *testing.T) {
+	t.Parallel()
 	hub := newKeyedHub()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()

--- a/logging_test.go
+++ b/logging_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestLogLevelToString(t *testing.T) {
+	t.Parallel()
 	level := LogLevelToString(LogLevelDebug)
 	require.Equal(t, "debug", level)
 }
@@ -20,6 +21,7 @@ func (h *testHandler) Handle(_ LogEntry) {
 }
 
 func TestLogger(t *testing.T) {
+	t.Parallel()
 	h := testHandler{}
 	l := newLogger(LogLevelError, h.Handle)
 	require.NotNil(t, l)
@@ -32,6 +34,7 @@ func TestLogger(t *testing.T) {
 }
 
 func TestNewLogEntry(t *testing.T) {
+	t.Parallel()
 	entry := newLogEntry(LogLevelDebug, "test", nil)
 	require.Equal(t, LogLevelDebug, entry.Level)
 	require.Equal(t, "test", entry.Message)

--- a/map_broker_memory_test.go
+++ b/map_broker_memory_test.go
@@ -34,6 +34,7 @@ func stateToMapMemory(pubs []*Publication) map[string][]byte {
 
 // TestMemoryMapBroker_StatefulChannel tests stateful channel with keyed state and revisions.
 func TestMemoryMapBroker_StatefulChannel(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -91,6 +92,7 @@ func TestMemoryMapBroker_StatefulChannel(t *testing.T) {
 
 // TestMemoryMapBroker_StatefulChannelOrdered tests ordered stateful channel.
 func TestMemoryMapBroker_StatefulChannelOrdered(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -133,6 +135,7 @@ func TestMemoryMapBroker_StatefulChannelOrdered(t *testing.T) {
 
 // TestMemoryMapBroker_StateRevision tests that state values include revisions.
 func TestMemoryMapBroker_StateRevision(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -185,6 +188,7 @@ func TestMemoryMapBroker_StateRevision(t *testing.T) {
 
 // TestMemoryMapBroker_StatePagination tests cursor-based state pagination.
 func TestMemoryMapBroker_StatePagination(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -246,6 +250,7 @@ func TestMemoryMapBroker_StatePagination(t *testing.T) {
 
 // TestMemoryMapBroker_EpochHandling tests epoch changes and state invalidation.
 func TestMemoryMapBroker_EpochHandling(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -284,6 +289,7 @@ func TestMemoryMapBroker_EpochHandling(t *testing.T) {
 // ErrorUnrecoverablePosition when client sends an epoch but the channel doesn't exist
 // (e.g., after server restart). This is the server restart recovery scenario.
 func TestMemoryMapBroker_EpochMismatchWhenChannelNotExists(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -313,6 +319,7 @@ func TestMemoryMapBroker_EpochMismatchWhenChannelNotExists(t *testing.T) {
 // TestMemoryMapBroker_NoEpochWhenChannelNotExists tests that we return success
 // when client doesn't send an epoch and the channel doesn't exist (fresh subscription).
 func TestMemoryMapBroker_NoEpochWhenChannelNotExists(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -340,6 +347,7 @@ func TestMemoryMapBroker_NoEpochWhenChannelNotExists(t *testing.T) {
 
 // TestMemoryMapBroker_Idempotency tests idempotent publishing.
 func TestMemoryMapBroker_Idempotency(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -389,6 +397,7 @@ func TestMemoryMapBroker_Idempotency(t *testing.T) {
 
 // TestMemoryMapBroker_VersionedPublishing tests version-based idempotency.
 func TestMemoryMapBroker_VersionedPublishing(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -443,6 +452,7 @@ func TestMemoryMapBroker_VersionedPublishing(t *testing.T) {
 
 // TestMemoryMapBroker_PerKeyVersion tests that version tracking is per-key independent.
 func TestMemoryMapBroker_PerKeyVersion(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -506,6 +516,7 @@ func TestMemoryMapBroker_PerKeyVersion(t *testing.T) {
 
 // TestMemoryMapBroker_MultipleChannels tests multiple channels independently.
 func TestMemoryMapBroker_MultipleChannels(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -557,6 +568,7 @@ func TestMemoryMapBroker_MultipleChannels(t *testing.T) {
 // TestMemoryMapBroker_OrderedStateOrdering tests that ordered state return entries
 // in correct score order (descending by score).
 func TestMemoryMapBroker_OrderedStateOrdering(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -613,6 +625,7 @@ func TestMemoryMapBroker_OrderedStateOrdering(t *testing.T) {
 // TestMemoryMapBroker_OrderedStatePagination tests that pagination over ordered state
 // maintains correct ordering across pages.
 func TestMemoryMapBroker_OrderedStatePagination(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -677,6 +690,7 @@ func TestMemoryMapBroker_OrderedStatePagination(t *testing.T) {
 
 // TestMemoryMapBroker_OrderedStateWithNegativeScores tests ordering with negative scores.
 func TestMemoryMapBroker_OrderedStateWithNegativeScores(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -732,6 +746,7 @@ func TestMemoryMapBroker_OrderedStateWithNegativeScores(t *testing.T) {
 // TestMemoryMapBroker_OrderedStateUpdatePreservesOrder tests that updating an entry's score
 // changes its position in the ordered state.
 func TestMemoryMapBroker_OrderedStateUpdatePreservesOrder(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -791,6 +806,7 @@ func TestMemoryMapBroker_OrderedStateUpdatePreservesOrder(t *testing.T) {
 
 // TestMemoryMapBroker_Remove tests removing keys from state.
 func TestMemoryMapBroker_Remove(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -865,6 +881,7 @@ func TestMemoryMapBroker_Remove(t *testing.T) {
 }
 
 func TestMemoryMapBroker_RemovePreservesTags(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -904,6 +921,7 @@ func TestMemoryMapBroker_RemovePreservesTags(t *testing.T) {
 }
 
 func TestMemoryMapBroker_RemoveExplicitTagsOverride(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -944,6 +962,7 @@ func TestMemoryMapBroker_RemoveExplicitTagsOverride(t *testing.T) {
 }
 
 func TestMemoryMapBroker_CleanupPreservesTags(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -998,6 +1017,7 @@ func TestMemoryMapBroker_CleanupPreservesTags(t *testing.T) {
 
 // TestMemoryMapBroker_KeyModeIfNew tests KeyModeIfNew - only write if key doesn't exist.
 func TestMemoryMapBroker_KeyModeIfNew(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -1050,6 +1070,7 @@ func TestMemoryMapBroker_KeyModeIfNew(t *testing.T) {
 
 // TestMemoryMapBroker_KeyModeIfExists tests KeyModeIfExists - only write if key exists.
 func TestMemoryMapBroker_KeyModeIfExists(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -1101,6 +1122,7 @@ func TestMemoryMapBroker_KeyModeIfExists(t *testing.T) {
 
 // TestMemoryMapBroker_KeyModeReplace tests default KeyModeReplace behavior.
 func TestMemoryMapBroker_KeyModeReplace(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -1224,6 +1246,7 @@ func simulateClientRecovery(
 // TestMemoryMapBroker_UnorderedContinuity_EntryRemoved tests that removing
 // an entry during unordered pagination doesn't cause data loss.
 func TestMemoryMapBroker_UnorderedContinuity_EntryRemoved(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -1324,6 +1347,7 @@ func TestMemoryMapBroker_UnorderedContinuity_EntryRemoved(t *testing.T) {
 // TestMemoryMapBroker_UnorderedContinuity_EntryAdded tests that adding
 // an entry during unordered pagination doesn't cause issues.
 func TestMemoryMapBroker_UnorderedContinuity_EntryAdded(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -1372,6 +1396,7 @@ func TestMemoryMapBroker_UnorderedContinuity_EntryAdded(t *testing.T) {
 // TestMemoryMapBroker_OrderedContinuity_HigherScoreAdded tests that adding
 // an entry with higher score during ordered pagination doesn't cause data loss.
 func TestMemoryMapBroker_OrderedContinuity_HigherScoreAdded(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -1433,6 +1458,7 @@ func TestMemoryMapBroker_OrderedContinuity_HigherScoreAdded(t *testing.T) {
 // TestMemoryMapBroker_OrderedContinuity_LowerScoreAdded tests that adding
 // an entry with lower score during ordered pagination works correctly.
 func TestMemoryMapBroker_OrderedContinuity_LowerScoreAdded(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -1490,6 +1516,7 @@ func TestMemoryMapBroker_OrderedContinuity_LowerScoreAdded(t *testing.T) {
 // TestMemoryMapBroker_OrderedContinuity_ScoreChanged tests that changing
 // an entry's score during pagination (causing reordering) doesn't lose data.
 func TestMemoryMapBroker_OrderedContinuity_ScoreChanged(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -1576,6 +1603,7 @@ func TestMemoryMapBroker_OrderedContinuity_ScoreChanged(t *testing.T) {
 // TestMemoryMapBroker_OrderedContinuity_EntryRemoved tests that removing
 // an entry during ordered pagination doesn't cause data loss.
 func TestMemoryMapBroker_OrderedContinuity_EntryRemoved(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -1662,6 +1690,7 @@ func TestMemoryMapBroker_OrderedContinuity_EntryRemoved(t *testing.T) {
 // TestMemoryMapBroker_OrderedContinuity_MultipleChanges tests recovery
 // with multiple concurrent changes during pagination.
 func TestMemoryMapBroker_OrderedContinuity_MultipleChanges(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -1755,6 +1784,7 @@ func TestMemoryMapBroker_OrderedContinuity_MultipleChanges(t *testing.T) {
 
 // TestMemoryMapBroker_CursorFormat tests that cursor format is correct.
 func TestMemoryMapBroker_CursorFormat(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -1870,6 +1900,7 @@ func TestMemoryMapBroker_CursorFormat(t *testing.T) {
 
 // TestMemoryMapBroker_Delta tests key-based delta delivery via HandlePublication.
 func TestMemoryMapBroker_Delta(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -1965,6 +1996,7 @@ func TestMemoryMapBroker_Delta(t *testing.T) {
 }
 
 func TestMemoryMapBroker_Clear(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -2023,6 +2055,7 @@ func TestMemoryMapBroker_Clear(t *testing.T) {
 }
 
 func TestMemoryMapBroker_ClearDoesNotAffectOtherChannels(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -2062,6 +2095,7 @@ func TestMemoryMapBroker_ClearDoesNotAffectOtherChannels(t *testing.T) {
 }
 
 func TestMemoryMapBroker_ReadStream_Table(t *testing.T) {
+	t.Parallel()
 	testMapBrokerReadStream(t, func(t *testing.T) MapBroker {
 		node, _ := New(Config{})
 		node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
@@ -2077,6 +2111,7 @@ func TestMemoryMapBroker_ReadStream_Table(t *testing.T) {
 }
 
 func TestMemoryMapBroker_EpochOnEmptyChannel(t *testing.T) {
+	t.Parallel()
 	testMapBrokerEpochOnEmptyChannel(t, func(t *testing.T) MapBroker {
 		node, _ := New(Config{})
 		node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
@@ -2092,6 +2127,7 @@ func TestMemoryMapBroker_EpochOnEmptyChannel(t *testing.T) {
 }
 
 func TestMemoryMapBroker_ReadStateAllEntries(t *testing.T) {
+	t.Parallel()
 	testMapBrokerReadStateAllEntries(t, func(t *testing.T) MapBroker {
 		node, _ := New(Config{})
 		node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
@@ -2107,6 +2143,7 @@ func TestMemoryMapBroker_ReadStateAllEntries(t *testing.T) {
 }
 
 func TestMemoryMapBroker_RemoveEmptyKey(t *testing.T) {
+	t.Parallel()
 	testMapBrokerRemoveEmptyKey(t, func(t *testing.T) MapBroker {
 		node, _ := New(Config{})
 		node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
@@ -2122,6 +2159,7 @@ func TestMemoryMapBroker_RemoveEmptyKey(t *testing.T) {
 }
 
 func TestMemoryMapBroker_ClientInfoInState(t *testing.T) {
+	t.Parallel()
 	testMapBrokerClientInfoInState(t, func(t *testing.T) MapBroker {
 		node, _ := New(Config{})
 		node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
@@ -2137,6 +2175,7 @@ func TestMemoryMapBroker_ClientInfoInState(t *testing.T) {
 }
 
 func TestMemoryMapBroker_ClientInfoInStream(t *testing.T) {
+	t.Parallel()
 	testMapBrokerClientInfoInStream(t, func(t *testing.T) MapBroker {
 		node, _ := New(Config{})
 		node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
@@ -2152,6 +2191,7 @@ func TestMemoryMapBroker_ClientInfoInStream(t *testing.T) {
 }
 
 func TestMemoryMapBroker_CheckOrder(t *testing.T) {
+	t.Parallel()
 	testMapBrokerCheckOrder(t, func(t *testing.T) MapBroker {
 		node, _ := New(Config{})
 		node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
@@ -2167,6 +2207,7 @@ func TestMemoryMapBroker_CheckOrder(t *testing.T) {
 }
 
 func TestMemoryMapBroker_VersionPreserved(t *testing.T) {
+	t.Parallel()
 	testMapBrokerVersionPreserved(t, func(t *testing.T) MapBroker {
 		node, _ := New(Config{})
 		node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
@@ -2184,6 +2225,7 @@ func TestMemoryMapBroker_VersionPreserved(t *testing.T) {
 // TestMemoryMapBroker_ClientInfoDelivery tests that ClientInfo is delivered
 // to the event handler when publishing with ClientInfo.
 func TestMemoryMapBroker_ClientInfoDelivery(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -2246,6 +2288,7 @@ func TestMemoryMapBroker_ClientInfoDelivery(t *testing.T) {
 
 // TestMemoryMapBroker_OrderedStateAsc tests ascending sort direction.
 func TestMemoryMapBroker_OrderedStateAsc(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -2308,6 +2351,7 @@ func TestMemoryMapBroker_OrderedStateAsc(t *testing.T) {
 
 // TestMemoryMapBroker_OrderedStatePaginationAsc tests pagination with ascending sort.
 func TestMemoryMapBroker_OrderedStatePaginationAsc(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -2385,6 +2429,7 @@ func TestMemoryMapBroker_OrderedStatePaginationAsc(t *testing.T) {
 // TestMemoryMapBroker_OrderedStateAscSameScores tests ASC ordering with
 // same-score entries — secondary sort by key ascending.
 func TestMemoryMapBroker_OrderedStateAscSameScores(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -2456,6 +2501,7 @@ func TestMemoryMapBroker_OrderedStateAscSameScores(t *testing.T) {
 }
 
 func TestMemoryMapBroker_CleanupMetrics(t *testing.T) {
+	t.Parallel()
 	registry := prometheus.NewRegistry()
 	node, err := New(Config{
 		Metrics: MetricsConfig{
@@ -2517,6 +2563,7 @@ func TestMemoryMapBroker_CleanupMetrics(t *testing.T) {
 }
 
 func TestResolveAndValidateMapChannelOptions(t *testing.T) {
+	t.Parallel()
 	t.Run("nil resolver", func(t *testing.T) {
 		_, err := ResolveAndValidateMapChannelOptions(nil, "ch")
 		require.Error(t, err)
@@ -2691,6 +2738,7 @@ func TestResolveAndValidateMapChannelOptions(t *testing.T) {
 }
 
 func TestParseOrderedCursor(t *testing.T) {
+	t.Parallel()
 	t.Run("valid cursor", func(t *testing.T) {
 		score, key := parseOrderedCursor("100\x00mykey")
 		require.Equal(t, "100", score)
@@ -2732,6 +2780,7 @@ func TestParseOrderedCursor(t *testing.T) {
 }
 
 func TestMapMode_Methods(t *testing.T) {
+	t.Parallel()
 	require.True(t, MapModeEphemeral.IsEphemeral())
 	require.False(t, MapModeRecoverable.IsEphemeral())
 	require.False(t, MapModePersistent.IsEphemeral())
@@ -2747,6 +2796,7 @@ func TestMapMode_Methods(t *testing.T) {
 
 // TestMemoryMapBroker_CAS_Publish tests Compare-And-Swap semantics for Publish.
 func TestMemoryMapBroker_CAS_Publish(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -2815,6 +2865,7 @@ func TestMemoryMapBroker_CAS_Publish(t *testing.T) {
 
 // TestMemoryMapBroker_CAS_Remove tests Compare-And-Swap semantics for Remove.
 func TestMemoryMapBroker_CAS_Remove(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -2866,6 +2917,7 @@ func TestMemoryMapBroker_CAS_Remove(t *testing.T) {
 
 // TestMemoryMapBroker_EphemeralRejectsCAS tests that CAS and Version are rejected in ephemeral mode.
 func TestMemoryMapBroker_EphemeralRejectsCAS(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -2903,6 +2955,7 @@ func TestMemoryMapBroker_EphemeralRejectsCAS(t *testing.T) {
 
 // TestMemoryMapBroker_RemoveIdempotency tests idempotency key for Remove operations.
 func TestMemoryMapBroker_RemoveIdempotency(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -2948,6 +3001,7 @@ func TestMemoryMapBroker_RemoveIdempotency(t *testing.T) {
 
 // TestMemoryMapBroker_RemoveCustomIdempotentTTL tests custom IdempotentResultTTL for Remove.
 func TestMemoryMapBroker_RemoveCustomIdempotentTTL(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -2984,6 +3038,7 @@ func TestMemoryMapBroker_RemoveCustomIdempotentTTL(t *testing.T) {
 
 // TestMemoryMapBroker_PublishCustomIdempotentTTL tests custom IdempotentResultTTL for Publish.
 func TestMemoryMapBroker_PublishCustomIdempotentTTL(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3080,6 +3135,7 @@ func TestMemoryMapBroker_KeyTTLExpiration(t *testing.T) {
 
 // TestMemoryMapBroker_KeyTTLRefresh tests that refreshing a key extends its TTL.
 func TestMemoryMapBroker_KeyTTLRefresh(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3116,6 +3172,7 @@ func TestMemoryMapBroker_KeyTTLRefresh(t *testing.T) {
 
 // TestMemoryMapBroker_StreamTTLExpiration tests that stream entries are cleared after StreamTTL.
 func TestMemoryMapBroker_StreamTTLExpiration(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3156,6 +3213,7 @@ func TestMemoryMapBroker_StreamTTLExpiration(t *testing.T) {
 
 // TestMemoryMapBroker_MetaTTLRemovesChannel tests that channel is removed after MetaTTL.
 func TestMemoryMapBroker_MetaTTLRemovesChannel(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3196,6 +3254,7 @@ func TestMemoryMapBroker_MetaTTLRemovesChannel(t *testing.T) {
 
 // TestMemoryMapBroker_IdempotencyCacheExpiration tests that idempotency cache entries expire.
 func TestMemoryMapBroker_IdempotencyCacheExpiration(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3242,6 +3301,7 @@ func TestMemoryMapBroker_IdempotencyCacheExpiration(t *testing.T) {
 
 // TestMemoryMapBroker_ReadStreamEpochMismatch tests epoch mismatch in ReadStream.
 func TestMemoryMapBroker_ReadStreamEpochMismatch(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3270,6 +3330,7 @@ func TestMemoryMapBroker_ReadStreamEpochMismatch(t *testing.T) {
 
 // TestMemoryMapBroker_ReadStreamReverse tests reverse stream reads.
 func TestMemoryMapBroker_ReadStreamReverse(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3304,6 +3365,7 @@ func TestMemoryMapBroker_ReadStreamReverse(t *testing.T) {
 
 // TestMemoryMapBroker_ReadStreamSinceMatchingOffset tests Since with current offset.
 func TestMemoryMapBroker_ReadStreamSinceMatchingOffset(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3334,6 +3396,7 @@ func TestMemoryMapBroker_ReadStreamSinceMatchingOffset(t *testing.T) {
 
 // TestMemoryMapBroker_ReadStreamSinceReverse tests Since with reverse read.
 func TestMemoryMapBroker_ReadStreamSinceReverse(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3378,6 +3441,7 @@ func TestMemoryMapBroker_ReadStreamSinceReverse(t *testing.T) {
 
 // TestMemoryMapBroker_ReadStreamNoStream tests ReadStream on a channel without a stream.
 func TestMemoryMapBroker_ReadStreamNoStream(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3401,6 +3465,7 @@ func TestMemoryMapBroker_ReadStreamNoStream(t *testing.T) {
 
 // TestMemoryMapBroker_RemoveFromNonExistentChannel tests removing from non-existent channel.
 func TestMemoryMapBroker_RemoveFromNonExistentChannel(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3424,6 +3489,7 @@ func TestMemoryMapBroker_RemoveFromNonExistentChannel(t *testing.T) {
 // TestMemoryMapBroker_RemoveKeyNotFoundWithStream tests that removing a non-existent key
 // from an existing channel returns the stream position.
 func TestMemoryMapBroker_RemoveKeyNotFoundWithStream(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3487,6 +3553,7 @@ func TestMemoryMapBroker_EphemeralPublishAndExpire(t *testing.T) {
 
 // TestMemoryMapBroker_ReadStateEpochMismatch tests epoch mismatch in ReadState with Revision.
 func TestMemoryMapBroker_ReadStateEpochMismatch(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3522,6 +3589,7 @@ func TestMemoryMapBroker_ReadStateEpochMismatch(t *testing.T) {
 
 // TestMemoryMapBroker_ReadStateKeyFilter tests single key lookup in ReadState.
 func TestMemoryMapBroker_ReadStateKeyFilter(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3560,6 +3628,7 @@ func TestMemoryMapBroker_ReadStateKeyFilter(t *testing.T) {
 
 // TestMemoryMapBroker_VersionEpoch tests that version epoch scoping works correctly.
 func TestMemoryMapBroker_VersionEpoch(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3598,6 +3667,7 @@ func TestMemoryMapBroker_VersionEpoch(t *testing.T) {
 
 // TestMemoryMapBroker_EventHandler tests that event handler receives publications.
 func TestMemoryMapBroker_EventHandler(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3645,6 +3715,7 @@ func TestMemoryMapBroker_EventHandler(t *testing.T) {
 
 // TestMemoryMapBroker_EphemeralNoStream tests that ephemeral mode has no stream.
 func TestMemoryMapBroker_EphemeralNoStream(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3674,6 +3745,7 @@ func TestMemoryMapBroker_EphemeralNoStream(t *testing.T) {
 
 // TestMemoryMapBroker_PersistentNeverExpires tests that persistent mode keys don't have TTL.
 func TestMemoryMapBroker_PersistentNeverExpires(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3706,6 +3778,7 @@ func TestMemoryMapBroker_PersistentNeverExpires(t *testing.T) {
 
 // TestMemoryMapBroker_ParseChKey tests the parseChKey helper.
 func TestMemoryMapBroker_ParseChKey(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	broker := newTestMemoryMapBroker(t, node)
 	h := broker.mapHub
@@ -3740,6 +3813,7 @@ func TestMemoryMapBroker_ParseChKey(t *testing.T) {
 // TestMemoryMapBroker_RemoveEphemeralNoStream tests Remove in ephemeral mode
 // where the channel has no stream but does have state.
 func TestMemoryMapBroker_RemoveEphemeralNoStream(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3767,6 +3841,7 @@ func TestMemoryMapBroker_RemoveEphemeralNoStream(t *testing.T) {
 
 // TestMemoryMapBroker_SubscribeUnsubscribeNoop tests that Subscribe and Unsubscribe are no-ops.
 func TestMemoryMapBroker_SubscribeUnsubscribeNoop(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	broker := newTestMemoryMapBroker(t, node)
 
@@ -3776,6 +3851,7 @@ func TestMemoryMapBroker_SubscribeUnsubscribeNoop(t *testing.T) {
 
 // TestMemoryMapBroker_Close tests that Close stops background goroutines.
 func TestMemoryMapBroker_Close(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	broker := newTestMemoryMapBroker(t, node)
 
@@ -3793,6 +3869,7 @@ func TestMemoryMapBroker_Close(t *testing.T) {
 // active keepalives still gets garbage-collected by removeChannels when
 // MetaTTL elapses, forcing an epoch reset on the next publish.
 func TestMemoryMapBroker_RefreshTTLOnSuppress_RefreshesMetaTTL(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3919,6 +3996,7 @@ func newMapBrokerNoOptions(t *testing.T) (*Node, *MemoryMapBroker) {
 // TestMapBroker_Publish_InvalidOptions covers the error path from
 // ResolveAndValidateMapChannelOptions in Publish.
 func TestMapBroker_Publish_InvalidOptions(t *testing.T) {
+	t.Parallel()
 	_, broker := newMapBrokerNoOptions(t)
 	_, err := broker.Publish(context.Background(), "ch", "k", MapPublishOptions{Data: []byte(`{}`)})
 	require.Error(t, err)
@@ -3926,6 +4004,7 @@ func TestMapBroker_Publish_InvalidOptions(t *testing.T) {
 
 // TestMapBroker_Remove_InvalidOptions covers the error path in Remove.
 func TestMapBroker_Remove_InvalidOptions(t *testing.T) {
+	t.Parallel()
 	_, broker := newMapBrokerNoOptions(t)
 	_, err := broker.Remove(context.Background(), "ch", "k", MapRemoveOptions{})
 	require.Error(t, err)
@@ -3933,6 +4012,7 @@ func TestMapBroker_Remove_InvalidOptions(t *testing.T) {
 
 // TestMapBroker_ReadState_InvalidOptions covers the error path in ReadState.
 func TestMapBroker_ReadState_InvalidOptions(t *testing.T) {
+	t.Parallel()
 	_, broker := newMapBrokerNoOptions(t)
 	_, err := broker.ReadState(context.Background(), "ch", MapReadStateOptions{Limit: 10})
 	require.Error(t, err)
@@ -3941,6 +4021,7 @@ func TestMapBroker_ReadState_InvalidOptions(t *testing.T) {
 // TestMapBroker_ReadState_LimitZero covers the Limit==0 branch in mapHub.getState
 // (returns just stream position, no entries).
 func TestMapBroker_ReadState_LimitZero(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{Mode: MapModeRecoverable, StreamSize: 100, StreamTTL: 5 * time.Minute, KeyTTL: 5 * time.Minute}
@@ -3960,6 +4041,7 @@ func TestMapBroker_ReadState_LimitZero(t *testing.T) {
 // TestMapBroker_Clear_NonExistentChannel covers the early-return branch in
 // mapHub.clear when the channel isn't in the map.
 func TestMapBroker_Clear_NonExistentChannel(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{Mode: MapModeRecoverable, StreamSize: 100, StreamTTL: 5 * time.Minute, KeyTTL: 5 * time.Minute}
@@ -3974,6 +4056,7 @@ func TestMapBroker_Clear_NonExistentChannel(t *testing.T) {
 // nextKeyExpireCheck and nextRemoveCheck update branches inside the
 // IfNew + RefreshTTLOnSuppress code path.
 func TestMapBroker_KeyModeIfNew_RefreshTTL_TimerSetters(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -4017,6 +4100,7 @@ func TestMapBroker_KeyModeIfNew_RefreshTTL_TimerSetters(t *testing.T) {
 // branch in mapHub.remove (when MetaTTL is set and the new removeAt earlier
 // than current nextRemoveCheck).
 func TestMapBroker_Remove_RefreshesRemoveCheck(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -4051,6 +4135,7 @@ func TestMapBroker_Remove_RefreshesRemoveCheck(t *testing.T) {
 // expireKeysIteration where the popped queue entry is stale (storedExpireAt
 // has been pushed forward by a refresh).
 func TestMapBroker_ExpireKeysIteration_Refreshed(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -4089,6 +4174,7 @@ func TestMapBroker_ExpireKeysIteration_Refreshed(t *testing.T) {
 // channel doesn't exist and we must allocate a stream-position holder so the
 // epoch is stable.
 func TestMapBroker_GetStream_NoChannel(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -4114,6 +4200,7 @@ func TestMapBroker_GetStream_NoChannel(t *testing.T) {
 // path in getStream where the channel is created by another goroutine between
 // RUnlock and Lock.
 func TestMapBroker_GetStream_ConcurrentChannelCreation(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -4148,6 +4235,7 @@ func TestMapBroker_GetStream_ConcurrentChannelCreation(t *testing.T) {
 // path in getState where another goroutine creates the channel between unlock
 // and re-lock.
 func TestMapBroker_ReadState_ConcurrentChannelCreation(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{

--- a/map_broker_memory_test.go
+++ b/map_broker_memory_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -3875,9 +3876,13 @@ func TestMemoryMapBroker_RefreshTTLOnSuppress_RefreshesMetaTTL(t *testing.T) {
 		return MapChannelOptions{
 			Mode:       MapModeRecoverable,
 			StreamSize: 100,
-			StreamTTL:  300 * time.Millisecond,
-			KeyTTL:     300 * time.Millisecond,
-			MetaTTL:    300 * time.Millisecond,
+			// TTLs are deliberately generous relative to the tick interval
+			// below so a stretched -race scheduler can't reap the key
+			// between keepalives — the test should fail on missing
+			// keepalive logic, not on tick scheduling.
+			StreamTTL: 2 * time.Second,
+			KeyTTL:    2 * time.Second,
+			MetaTTL:   2 * time.Second,
 		}
 	}
 	broker := newTestMemoryMapBroker(t, node)
@@ -3893,13 +3898,12 @@ func TestMemoryMapBroker_RefreshTTLOnSuppress_RefreshesMetaTTL(t *testing.T) {
 	firstEpoch := res.Position.Epoch
 	require.NotEmpty(t, firstEpoch)
 
-	// Drive keepalives every 100ms via require.Eventually's tick — under -race
+	// Drive keepalives every 200ms via require.Eventually's tick — under -race
 	// this is more robust than a fixed time.Sleep loop, because each tick
 	// issues the keepalive AND verifies the channel is still alive in one
-	// step. With the fix, each suppressed keepalive extends meta's removeAt
-	// by 300ms; the assertion fails fast if the channel was reaped between
-	// ticks instead of silently passing.
-	keepaliveDeadline := time.Now().Add(600 * time.Millisecond)
+	// step. Each suppressed keepalive extends meta's removeAt by 2s; the
+	// assertion fails fast if the channel was reaped between ticks.
+	keepaliveDeadline := time.Now().Add(3 * time.Second)
 	require.Eventually(t, func() bool {
 		res, err := broker.Publish(ctx, ch, "k", MapPublishOptions{
 			Data:                 []byte("v1"),
@@ -3913,7 +3917,7 @@ func TestMemoryMapBroker_RefreshTTLOnSuppress_RefreshesMetaTTL(t *testing.T) {
 		broker.mapHub.RUnlock()
 		require.True(t, exists, "channel must survive while keepalives run")
 		return time.Now().After(keepaliveDeadline)
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 200*time.Millisecond)
 
 	// A real publish (non-suppressed) must use the same epoch — confirms no
 	// reset happened during the keepalive loop.
@@ -4260,4 +4264,126 @@ func TestMapBroker_ReadState_ConcurrentChannelCreation(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// TestMemoryMapBroker_KeyExpire_FreshSubscriber_NoOrphanRemoval covers audit
+// finding 1: a fresh subscriber's ReadState→ReadStream sequence must never
+// observe a removal event for a key that was not in its state snapshot.
+//
+// Pre-fix: Phase 1 of expireKeysIteration deleted from channel.state under
+// h.Lock without appending to the stream; Phase 2 added the removal stream
+// entry under pubLock(ch) → h.Lock. Between phases, a fresh subscriber's
+// ReadState saw the key gone but ReadStream's position was unchanged —
+// then live PUB/SUB delivered a removal for a key the subscriber never
+// saw in state.
+//
+// Post-fix: Phase 1 only collects expired candidates; Phase 2 atomically
+// deletes state + appends removal stream entry under pubLock(ch) → h.Lock.
+// The (state, stream-since-state.position) snapshot is internally
+// consistent — any removal for key K must have K in state at snapshot time.
+//
+// Test pattern: many concurrent fresh-subscriber snapshots while keys
+// expire and republish in the background. Statistically catches the race
+// if the fix regresses.
+func TestMemoryMapBroker_KeyExpire_FreshSubscriber_NoOrphanRemoval(t *testing.T) {
+	t.Parallel()
+	node, _ := New(Config{})
+	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
+		return MapChannelOptions{
+			Mode:       MapModeRecoverable,
+			StreamSize: 500,
+			StreamTTL:  60 * time.Second,
+			KeyTTL:     80 * time.Millisecond, // short — drives expirations
+			MetaTTL:    60 * time.Second,
+		}
+	}
+	broker := newTestMemoryMapBroker(t, node)
+
+	ctx := context.Background()
+	ch := "test_fresh_sub_no_orphan"
+
+	// Pre-populate keys.
+	const numKeys = 16
+	for i := 0; i < numKeys; i++ {
+		_, err := broker.Publish(ctx, ch, fmt.Sprintf("k%02d", i), MapPublishOptions{Data: []byte("v")})
+		require.NoError(t, err)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Background republisher: keeps a subset of keys alive while others expire.
+	// Avoids "everything gone" steady state which would make the test trivial.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(60 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+			}
+			for i := 0; i < numKeys/2; i++ {
+				_, _ = broker.Publish(ctx, ch, fmt.Sprintf("k%02d", i), MapPublishOptions{Data: []byte("v")})
+			}
+		}
+	}()
+
+	// Multiple subscriber goroutines. Each snapshot loop:
+	//   1. ReadState → keys present + position P
+	//   2. ReadStream(since P) → events strictly after P
+	//   3. For each removed event, key must be in state snapshot.
+	const subscribers = 4
+	var violations atomic.Int64
+	var iterations atomic.Int64
+	for w := 0; w < subscribers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				stateRes, err := broker.ReadState(ctx, ch, MapReadStateOptions{Limit: 100})
+				if err != nil {
+					continue
+				}
+				stateKeys := make(map[string]bool, len(stateRes.Publications))
+				for _, pub := range stateRes.Publications {
+					stateKeys[pub.Key] = true
+				}
+				streamRes, err := broker.ReadStream(ctx, ch, MapReadStreamOptions{
+					Filter: StreamFilter{Since: &stateRes.Position, Limit: 100},
+				})
+				if err != nil {
+					continue
+				}
+				for _, pub := range streamRes.Publications {
+					if pub.Removed && !stateKeys[pub.Key] {
+						// Pre-fix bug: removal of a key that was not in
+						// our state snapshot.
+						violations.Add(1)
+					}
+				}
+				iterations.Add(1)
+			}
+		}()
+	}
+
+	// Run long enough to span at least one expiration cycle (cleanup ticks
+	// at 1s). One cycle plus a small slack is sufficient — under -race the
+	// 4 subscriber loops easily clear the 200-iteration regression-test
+	// threshold within ~1.2s.
+	time.Sleep(1200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	require.Greater(t, iterations.Load(), int64(200),
+		"too few snapshot iterations to be a meaningful regression test")
+	require.Equal(t, int64(0), violations.Load(),
+		"fresh subscriber observed removal for key not present in state snapshot")
 }

--- a/map_broker_memory_test.go
+++ b/map_broker_memory_test.go
@@ -3017,6 +3017,7 @@ func TestMemoryMapBroker_PublishCustomIdempotentTTL(t *testing.T) {
 
 // TestMemoryMapBroker_KeyTTLExpiration tests that keys expire after KeyTTL.
 func TestMemoryMapBroker_KeyTTLExpiration(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3451,6 +3452,7 @@ func TestMemoryMapBroker_RemoveKeyNotFoundWithStream(t *testing.T) {
 
 // TestMemoryMapBroker_EphemeralPublishAndExpire tests ephemeral mode publish and auto-expiration.
 func TestMemoryMapBroker_EphemeralPublishAndExpire(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{
@@ -3849,6 +3851,7 @@ func TestMemoryMapBroker_RefreshTTLOnSuppress_RefreshesMetaTTL(t *testing.T) {
 // MetaTTL. Guards against the fix accidentally bumping meta on every
 // suppressed publish (e.g. version-conflict, idempotency hits).
 func TestMemoryMapBroker_NoRefreshTTL_LetsMetaExpire(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{})
 	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
 		return MapChannelOptions{

--- a/map_broker_redis_test.go
+++ b/map_broker_redis_test.go
@@ -17,6 +17,7 @@ import (
 
 // TestParseMessage tests parseMessage which parses PUB/SUB messages.
 func TestParseMessage(t *testing.T) {
+	t.Parallel()
 	t.Run("empty data", func(t *testing.T) {
 		_, _, _, _, _, err := parseMessage([]byte{})
 		require.Error(t, err)
@@ -88,6 +89,7 @@ func TestParseMessage(t *testing.T) {
 
 // TestParseDeltaMessage tests parseDeltaMessage directly.
 func TestParseDeltaMessage(t *testing.T) {
+	t.Parallel()
 	t.Run("valid delta", func(t *testing.T) {
 		prevData := []byte("abc")
 		currData := []byte("xyz12")
@@ -306,6 +308,7 @@ func stateToMap(pubs []*Publication) map[string][]byte {
 
 // TestRedisMapBroker_StatefulChannel tests stateful channel with keyed state and revisions.
 func TestRedisMapBroker_StatefulChannel(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -358,6 +361,7 @@ func TestRedisMapBroker_StatefulChannel(t *testing.T) {
 
 // TestRedisMapBroker_StatefulChannelOrdered tests ordered stateful channel.
 func TestRedisMapBroker_StatefulChannelOrdered(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -407,6 +411,7 @@ func TestRedisMapBroker_StatefulChannelOrdered(t *testing.T) {
 
 // TestRedisMapBroker_StateRevision tests that state values include revisions.
 func TestRedisMapBroker_StateRevision(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -454,6 +459,7 @@ func TestRedisMapBroker_StateRevision(t *testing.T) {
 
 // TestRedisMapBroker_StatePagination tests cursor-based state pagination.
 func TestRedisMapBroker_StatePagination(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -512,6 +518,7 @@ func TestRedisMapBroker_StatePagination(t *testing.T) {
 
 // TestRedisMapBroker_EpochHandling tests epoch changes and state invalidation.
 func TestRedisMapBroker_EpochHandling(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -545,6 +552,7 @@ func TestRedisMapBroker_EpochHandling(t *testing.T) {
 
 // TestRedisMapBroker_Idempotency tests idempotent publishing.
 func TestRedisMapBroker_Idempotency(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -589,6 +597,7 @@ func TestRedisMapBroker_Idempotency(t *testing.T) {
 
 // TestRedisMapBroker_VersionedPublishing tests version-based idempotency.
 func TestRedisMapBroker_VersionedPublishing(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -638,6 +647,7 @@ func TestRedisMapBroker_VersionedPublishing(t *testing.T) {
 
 // TestRedisMapBroker_PerKeyVersion tests that version tracking is per-key independent.
 func TestRedisMapBroker_PerKeyVersion(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -695,6 +705,7 @@ func TestRedisMapBroker_PerKeyVersion(t *testing.T) {
 
 // TestRedisMapBroker_MultipleChannels tests multiple channels independently.
 func TestRedisMapBroker_MultipleChannels(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -741,6 +752,7 @@ func TestRedisMapBroker_MultipleChannels(t *testing.T) {
 
 // TestParseStateValue tests the state value parsing helper.
 func TestParseStateValue(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		input       []byte
@@ -804,6 +816,7 @@ func TestParseStateValue(t *testing.T) {
 
 // TestRedisMapBroker_ReadStream2 tests the 2-call version of ReadStream.
 func TestRedisMapBroker_ReadStream2(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -1024,6 +1037,7 @@ func TestRedisMapBroker_ReadStream2(t *testing.T) {
 // TestRedisMapBroker_CleanupGeneratesRemovalEvents verifies that the Lua cleanup script
 // correctly generates removal events (key + removed + timestamp) when entries expire by TTL.
 func TestRedisMapBroker_CleanupGeneratesRemovalEvents(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -1126,6 +1140,7 @@ func TestRedisMapBroker_CleanupGeneratesRemovalEvents(t *testing.T) {
 }
 
 func TestRedisMapBroker_CleanupPreservesTags(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -1188,6 +1203,7 @@ func TestRedisMapBroker_CleanupPreservesTags(t *testing.T) {
 }
 
 func TestRedisMapBroker_RemovePreservesTags(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -1241,6 +1257,7 @@ func TestRedisMapBroker_RemovePreservesTags(t *testing.T) {
 // and publishes removal events to the stream. Uses two channels with different
 // TTLs to verify that only expired channel entries are cleaned up.
 func TestRedisMapBroker_CleanupExpiry(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		shortChannel := randomChannel("test_cleanup_short")
 		longChannel := randomChannel("test_cleanup_long")
@@ -1323,6 +1340,7 @@ func TestRedisMapBroker_CleanupExpiry(t *testing.T) {
 // TestRedisMapBroker_CleanupRefreshedTTL verifies that refreshing a key's TTL
 // (by re-publishing with a longer TTL) prevents it from being cleaned up.
 func TestRedisMapBroker_CleanupRefreshedTTL(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -1391,6 +1409,7 @@ func TestRedisMapBroker_CleanupRefreshedTTL(t *testing.T) {
 // TestRedisMapBroker_CleanupRegistration verifies that the cleanup registration ZSET
 // is properly maintained (entries added on publish, removed when channel is fully cleaned).
 func TestRedisMapBroker_CleanupRegistration(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -1455,6 +1474,7 @@ func TestRedisMapBroker_CleanupRegistration(t *testing.T) {
 // TestRedisMapBroker_OrderedStateOrdering tests that ordered  state return entries
 // in correct score order (ascending by score).
 func TestRedisMapBroker_OrderedStateOrdering(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -1518,6 +1538,7 @@ func TestRedisMapBroker_OrderedStateOrdering(t *testing.T) {
 // TestRedisMapBroker_OrderedStatePagination tests that pagination over ordered state
 // maintains correct ordering across pages.
 func TestRedisMapBroker_OrderedStatePagination(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -1639,6 +1660,7 @@ func TestRedisMapBroker_OrderedStatePagination(t *testing.T) {
 
 // TestRedisMapBroker_OrderedStateWithNegativeScores tests ordering with negative scores.
 func TestRedisMapBroker_OrderedStateWithNegativeScores(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -1700,6 +1722,7 @@ func TestRedisMapBroker_OrderedStateWithNegativeScores(t *testing.T) {
 
 // TestRedisMapBroker_OrderedStateWithSameScores tests ordering stability when scores are equal.
 func TestRedisMapBroker_OrderedStateWithSameScores(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -1753,6 +1776,7 @@ func TestRedisMapBroker_OrderedStateWithSameScores(t *testing.T) {
 
 // TestRedisMapBroker_OrderedStatePaginationBoundaries tests edge cases in cursor-based pagination.
 func TestRedisMapBroker_OrderedStatePaginationBoundaries(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -1858,6 +1882,7 @@ func TestRedisMapBroker_OrderedStatePaginationBoundaries(t *testing.T) {
 
 // TestRedisMapBroker_OrderedStateFullPagination tests complete cursor-based pagination loop.
 func TestRedisMapBroker_OrderedStateFullPagination(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -1937,6 +1962,7 @@ func TestRedisMapBroker_OrderedStateFullPagination(t *testing.T) {
 // TestRedisMapBroker_OrderedStateUpdatePreservesOrder tests that updating an entry's score
 // changes its position in the ordered state.
 func TestRedisMapBroker_OrderedStateUpdatePreservesOrder(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -2004,6 +2030,7 @@ func TestRedisMapBroker_OrderedStateUpdatePreservesOrder(t *testing.T) {
 
 // TestRedisMapBroker_KeyModeIfNew tests KeyModeIfNew - only write if key doesn't exist.
 func TestRedisMapBroker_KeyModeIfNew(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -2051,6 +2078,7 @@ func TestRedisMapBroker_KeyModeIfNew(t *testing.T) {
 
 // TestRedisMapBroker_KeyModeIfExists tests KeyModeIfExists - only write if key exists.
 func TestRedisMapBroker_KeyModeIfExists(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -2097,6 +2125,7 @@ func TestRedisMapBroker_KeyModeIfExists(t *testing.T) {
 
 // TestRedisMapBroker_KeyModeReplace tests default KeyModeReplace behavior.
 func TestRedisMapBroker_KeyModeReplace(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -2133,6 +2162,7 @@ func TestRedisMapBroker_KeyModeReplace(t *testing.T) {
 }
 
 func TestRedisMapBroker_Remove(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -2212,6 +2242,7 @@ func TestRedisMapBroker_Remove(t *testing.T) {
 // Note: HSCAN COUNT is only a hint — Redis may return more entries than requested
 // (especially for small hashes stored as listpack), so we don't assert exact page sizes.
 func TestRedisMapBroker_UnorderedContinuity_EntryRemoved(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -2248,6 +2279,7 @@ func TestRedisMapBroker_UnorderedContinuity_EntryRemoved(t *testing.T) {
 // Note: HSCAN COUNT is only a hint — Redis may return more entries than requested
 // (especially for small hashes stored as listpack), so we don't assert exact page sizes.
 func TestRedisMapBroker_UnorderedContinuity_EntryAdded(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -2283,6 +2315,7 @@ func TestRedisMapBroker_UnorderedContinuity_EntryAdded(t *testing.T) {
 // TestRedisMapBroker_OrderedContinuity_HigherScoreAdded tests that adding
 // an entry with higher score during ordered pagination doesn't cause data loss.
 func TestRedisMapBroker_OrderedContinuity_HigherScoreAdded(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -2352,6 +2385,7 @@ func TestRedisMapBroker_OrderedContinuity_HigherScoreAdded(t *testing.T) {
 // TestRedisMapBroker_OrderedContinuity_LowerScoreAdded tests that adding
 // an entry with lower score during ordered pagination works correctly.
 func TestRedisMapBroker_OrderedContinuity_LowerScoreAdded(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -2418,6 +2452,7 @@ func TestRedisMapBroker_OrderedContinuity_LowerScoreAdded(t *testing.T) {
 // TestRedisMapBroker_OrderedContinuity_ScoreChanged tests that changing
 // an entry's score during pagination (causing reordering) doesn't lose data.
 func TestRedisMapBroker_OrderedContinuity_ScoreChanged(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -2513,6 +2548,7 @@ func TestRedisMapBroker_OrderedContinuity_ScoreChanged(t *testing.T) {
 // TestRedisMapBroker_OrderedContinuity_EntryRemoved tests that removing
 // an entry during ordered pagination doesn't cause data loss.
 func TestRedisMapBroker_OrderedContinuity_EntryRemoved(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -2608,6 +2644,7 @@ func TestRedisMapBroker_OrderedContinuity_EntryRemoved(t *testing.T) {
 // TestRedisMapBroker_OrderedContinuity_MultipleChanges tests recovery
 // with multiple concurrent changes during pagination.
 func TestRedisMapBroker_OrderedContinuity_MultipleChanges(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -2711,6 +2748,7 @@ func TestRedisMapBroker_OrderedContinuity_MultipleChanges(t *testing.T) {
 
 // TestRedisMapBroker_Delta tests key-based delta delivery via PUB/SUB and HandlePublication.
 func TestRedisMapBroker_Delta(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 
@@ -2803,6 +2841,7 @@ func TestRedisMapBroker_Delta(t *testing.T) {
 }
 
 func TestRedisMapBroker_Clear(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -2857,6 +2896,7 @@ func TestRedisMapBroker_Clear(t *testing.T) {
 }
 
 func TestRedisMapBroker_ClearDoesNotAffectOtherChannels(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -2894,6 +2934,7 @@ func TestRedisMapBroker_ClearDoesNotAffectOtherChannels(t *testing.T) {
 }
 
 func TestRedisMapBroker_ReadStream_Table(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		testMapBrokerReadStream(t, func(t *testing.T) MapBroker {
 			node, _ := New(Config{})
@@ -2911,6 +2952,7 @@ func TestRedisMapBroker_ReadStream_Table(t *testing.T) {
 }
 
 func TestRedisMapBroker_EpochOnEmptyChannel(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		testMapBrokerEpochOnEmptyChannel(t, func(t *testing.T) MapBroker {
 			node, _ := New(Config{})
@@ -2920,6 +2962,7 @@ func TestRedisMapBroker_EpochOnEmptyChannel(t *testing.T) {
 }
 
 func TestRedisMapBroker_ReadStateAllEntries(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		testMapBrokerReadStateAllEntries(t, func(t *testing.T) MapBroker {
 			node, _ := New(Config{})
@@ -2929,6 +2972,7 @@ func TestRedisMapBroker_ReadStateAllEntries(t *testing.T) {
 }
 
 func TestRedisMapBroker_RemoveEmptyKey(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		testMapBrokerRemoveEmptyKey(t, func(t *testing.T) MapBroker {
 			node, _ := New(Config{})
@@ -2938,6 +2982,7 @@ func TestRedisMapBroker_RemoveEmptyKey(t *testing.T) {
 }
 
 func TestRedisMapBroker_ClientInfoInState(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		testMapBrokerClientInfoInState(t, func(t *testing.T) MapBroker {
 			node, _ := New(Config{})
@@ -2947,6 +2992,7 @@ func TestRedisMapBroker_ClientInfoInState(t *testing.T) {
 }
 
 func TestRedisMapBroker_ClientInfoInStream(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		testMapBrokerClientInfoInStream(t, func(t *testing.T) MapBroker {
 			node, _ := New(Config{})
@@ -2956,6 +3002,7 @@ func TestRedisMapBroker_ClientInfoInStream(t *testing.T) {
 }
 
 func TestRedisMapBroker_CheckOrder(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		testMapBrokerCheckOrder(t, func(t *testing.T) MapBroker {
 			node, _ := New(Config{})
@@ -2965,6 +3012,7 @@ func TestRedisMapBroker_CheckOrder(t *testing.T) {
 }
 
 func TestRedisMapBroker_VersionPreserved(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		testMapBrokerVersionPreserved(t, func(t *testing.T) MapBroker {
 			node, _ := New(Config{})
@@ -2976,6 +3024,7 @@ func TestRedisMapBroker_VersionPreserved(t *testing.T) {
 // TestRedisMapBroker_ClientInfoDelivery tests that ClientInfo is delivered
 // via PUB/SUB when publishing with ClientInfo.
 func TestRedisMapBroker_ClientInfoDelivery(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 
@@ -3031,6 +3080,7 @@ func TestRedisMapBroker_ClientInfoDelivery(t *testing.T) {
 // TestRedisMapBroker_OrderedStateAsc tests that ASC ordering returns entries
 // in ascending score order (lowest score first).
 func TestRedisMapBroker_OrderedStateAsc(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -3101,6 +3151,7 @@ func TestRedisMapBroker_OrderedStateAsc(t *testing.T) {
 // TestRedisMapBroker_OrderedStatePaginationAsc tests cursor-based pagination
 // with ASC ordering across multiple pages.
 func TestRedisMapBroker_OrderedStatePaginationAsc(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -3177,6 +3228,7 @@ func TestRedisMapBroker_OrderedStatePaginationAsc(t *testing.T) {
 // TestRedisMapBroker_OrderedStateAscSameScores tests ASC ordering with
 // same-score entries — secondary sort by key ascending.
 func TestRedisMapBroker_OrderedStateAscSameScores(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -3250,6 +3302,7 @@ func TestRedisMapBroker_OrderedStateAscSameScores(t *testing.T) {
 }
 
 func TestRedisMapBroker_CleanupMetrics(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		registry := prometheus.NewRegistry()
 		node, _ := New(Config{
@@ -3311,6 +3364,7 @@ func TestRedisMapBroker_CleanupMetrics(t *testing.T) {
 
 // TestRedisMapBroker_Unsubscribe tests Unsubscribe after Subscribe.
 func TestRedisMapBroker_Unsubscribe(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		handler := &testBrokerEventHandler{
@@ -3340,6 +3394,7 @@ func TestRedisMapBroker_Unsubscribe(t *testing.T) {
 
 // TestRedisMapBroker_UnsubscribeWithoutSubscribe tests Unsubscribe on a channel not subscribed.
 func TestRedisMapBroker_UnsubscribeWithoutSubscribe(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		handler := &testBrokerEventHandler{
@@ -3365,6 +3420,7 @@ func TestRedisMapBroker_UnsubscribeWithoutSubscribe(t *testing.T) {
 
 // TestRedisMapBroker_CAS_Publish tests CAS semantics for Publish in Redis.
 func TestRedisMapBroker_CAS_Publish(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -3418,6 +3474,7 @@ func TestRedisMapBroker_CAS_Publish(t *testing.T) {
 
 // TestRedisMapBroker_CAS_Remove tests CAS semantics for Remove in Redis.
 func TestRedisMapBroker_CAS_Remove(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -3455,6 +3512,7 @@ func TestRedisMapBroker_CAS_Remove(t *testing.T) {
 
 // TestRedisMapBroker_RemoveIdempotency tests idempotency key for Remove in Redis.
 func TestRedisMapBroker_RemoveIdempotency(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -3493,6 +3551,7 @@ func TestRedisMapBroker_RemoveIdempotency(t *testing.T) {
 
 // TestRedisMapBroker_VersionEpoch tests version epoch scoping in Redis.
 func TestRedisMapBroker_VersionEpoch(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{})
 		broker := mb.make(t, node)
@@ -3576,6 +3635,7 @@ func TestNewRedisMapBrokerErrors(t *testing.T) {
 // against a live Redis Cluster. Requires a 3-node cluster on 7001-7003 with
 // sharded PUB/SUB support (Redis 7+); skipped otherwise.
 func TestRedisMapBroker_UsePrecomputedPartitionTags_ClusterE2E(t *testing.T) {
+	t.Parallel()
 	node, _ := New(Config{
 		Map: MapConfig{
 			GetMapChannelOptions: func(string) MapChannelOptions {
@@ -3642,6 +3702,7 @@ func TestRedisMapBroker_UsePrecomputedPartitionTags_ClusterE2E(t *testing.T) {
 // subscriber and publisher could end up on different nodes for the same
 // partition. Run for both tag schemes.
 func TestRedisMapBroker_PartitionSlotInvariant(t *testing.T) {
+	t.Parallel()
 	clusterShard := &RedisShard{isCluster: true}
 	const numPartitions = 16
 	const numPsShards = 2
@@ -3689,6 +3750,7 @@ func TestRedisMapBroker_PartitionSlotInvariant(t *testing.T) {
 }
 
 func TestRedisMapBroker_PubSubPartitionHashTag(t *testing.T) {
+	t.Parallel()
 	t.Run("default scheme returns bare integer", func(t *testing.T) {
 		broker := &RedisMapBroker{
 			conf: RedisMapBrokerConfig{NumShardedPubSubPartitions: 16},
@@ -3715,6 +3777,7 @@ func TestRedisMapBroker_PubSubPartitionHashTag(t *testing.T) {
 // builders that thread partition tags through and verifies they all use the
 // precomputed tag rather than the bare partition index.
 func TestRedisMapBroker_PrecomputedTags_KeyConsistency(t *testing.T) {
+	t.Parallel()
 	tags, err := redispartition.FindTags(16)
 	require.NoError(t, err)
 
@@ -3757,6 +3820,7 @@ func TestRedisMapBroker_PrecomputedTags_KeyConsistency(t *testing.T) {
 // returns publications and a stream position consistent with ReadState.
 // ReadPresenceState is a thin wrapper over ReadState.
 func TestRedisMapBrokerReadPresenceState(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		t.Parallel()
 		node := testNode(t)
@@ -3782,6 +3846,7 @@ func TestRedisMapBrokerReadPresenceState(t *testing.T) {
 // TestRedisMapBrokerReadPresenceStream verifies the presence-stream read wrapper
 // returns the underlying stream entries.
 func TestRedisMapBrokerReadPresenceStream(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		t.Parallel()
 		node := testNode(t)
@@ -3807,6 +3872,7 @@ func TestRedisMapBrokerReadPresenceStream(t *testing.T) {
 // TestRedisMapBrokerCloseIdempotent exercises Close, including the closeOnce
 // guard on a second invocation.
 func TestRedisMapBrokerCloseIdempotent(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		t.Parallel()
 		node := testNode(t)
@@ -3895,6 +3961,7 @@ func TestRedisMapBrokerPublishEphemeralRejectsCASAndVersion(t *testing.T) {
 // whose keys are being kept alive can still lose meta + stream to native Redis
 // TTL, forcing an epoch reset on the next publish.
 func TestRedisMapBroker_RefreshTTLOnSuppress_RefreshesMetaAndStream(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -3965,6 +4032,7 @@ func TestRedisMapBroker_RefreshTTLOnSuppress_RefreshesMetaAndStream(t *testing.T
 // TestRedisMapBroker_NoRefreshTTL_LeavesMetaAlone is the negative case:
 // without RefreshTTLOnSuppress, suppressed publishes do not bump meta_key.
 func TestRedisMapBroker_NoRefreshTTL_LeavesMetaAlone(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -4023,6 +4091,7 @@ func TestRedisMapBroker_NoRefreshTTL_LeavesMetaAlone(t *testing.T) {
 // runs. Without this, a zombie key under the dead epoch would suppress a
 // legitimate fresh-epoch publish via KeyModeIfNew.
 func TestRedisMapBroker_PublishWipesStateOnEpochReset(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -4092,6 +4161,7 @@ func TestRedisMapBroker_PublishWipesStateOnEpochReset(t *testing.T) {
 // the wipe firing when meta_key is intact — every subsequent publish must
 // preserve the state hash, only the explicit-eviction path triggers the wipe.
 func TestRedisMapBroker_PublishDoesNotWipeStateOnNormalPublish(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -4130,6 +4200,7 @@ func TestRedisMapBroker_PublishDoesNotWipeStateOnNormalPublish(t *testing.T) {
 // before the KeyMode=if_new check, otherwise a fresh-epoch publish would be
 // suppressed by zombie keys with no live metadata.
 func TestRedisMapBroker_PublishWipesZombieStateWhenStateMetaEvicted(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{
@@ -4204,6 +4275,7 @@ func TestRedisMapBroker_PublishWipesZombieStateWhenStateMetaEvicted(t *testing.T
 // xrange would return dead-epoch entries under the fresh meta wrapper.
 // Mirrors the publish-path safety net (`if top_offset == 1 then del stream_key`).
 func TestRedisMapBroker_StreamReadWipesStreamOnFreshMeta(t *testing.T) {
+	t.Parallel()
 	runMapBrokerTest(t, func(t *testing.T, mb redisMapBrokerFactory) {
 		node, _ := New(Config{
 			Map: MapConfig{

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -158,6 +158,7 @@ func BenchmarkIncUnsubscribe(b *testing.B) {
 }
 
 func TestMetrics(t *testing.T) {
+	t.Parallel()
 	_, err := newMetricsRegistry(MetricsConfig{
 		GetChannelNamespaceLabel: func(channel string) string {
 			return channel
@@ -295,6 +296,7 @@ func TestMetrics(t *testing.T) {
 }
 
 func Test_getHTTPTransportProto(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		protoMajor int8
 	}
@@ -334,6 +336,7 @@ func Test_getHTTPTransportProto(t *testing.T) {
 }
 
 func TestMetrics_MapBrokerAndRedisBrokerCounters(t *testing.T) {
+	t.Parallel()
 	m, err := newMetricsRegistry(MetricsConfig{
 		MetricsNamespace: "test_map",
 		GetChannelNamespaceLabel: func(channel string) string {

--- a/node_test.go
+++ b/node_test.go
@@ -307,6 +307,7 @@ func TestClientEventHub(t *testing.T) {
 }
 
 func TestNodeRegistry(t *testing.T) {
+	t.Parallel()
 	registry := newNodeRegistry("node1")
 	nodeInfo1 := controlpb.Node{Uid: "node1"}
 	nodeInfo2 := controlpb.Node{Uid: "node2"}

--- a/node_test.go
+++ b/node_test.go
@@ -278,11 +278,13 @@ func defaultTestNode() *Node {
 }
 
 func TestErrorMessage(t *testing.T) {
+	t.Parallel()
 	errMessage := ErrorTooManyRequests.Error()
 	require.Equal(t, "111: too many requests", errMessage)
 }
 
 func TestNode_Shutdown(t *testing.T) {
+	t.Parallel()
 	n := defaultNodeNoHandlers()
 	require.NoError(t, n.Shutdown(context.Background()))
 	require.True(t, n.shutdown)
@@ -291,6 +293,7 @@ func TestNode_Shutdown(t *testing.T) {
 }
 
 func TestNode_shutdownCmd(t *testing.T) {
+	t.Parallel()
 	// Testing that shutdownCmd removes node from nodes registry.
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
@@ -300,6 +303,7 @@ func TestNode_shutdownCmd(t *testing.T) {
 }
 
 func TestClientEventHub(t *testing.T) {
+	t.Parallel()
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 	n.OnConnect(func(_ *Client) {})
@@ -328,6 +332,7 @@ func TestNodeRegistry(t *testing.T) {
 }
 
 func TestNodeLogHandler(t *testing.T) {
+	t.Parallel()
 	doneCh := make(chan struct{})
 	n, _ := New(Config{
 		LogLevel: LogLevelInfo,
@@ -348,6 +353,7 @@ func TestNodeLogHandler(t *testing.T) {
 }
 
 func TestNode_SetBroker(t *testing.T) {
+	t.Parallel()
 	n, _ := New(Config{})
 	broker := testMemoryBroker()
 	n.SetBroker(broker)
@@ -355,6 +361,7 @@ func TestNode_SetBroker(t *testing.T) {
 }
 
 func TestNode_SetPresenceManager_NilPresenceManager(t *testing.T) {
+	t.Parallel()
 	n, _ := New(Config{})
 	n.SetPresenceManager(nil)
 	require.NoError(t, n.addPresence("test", "uid", &ClientInfo{}))
@@ -366,6 +373,7 @@ func TestNode_SetPresenceManager_NilPresenceManager(t *testing.T) {
 }
 
 func TestNode_LogEnabled(t *testing.T) {
+	t.Parallel()
 	n, _ := New(Config{
 		LogLevel:   LogLevelInfo,
 		LogHandler: func(entry LogEntry) {},
@@ -375,6 +383,7 @@ func TestNode_LogEnabled(t *testing.T) {
 }
 
 func TestNode_RunError(t *testing.T) {
+	t.Parallel()
 	broker := NewTestBroker()
 	broker.errorOnRegister = true
 	node, err := New(Config{})
@@ -385,6 +394,7 @@ func TestNode_RunError(t *testing.T) {
 }
 
 func TestNode_RunPubControlError(t *testing.T) {
+	t.Parallel()
 	controller := NewTestController()
 	controller.errorOnPublishControl = true
 	node, err := New(Config{})
@@ -395,6 +405,7 @@ func TestNode_RunPubControlError(t *testing.T) {
 }
 
 func TestNode_SetPresenceManager(t *testing.T) {
+	t.Parallel()
 	n, _ := New(Config{})
 	presenceManager := testMemoryPresenceManager(t)
 	n.SetPresenceManager(presenceManager)
@@ -402,6 +413,7 @@ func TestNode_SetPresenceManager(t *testing.T) {
 }
 
 func TestNode_Info(t *testing.T) {
+	t.Parallel()
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 	info, err := n.Info()
@@ -410,6 +422,7 @@ func TestNode_Info(t *testing.T) {
 }
 
 func TestNode_handleJoin(t *testing.T) {
+	t.Parallel()
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 	err := n.handleJoin("test", &ClientInfo{})
@@ -417,6 +430,7 @@ func TestNode_handleJoin(t *testing.T) {
 }
 
 func TestNode_handleLeave(t *testing.T) {
+	t.Parallel()
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 	err := n.handleLeave("test", &ClientInfo{})
@@ -424,6 +438,7 @@ func TestNode_handleLeave(t *testing.T) {
 }
 
 func TestNode_Subscribe(t *testing.T) {
+	t.Parallel()
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -455,6 +470,7 @@ func TestNode_Subscribe(t *testing.T) {
 }
 
 func TestNode_Unsubscribe(t *testing.T) {
+	t.Parallel()
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -486,6 +502,7 @@ func TestNode_Unsubscribe(t *testing.T) {
 }
 
 func TestNode_Disconnect(t *testing.T) {
+	t.Parallel()
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -514,6 +531,7 @@ func TestNode_Disconnect(t *testing.T) {
 }
 
 func TestNode_pubUnsubscribe(t *testing.T) {
+	t.Parallel()
 	node := nodeWithTestController()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -526,6 +544,7 @@ func TestNode_pubUnsubscribe(t *testing.T) {
 }
 
 func TestNode_pubDisconnect(t *testing.T) {
+	t.Parallel()
 	node := nodeWithTestController()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -538,6 +557,7 @@ func TestNode_pubDisconnect(t *testing.T) {
 }
 
 func TestNode_publishJoin(t *testing.T) {
+	t.Parallel()
 	n := nodeWithTestBroker()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -556,6 +576,7 @@ func TestNode_publishJoin(t *testing.T) {
 }
 
 func TestNode_publishLeave(t *testing.T) {
+	t.Parallel()
 	n := nodeWithTestBroker()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -574,6 +595,7 @@ func TestNode_publishLeave(t *testing.T) {
 }
 
 func TestNode_RemoveHistory(t *testing.T) {
+	t.Parallel()
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -582,6 +604,7 @@ func TestNode_RemoveHistory(t *testing.T) {
 }
 
 func TestNode_History_ErrorOnReverseWithZeroOffset(t *testing.T) {
+	t.Parallel()
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 	_, err := n.History("test", WithReverse(true), WithSince(&StreamPosition{Offset: 0}))
@@ -589,6 +612,7 @@ func TestNode_History_ErrorOnReverseWithZeroOffset(t *testing.T) {
 }
 
 func TestIndex(t *testing.T) {
+	t.Parallel()
 	require.Equal(t, 0, index("2121", 1))
 }
 
@@ -740,6 +764,7 @@ func BenchmarkHistory(b *testing.B) {
 }
 
 func TestNode_handleControl(t *testing.T) {
+	t.Parallel()
 	t.Run("BrokenData", func(t *testing.T) {
 		t.Parallel()
 
@@ -927,6 +952,7 @@ func TestNode_handleControl(t *testing.T) {
 }
 
 func Test_infoFromProto(t *testing.T) {
+	t.Parallel()
 	info := infoFromProto(nil)
 	require.Nil(t, info)
 
@@ -954,6 +980,7 @@ func Test_infoFromProto(t *testing.T) {
 }
 
 func Test_infoToProto(t *testing.T) {
+	t.Parallel()
 	info := infoToProto(nil)
 	require.Nil(t, info)
 
@@ -981,6 +1008,7 @@ func Test_infoToProto(t *testing.T) {
 }
 
 func Test_pubToProto(t *testing.T) {
+	t.Parallel()
 	pub := pubToProto(nil)
 	require.Nil(t, pub)
 
@@ -998,6 +1026,7 @@ func Test_pubToProto(t *testing.T) {
 }
 
 func Test_pubFromProto(t *testing.T) {
+	t.Parallel()
 	pub := pubFromProto(nil)
 	require.Nil(t, pub)
 
@@ -1015,6 +1044,7 @@ func Test_pubFromProto(t *testing.T) {
 }
 
 func TestNode_OnSurvey(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1039,6 +1069,7 @@ func TestNode_OnSurvey(t *testing.T) {
 }
 
 func TestNode_OnSurveyWithNodeID(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1063,6 +1094,7 @@ func TestNode_OnSurveyWithNodeID(t *testing.T) {
 }
 
 func TestNode_OnSurvey_NoHandler(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1072,6 +1104,7 @@ func TestNode_OnSurvey_NoHandler(t *testing.T) {
 }
 
 func TestNode_OnSurvey_Timeout(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1097,6 +1130,7 @@ func TestNode_OnSurvey_Timeout(t *testing.T) {
 }
 
 func TestNode_OnNotification(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1115,6 +1149,7 @@ func TestNode_OnNotification(t *testing.T) {
 }
 
 func TestNode_OnNotification_SameNode(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1133,6 +1168,7 @@ func TestNode_OnNotification_SameNode(t *testing.T) {
 }
 
 func TestNode_OnNotification_NoHandler(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	err := node.Notify("notification", []byte(`notification`), "")
@@ -1140,6 +1176,7 @@ func TestNode_OnNotification_NoHandler(t *testing.T) {
 }
 
 func TestNode_handleNotification_NoHandler(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	err := node.handleNotification("test", &controlpb.Notification{})
@@ -1147,6 +1184,7 @@ func TestNode_handleNotification_NoHandler(t *testing.T) {
 }
 
 func TestNode_handleSurveyRequest_NoHandler(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	err := node.handleSurveyRequest("test", &controlpb.SurveyRequest{})
@@ -1154,6 +1192,7 @@ func TestNode_handleSurveyRequest_NoHandler(t *testing.T) {
 }
 
 func TestErrors(t *testing.T) {
+	t.Parallel()
 	err := ErrorUnauthorized
 	protoErr := err.toProto()
 	require.Equal(t, ErrorUnauthorized.Code, protoErr.Code)
@@ -1163,6 +1202,7 @@ func TestErrors(t *testing.T) {
 }
 
 func TestSingleFlightHistory(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	node.config.UseSingleFlight = true
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -1182,6 +1222,7 @@ func TestSingleFlightHistory(t *testing.T) {
 }
 
 func TestSingleFlightPresence(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	node.config.UseSingleFlight = true
 
@@ -1215,6 +1256,7 @@ func TestSingleFlightPresence(t *testing.T) {
 }
 
 func TestBrokerEventHandler_PanicsOnNil(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 	require.Panics(t, func() {
@@ -1229,6 +1271,7 @@ func TestBrokerEventHandler_PanicsOnNil(t *testing.T) {
 }
 
 func TestNode_OnNodeInfoSend(t *testing.T) {
+	t.Parallel()
 	n, err := New(Config{})
 	if err != nil {
 		panic(err)
@@ -1258,6 +1301,7 @@ func TestNode_OnNodeInfoSend(t *testing.T) {
 }
 
 func TestNode_OnTransportWrite(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1293,6 +1337,7 @@ func TestNode_OnTransportWrite(t *testing.T) {
 }
 
 func TestNode_OnTransportWriteProtocolV2(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1317,6 +1362,7 @@ func TestNode_OnTransportWriteProtocolV2(t *testing.T) {
 }
 
 func TestNode_OnTransportWriteSkip(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1343,6 +1389,7 @@ func TestNode_OnTransportWriteSkip(t *testing.T) {
 }
 
 func TestNode_OnCommandRead(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1394,6 +1441,7 @@ func TestNode_OnCommandRead(t *testing.T) {
 }
 
 func TestNodeCheckPosition(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1428,6 +1476,7 @@ func TestNodeCheckPosition(t *testing.T) {
 }
 
 func TestNodeCheckPositionMap(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1493,6 +1542,7 @@ func TestNodeCheckPositionMap(t *testing.T) {
 }
 
 func TestNodeCheckPositionMapWithMedium(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1567,6 +1617,7 @@ func TestNodeCheckPositionMapWithMedium(t *testing.T) {
 }
 
 func TestGetBroker(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	customBroker := NewTestBroker()
 	node.config.GetBroker = func(channel string) (Broker, bool) {
@@ -1591,6 +1642,7 @@ func TestGetBroker(t *testing.T) {
 }
 
 func TestGetPresenceManager(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	customPresenceManager := NewTestPresenceManager()
 	node.config.GetPresenceManager = func(channel string) (PresenceManager, bool) {
@@ -1613,6 +1665,7 @@ func TestGetPresenceManager(t *testing.T) {
 }
 
 func TestGetMapBroker(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1683,6 +1736,7 @@ func TestGetMapBroker(t *testing.T) {
 }
 
 func TestNode_MapStreamReadUnrecoverablePosition(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1721,6 +1775,7 @@ func TestNode_MapStreamReadUnrecoverablePosition(t *testing.T) {
 }
 
 func TestNode_MapRemoveEmptyKey(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1740,6 +1795,7 @@ func TestNode_MapRemoveEmptyKey(t *testing.T) {
 }
 
 func TestNode_Config(t *testing.T) {
+	t.Parallel()
 	cfg := Config{
 		LogLevel: LogLevelInfo,
 	}
@@ -1750,6 +1806,7 @@ func TestNode_Config(t *testing.T) {
 }
 
 func TestNode_MapMetricMethods(t *testing.T) {
+	t.Parallel()
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 	// These should not panic even when metrics are initialized.
@@ -1759,6 +1816,7 @@ func TestNode_MapMetricMethods(t *testing.T) {
 }
 
 func TestNode_MapMetricMethods_NilMetrics(t *testing.T) {
+	t.Parallel()
 	n, err := New(Config{})
 	require.NoError(t, err)
 	// Before Run(), metrics may be nil — should not panic.
@@ -1768,6 +1826,7 @@ func TestNode_MapMetricMethods_NilMetrics(t *testing.T) {
 }
 
 func TestNode_mapStateKey(t *testing.T) {
+	t.Parallel()
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -1788,6 +1847,7 @@ func TestNode_mapStateKey(t *testing.T) {
 }
 
 func TestNode_mapStreamKey(t *testing.T) {
+	t.Parallel()
 	n := defaultNodeNoHandlers()
 	defer func() { _ = n.Shutdown(context.Background()) }()
 
@@ -1809,6 +1869,7 @@ func TestNode_mapStreamKey(t *testing.T) {
 }
 
 func TestNode_MapStats(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1833,6 +1894,7 @@ func TestNode_MapStats(t *testing.T) {
 }
 
 func TestNode_MapClear(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1861,6 +1923,7 @@ func TestNode_MapClear(t *testing.T) {
 }
 
 func TestNode_MapPublishEmptyKey(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1880,6 +1943,7 @@ func TestNode_MapPublishEmptyKey(t *testing.T) {
 }
 
 func TestNode_MapPublish(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1897,6 +1961,7 @@ func TestNode_MapPublish(t *testing.T) {
 }
 
 func TestNode_MapRemove(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -1920,6 +1985,7 @@ func TestNode_MapRemove(t *testing.T) {
 }
 
 func TestHub_Connections(t *testing.T) {
+	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 

--- a/options_test.go
+++ b/options_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestWithHistory(t *testing.T) {
+	t.Parallel()
 	opt := WithHistory(10, time.Second)
 	opts := &PublishOptions{}
 	opt(opts)
@@ -16,6 +17,7 @@ func TestWithHistory(t *testing.T) {
 }
 
 func TestWithIdempotencyKey(t *testing.T) {
+	t.Parallel()
 	opt := WithIdempotencyKey("ik")
 	opts := &PublishOptions{}
 	opt(opts)
@@ -23,6 +25,7 @@ func TestWithIdempotencyKey(t *testing.T) {
 }
 
 func TestWithDelta(t *testing.T) {
+	t.Parallel()
 	opt := WithDelta(true)
 	opts := &PublishOptions{}
 	opt(opts)
@@ -30,6 +33,7 @@ func TestWithDelta(t *testing.T) {
 }
 
 func TestWithIdempotentResultTTL(t *testing.T) {
+	t.Parallel()
 	opt := WithIdempotentResultTTL(time.Minute)
 	opts := &PublishOptions{}
 	opt(opts)
@@ -37,6 +41,7 @@ func TestWithIdempotentResultTTL(t *testing.T) {
 }
 
 func TestWithMeta(t *testing.T) {
+	t.Parallel()
 	opt := WithTags(map[string]string{"test": "value"})
 	opts := &PublishOptions{}
 	opt(opts)
@@ -44,6 +49,7 @@ func TestWithMeta(t *testing.T) {
 }
 
 func TestWithVersion(t *testing.T) {
+	t.Parallel()
 	opt := WithVersion(2, "xxx")
 	opts := &PublishOptions{}
 	opt(opts)
@@ -52,6 +58,7 @@ func TestWithVersion(t *testing.T) {
 }
 
 func TestSubscribeOptions(t *testing.T) {
+	t.Parallel()
 	subscribeOpts := []SubscribeOption{
 		WithExpireAt(1),
 		WithEmitPresence(true),
@@ -85,6 +92,7 @@ func TestSubscribeOptions(t *testing.T) {
 }
 
 func TestWithDisconnect(t *testing.T) {
+	t.Parallel()
 	opt := WithCustomDisconnect(DisconnectConnectionLimit)
 	opts := &DisconnectOptions{}
 	opt(opts)
@@ -92,6 +100,7 @@ func TestWithDisconnect(t *testing.T) {
 }
 
 func TestWithClientWhitelist(t *testing.T) {
+	t.Parallel()
 	opt := WithDisconnectClientWhitelist([]string{"client"})
 	opts := &DisconnectOptions{}
 	opt(opts)
@@ -99,6 +108,7 @@ func TestWithClientWhitelist(t *testing.T) {
 }
 
 func TestWithLimit(t *testing.T) {
+	t.Parallel()
 	opt := WithLimit(NoLimit)
 	opts := &HistoryOptions{}
 	opt(opts)
@@ -106,6 +116,7 @@ func TestWithLimit(t *testing.T) {
 }
 
 func TestWithSubscribeClient(t *testing.T) {
+	t.Parallel()
 	opt := WithSubscribeClient("client")
 	opts := &SubscribeOptions{}
 	opt(opts)
@@ -113,6 +124,7 @@ func TestWithSubscribeClient(t *testing.T) {
 }
 
 func TestWithSubscribeData(t *testing.T) {
+	t.Parallel()
 	opt := WithSubscribeData([]byte("test"))
 	opts := &SubscribeOptions{}
 	opt(opts)
@@ -120,6 +132,7 @@ func TestWithSubscribeData(t *testing.T) {
 }
 
 func TestWithUnsubscribeClient(t *testing.T) {
+	t.Parallel()
 	opt := WithUnsubscribeClient("client")
 	opts := &UnsubscribeOptions{}
 	opt(opts)
@@ -127,6 +140,7 @@ func TestWithUnsubscribeClient(t *testing.T) {
 }
 
 func TestWithUnsubscribeSession(t *testing.T) {
+	t.Parallel()
 	opt := WithUnsubscribeSession("session")
 	opts := &UnsubscribeOptions{}
 	opt(opts)
@@ -134,6 +148,7 @@ func TestWithUnsubscribeSession(t *testing.T) {
 }
 
 func TestWithCustomUnsubscribe(t *testing.T) {
+	t.Parallel()
 	opt := WithCustomUnsubscribe(Unsubscribe{
 		Code:   2200,
 		Reason: "x",
@@ -145,6 +160,7 @@ func TestWithCustomUnsubscribe(t *testing.T) {
 }
 
 func TestWithDisconnectClient(t *testing.T) {
+	t.Parallel()
 	opt := WithDisconnectClient("client")
 	opts := &DisconnectOptions{}
 	opt(opts)
@@ -152,6 +168,7 @@ func TestWithDisconnectClient(t *testing.T) {
 }
 
 func TestWithDisconnectSession(t *testing.T) {
+	t.Parallel()
 	opt := WithDisconnectSession("session")
 	opts := &DisconnectOptions{}
 	opt(opts)
@@ -159,6 +176,7 @@ func TestWithDisconnectSession(t *testing.T) {
 }
 
 func TestWithKey(t *testing.T) {
+	t.Parallel()
 	opt := WithKey("mykey")
 	opts := &PublishOptions{}
 	opt(opts)
@@ -166,6 +184,7 @@ func TestWithKey(t *testing.T) {
 }
 
 func TestWithClientInfo(t *testing.T) {
+	t.Parallel()
 	info := &ClientInfo{UserID: "user1"}
 	opt := WithClientInfo(info)
 	opts := &PublishOptions{}
@@ -174,6 +193,7 @@ func TestWithClientInfo(t *testing.T) {
 }
 
 func TestSubscriptionType_String(t *testing.T) {
+	t.Parallel()
 	require.Equal(t, "stream", SubscriptionTypeStream.String())
 	require.Equal(t, "map", SubscriptionTypeMap.String())
 	require.Equal(t, "map_clients", SubscriptionTypeMapClients.String())
@@ -183,6 +203,7 @@ func TestSubscriptionType_String(t *testing.T) {
 }
 
 func TestSubscriptionType_IsMapPresence(t *testing.T) {
+	t.Parallel()
 	require.False(t, SubscriptionTypeStream.IsMapPresence())
 	require.False(t, SubscriptionTypeMap.IsMapPresence())
 	require.True(t, SubscriptionTypeMapClients.IsMapPresence())
@@ -191,6 +212,7 @@ func TestSubscriptionType_IsMapPresence(t *testing.T) {
 }
 
 func TestWithRecoverSince(t *testing.T) {
+	t.Parallel()
 	opt := WithRecoverSince(&StreamPosition{Offset: 10, Epoch: "abc"})
 	opts := &SubscribeOptions{}
 	opt(opts)
@@ -199,6 +221,7 @@ func TestWithRecoverSince(t *testing.T) {
 }
 
 func TestWithHistoryFilter(t *testing.T) {
+	t.Parallel()
 	opt := WithHistoryFilter(HistoryFilter{Limit: 5, Reverse: true})
 	opts := &HistoryOptions{}
 	opt(opts)
@@ -207,6 +230,7 @@ func TestWithHistoryFilter(t *testing.T) {
 }
 
 func TestWithSince(t *testing.T) {
+	t.Parallel()
 	opt := WithSince(&StreamPosition{Offset: 7, Epoch: "xyz"})
 	opts := &HistoryOptions{}
 	opt(opts)
@@ -215,6 +239,7 @@ func TestWithSince(t *testing.T) {
 }
 
 func TestWithReverse(t *testing.T) {
+	t.Parallel()
 	opt := WithReverse(true)
 	opts := &HistoryOptions{}
 	opt(opts)
@@ -222,6 +247,7 @@ func TestWithReverse(t *testing.T) {
 }
 
 func TestWithHistoryMetaTTL(t *testing.T) {
+	t.Parallel()
 	opt := WithHistoryMetaTTL(time.Hour)
 	opts := &HistoryOptions{}
 	opt(opts)
@@ -229,6 +255,7 @@ func TestWithHistoryMetaTTL(t *testing.T) {
 }
 
 func TestRefreshOptions(t *testing.T) {
+	t.Parallel()
 	refreshOpts := []RefreshOption{
 		WithRefreshClient("client"),
 		WithRefreshExpireAt(12),

--- a/presence_redis_test.go
+++ b/presence_redis_test.go
@@ -101,6 +101,7 @@ func excludeClusterPresenceTests(tests []redisPresenceTest) []redisPresenceTest 
 }
 
 func TestRedisPresenceManager(t *testing.T) {
+	t.Parallel()
 	for _, tt := range redisPresenceTests {
 		t.Run(tt.Name, func(t *testing.T) {
 			node := testNode(t)
@@ -131,6 +132,7 @@ func TestRedisPresenceManager(t *testing.T) {
 }
 
 func TestRedisPresenceManagerWithUserMapping(t *testing.T) {
+	t.Parallel()
 	for _, tt := range redisPresenceTests {
 		t.Run(tt.Name, func(t *testing.T) {
 			node := testNode(t)
@@ -205,6 +207,7 @@ func TestRedisPresenceManagerWithUserMapping(t *testing.T) {
 }
 
 func TestRedisPresenceManagerWithHashFieldTTL(t *testing.T) {
+	t.Parallel()
 	t.Skip() // Will work on Redis 7.4 for now, so skipping for now since CI also runs on Redis 6.
 	for _, tt := range redisPresenceTests {
 		for _, userMapping := range []bool{true, false} {

--- a/redis_cluster_slot_test.go
+++ b/redis_cluster_slot_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestRedisSlot_KnownValues(t *testing.T) {
+	t.Parallel()
 	// These values match Redis CLUSTER KEYSLOT output.
 	tests := []struct {
 		key  string
@@ -35,6 +36,7 @@ func TestRedisSlot_KnownValues(t *testing.T) {
 }
 
 func TestRedisSlot_HashTagEdgeCases(t *testing.T) {
+	t.Parallel()
 	// Empty hash tag {}: no valid tag, hash full key.
 	slotFull := redisSlot("abc{}")
 	slotABC := redisSlot("abc{}")
@@ -58,6 +60,7 @@ func TestRedisSlot_HashTagEdgeCases(t *testing.T) {
 }
 
 func TestRedisSlot_PartitionHashTags(t *testing.T) {
+	t.Parallel()
 	// Verify that partition hash tags {0}, {1}, ... map to different slots.
 	seen := make(map[uint16]bool)
 	for i := 0; i < 256; i++ {

--- a/shared_poll.go
+++ b/shared_poll.go
@@ -165,17 +165,35 @@ func (m *SharedPollManager) track(channel string, opts SharedPollChannelOptions,
 	default:
 	}
 
-	// If this state was removed by shutdown timer, replace it.
-	if s.removed {
+	// If this state was removed by shutdown timer, replace it and loop
+	// until we hold the lock on a non-removed state.
+	//
+	// Re-check m.channels[channel] under m.mu and reuse any fresh state a
+	// concurrent caller installed — an unconditional overwrite would
+	// orphan that caller's worker (nothing outside m.channels keeps a
+	// reference for cancellation, so the lost worker would stay parked in
+	// select with an uncancelled context, and m.close()'s wg.Wait would
+	// hang forever).
+	//
+	// Loop, because the cur we ended up with may itself be removed by a
+	// third goroutine between when it was placed and when we acquire
+	// cur.mu — that would otherwise fall through to add a key + restart
+	// the worker on an about-to-be-finalized state, leaking the new
+	// worker the same way.
+	for s.removed {
 		s.mu.Unlock()
 		m.mu.Lock()
-		s = &sharedPollChannelState{
-			opts:      opts,
-			epoch:     initialChannelEpoch(opts),
-			itemIndex: make(map[string]*sharedPollTrackedEntry),
-			notifCh:   make(chan string, notifChCapacity),
+		cur, ok := m.channels[channel]
+		if !ok || cur == s {
+			cur = &sharedPollChannelState{
+				opts:      opts,
+				epoch:     initialChannelEpoch(opts),
+				itemIndex: make(map[string]*sharedPollTrackedEntry),
+				notifCh:   make(chan string, notifChCapacity),
+			}
+			m.channels[channel] = cur
 		}
-		m.channels[channel] = s
+		s = cur
 		m.mu.Unlock()
 		s.mu.Lock()
 		select {
@@ -289,17 +307,25 @@ func (m *SharedPollManager) trackKeys(channel string, opts SharedPollChannelOpti
 	default:
 	}
 
-	// If this state was removed by shutdown timer, replace it.
-	if s.removed {
+	// If this state was removed by shutdown timer, replace it. See the
+	// matching loop in track() for the race rationale: both an
+	// unconditional overwrite and a single-shot re-check would still
+	// orphan a worker — a fresh state we land on may itself be in the
+	// process of being shut down by a third goroutine.
+	for s.removed {
 		s.mu.Unlock()
 		m.mu.Lock()
-		s = &sharedPollChannelState{
-			opts:      opts,
-			epoch:     initialChannelEpoch(opts),
-			itemIndex: make(map[string]*sharedPollTrackedEntry),
-			notifCh:   make(chan string, notifChCapacity),
+		cur, ok := m.channels[channel]
+		if !ok || cur == s {
+			cur = &sharedPollChannelState{
+				opts:      opts,
+				epoch:     initialChannelEpoch(opts),
+				itemIndex: make(map[string]*sharedPollTrackedEntry),
+				notifCh:   make(chan string, notifChCapacity),
+			}
+			m.channels[channel] = cur
 		}
-		m.channels[channel] = s
+		s = cur
 		m.mu.Unlock()
 		s.mu.Lock()
 		select {

--- a/shared_poll_test.go
+++ b/shared_poll_test.go
@@ -85,6 +85,7 @@ func (b *controllableBroker) Unsubscribe(channels ...string) error {
 }
 
 func TestSharedPollManager_TrackCreatesChannel(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 
@@ -105,6 +106,7 @@ func TestSharedPollManager_TrackCreatesChannel(t *testing.T) {
 }
 
 func TestSharedPollManager_UntrackRemovesFromIndex(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 
@@ -132,6 +134,7 @@ func TestSharedPollManager_UntrackRemovesFromIndex(t *testing.T) {
 }
 
 func TestSharedPollManager_HasChannel(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 
@@ -148,6 +151,7 @@ func TestSharedPollManager_HasChannel(t *testing.T) {
 }
 
 func TestSharedPollManager_WorkerStartsOnTrack(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 
@@ -167,6 +171,7 @@ func TestSharedPollManager_WorkerStartsOnTrack(t *testing.T) {
 }
 
 func TestSharedPollManager_Close(t *testing.T) {
+	t.Parallel()
 	node, err := New(Config{
 		LogLevel:   LogLevelTrace,
 		LogHandler: func(entry LogEntry) {},
@@ -207,6 +212,7 @@ func TestSharedPollManager_Close(t *testing.T) {
 }
 
 func TestSharedPollNotify_TriggersRefresh(t *testing.T) {
+	t.Parallel()
 	callCh := make(chan SharedPollEvent, 10)
 
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
@@ -261,6 +267,7 @@ func TestSharedPollNotify_TriggersRefresh(t *testing.T) {
 }
 
 func TestSharedPollNotify_BatchBySize(t *testing.T) {
+	t.Parallel()
 	callCh := make(chan SharedPollEvent, 10)
 
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
@@ -310,6 +317,7 @@ func TestSharedPollNotify_BatchBySize(t *testing.T) {
 }
 
 func TestSharedPollNotify_DeduplicatesKeys(t *testing.T) {
+	t.Parallel()
 	callCh := make(chan SharedPollEvent, 10)
 
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
@@ -359,6 +367,7 @@ func TestSharedPollNotify_DeduplicatesKeys(t *testing.T) {
 }
 
 func TestSharedPollNotify_UnknownChannelDropped(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 
@@ -369,6 +378,7 @@ func TestSharedPollNotify_UnknownChannelDropped(t *testing.T) {
 }
 
 func TestSharedPollNotify_FullFlow_DataDelivered(t *testing.T) {
+	t.Parallel()
 	// Full flow: client subscribes + tracks → notification arrives →
 	// backend polled for notified keys → data delivered to client
 	// (per-connection version updated). Timer interval is long so
@@ -430,6 +440,7 @@ func TestSharedPollNotify_FullFlow_DataDelivered(t *testing.T) {
 }
 
 func TestSharedPollNotify_FullFlow_TwoClients(t *testing.T) {
+	t.Parallel()
 	// Two clients track the same key. Notification triggers backend poll.
 	// Both clients should receive the update.
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
@@ -494,6 +505,7 @@ func TestSharedPollNotify_FullFlow_TwoClients(t *testing.T) {
 }
 
 func TestSharedPollNotify_FullFlow_Removal(t *testing.T) {
+	t.Parallel()
 	// Backend returns Removed=true for a notified key.
 	// Client should see the item removed.
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
@@ -550,6 +562,7 @@ func TestSharedPollNotify_FullFlow_Removal(t *testing.T) {
 }
 
 func TestSharedPollNotify_UntrackedKeyFiltered(t *testing.T) {
+	t.Parallel()
 	callCh := make(chan SharedPollEvent, 10)
 
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
@@ -596,6 +609,7 @@ func TestSharedPollNotify_UntrackedKeyFiltered(t *testing.T) {
 }
 
 func TestKeyedManager_GetOrCreateChannel(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -613,6 +627,7 @@ func TestKeyedManager_GetOrCreateChannel(t *testing.T) {
 }
 
 func TestKeyedManager_MaxTrackedPerConnection(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -631,6 +646,7 @@ func TestKeyedManager_MaxTrackedPerConnection(t *testing.T) {
 }
 
 func TestKeyedManager_RemoveChannel(t *testing.T) {
+	t.Parallel()
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
 
@@ -644,6 +660,7 @@ func TestKeyedManager_RemoveChannel(t *testing.T) {
 }
 
 func TestSharedPollPublish_LocalOnly(t *testing.T) {
+	t.Parallel()
 	// Publish without PublishEnabled — data delivered locally to subscriber.
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		Mode:                 SharedPollModeVersioned,
@@ -678,6 +695,7 @@ func TestSharedPollPublish_LocalOnly(t *testing.T) {
 }
 
 func TestSharedPollPublish_FreshFromPublish_SkipsTimerPoll(t *testing.T) {
+	t.Parallel()
 	// Publish data, verify next timer cycle skips the key.
 	callCh := make(chan SharedPollEvent, 10)
 
@@ -743,6 +761,7 @@ func TestSharedPollPublish_FreshFromPublish_SkipsTimerPoll(t *testing.T) {
 }
 
 func TestSharedPollPublish_FreshFromPublish_NotSkippedByNotify(t *testing.T) {
+	t.Parallel()
 	// Publish data, then notify same key — notification should still trigger poll.
 	callCh := make(chan SharedPollEvent, 10)
 
@@ -809,6 +828,7 @@ func TestSharedPollPublish_FreshFromPublish_NotSkippedByNotify(t *testing.T) {
 }
 
 func TestSharedPollPublish_UnknownChannel(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t)
 	setupSharedPollHandlers(node)
 
@@ -818,6 +838,7 @@ func TestSharedPollPublish_UnknownChannel(t *testing.T) {
 }
 
 func TestSharedPollPublish_UntrackedKey(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		Mode:                 SharedPollModeVersioned,
 		RefreshInterval:      30 * time.Second,
@@ -842,6 +863,7 @@ func TestSharedPollPublish_UntrackedKey(t *testing.T) {
 }
 
 func TestSharedPollPublish_DeltaWithKeepLatestData(t *testing.T) {
+	t.Parallel()
 	// With KeepLatestData=true, two publishes → second should use delta.
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		Mode:                 SharedPollModeVersioned,
@@ -898,6 +920,7 @@ func TestSharedPollPublish_DeltaWithKeepLatestData(t *testing.T) {
 }
 
 func TestSharedPollPublish_MultipleClients(t *testing.T) {
+	t.Parallel()
 	// Two clients tracking same key, publish delivers to both.
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		Mode:                 SharedPollModeVersioned,
@@ -950,6 +973,7 @@ func TestSharedPollPublish_MultipleClients(t *testing.T) {
 }
 
 func TestSharedPollPublish_BrokerSubscribeOnTrack(t *testing.T) {
+	t.Parallel()
 	// With PublishEnabled=true, track key → verify broker subscription.
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		Mode:                 SharedPollModeVersioned,
@@ -978,6 +1002,7 @@ func TestSharedPollPublish_BrokerSubscribeOnTrack(t *testing.T) {
 }
 
 func TestSharedPollPublish_BrokerUnsubscribeOnShutdown(t *testing.T) {
+	t.Parallel()
 	// With PublishEnabled=true, track → untrack all → verify broker unsubscription after shutdown.
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		Mode:                 SharedPollModeVersioned,
@@ -1018,6 +1043,7 @@ func TestSharedPollPublish_BrokerUnsubscribeOnShutdown(t *testing.T) {
 }
 
 func TestSharedPollPublish_CrossNode_ViaHandlePublication(t *testing.T) {
+	t.Parallel()
 	// Call HandlePublication with keyed pub matching shared poll channel → routes to handlePublishedData.
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		Mode:                 SharedPollModeVersioned,
@@ -1056,6 +1082,7 @@ func TestSharedPollPublish_CrossNode_ViaHandlePublication(t *testing.T) {
 }
 
 func TestSharedPollPublish_VersionIncrementsConsecutive(t *testing.T) {
+	t.Parallel()
 	// Multiple publishes → version strictly increases, each delivered.
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		Mode:                 SharedPollModeVersioned,
@@ -1101,6 +1128,7 @@ func TestSharedPollPublish_VersionIncrementsConsecutive(t *testing.T) {
 }
 
 func TestSharedPollPublish_NilManager(t *testing.T) {
+	t.Parallel()
 	// SharedPollPublish on a node without SharedPollManager returns error.
 	node := defaultNodeNoHandlers()
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -1110,6 +1138,7 @@ func TestSharedPollPublish_NilManager(t *testing.T) {
 }
 
 func TestSharedPoll_StaleResponseDoesNotOverwriteData(t *testing.T) {
+	t.Parallel()
 	// Verify: when direct publish advances entry.version past what the
 	// backend/notification returns, the stale response does NOT overwrite entry.data.
 	version := &atomic.Int64{}
@@ -1203,6 +1232,7 @@ func TestSharedPoll_StaleResponseDoesNotOverwriteData(t *testing.T) {
 }
 
 func TestSharedPoll_EqualVersionPublishNoOverwrite(t *testing.T) {
+	t.Parallel()
 	// Verify: equal-version publish does NOT overwrite entry.data.
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		Mode:                      SharedPollModeVersioned,
@@ -1274,6 +1304,7 @@ func TestSharedPoll_EqualVersionPublishNoOverwrite(t *testing.T) {
 }
 
 func TestSharedPoll_VersionlessBasic(t *testing.T) {
+	t.Parallel()
 	// Default config (no Mode → versionless).
 	// Handler returns {key, data} without version (version=0).
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
@@ -1370,6 +1401,7 @@ func TestSharedPoll_VersionlessBasic(t *testing.T) {
 }
 
 func TestSharedPoll_VersionlessUnchangedWithKeepLatestData(t *testing.T) {
+	t.Parallel()
 	// KeepLatestData=true → uses bytes.Equal instead of xxhash.
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
@@ -1424,6 +1456,7 @@ func TestSharedPoll_VersionlessUnchangedWithKeepLatestData(t *testing.T) {
 }
 
 func TestSharedPoll_VersionlessPublishRejected(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      30 * time.Second,
 		MaxKeysPerConnection: 100,
@@ -1447,6 +1480,7 @@ func TestSharedPoll_VersionlessPublishRejected(t *testing.T) {
 }
 
 func TestSharedPoll_VersionlessNoCachedData(t *testing.T) {
+	t.Parallel()
 	// getCachedData returns nil in versionless mode even with KeepLatestData.
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
@@ -1493,6 +1527,7 @@ func TestSharedPoll_VersionlessNoCachedData(t *testing.T) {
 }
 
 func TestSharedPoll_VersionlessNotification(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:           30 * time.Second,
 		RefreshBatchSize:          100,
@@ -1578,6 +1613,7 @@ func TestSharedPoll_VersionlessNotification(t *testing.T) {
 }
 
 func TestSharedPoll_VersionlessMultipleKeys(t *testing.T) {
+	t.Parallel()
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
 		RefreshBatchSize:     100,
@@ -1655,6 +1691,7 @@ func TestSharedPoll_VersionlessMultipleKeys(t *testing.T) {
 }
 
 func TestSharedPoll_VersionlessDelta(t *testing.T) {
+	t.Parallel()
 	// Versionless + KeepLatestData enables delta compression.
 	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
 		RefreshInterval:      100 * time.Millisecond,
@@ -1753,6 +1790,7 @@ func newTestNodeWithControllableBroker(t *testing.T, broker *controllableBroker,
 }
 
 func TestSharedPollManager_ConcurrentTrackSingleBrokerSubscribe(t *testing.T) {
+	t.Parallel()
 	// Multiple concurrent track() calls for the same channel should result in
 	// exactly one broker.Subscribe call.
 	broker := &controllableBroker{}
@@ -1790,6 +1828,7 @@ func TestSharedPollManager_ConcurrentTrackSingleBrokerSubscribe(t *testing.T) {
 }
 
 func TestSharedPollManager_BrokerSubscribeFailureCleanup(t *testing.T) {
+	t.Parallel()
 	// When broker.Subscribe fails, track() should clean up the channel state
 	// and return an error.
 	broker := &controllableBroker{subscribeErr: errors.New("broker unavailable")}
@@ -1819,6 +1858,7 @@ func TestSharedPollManager_BrokerSubscribeFailureCleanup(t *testing.T) {
 }
 
 func TestSharedPollManager_BrokerSubscribeFailureNoOrphanConcurrent(t *testing.T) {
+	t.Parallel()
 	// Scenario: goroutine A creates channel, starts broker.Subscribe (which blocks).
 	// Goroutine B arrives, sees existing channel, adds its own key.
 	// A's broker.Subscribe fails. A should NOT tear down the channel because B's
@@ -1883,6 +1923,7 @@ func TestSharedPollManager_BrokerSubscribeFailureNoOrphanConcurrent(t *testing.T
 }
 
 func TestSharedPollManager_BrokerUnsubscribeViaDissolver(t *testing.T) {
+	t.Parallel()
 	// After all keys removed, broker.Unsubscribe should be called via subDissolver.
 	broker := &controllableBroker{}
 	opts := SharedPollChannelOptions{
@@ -1960,6 +2001,7 @@ func TestSharedPollManager_BrokerUnsubscribeRetryOnFailure(t *testing.T) {
 }
 
 func TestSharedPollManager_BrokerUnsubscribeSkipsIfResubscribed(t *testing.T) {
+	t.Parallel()
 	// Scenario: track→untrack triggers dissolver unsubscribe. We immediately
 	// re-track the channel. The dissolver's stillActive check (or serialization
 	// via brokerSubMu) should ensure the final state is: channel active with
@@ -2015,6 +2057,7 @@ func TestSharedPollManager_BrokerUnsubscribeSkipsIfResubscribed(t *testing.T) {
 }
 
 func TestSharedPollManager_ConcurrentTrackNoPanic(t *testing.T) {
+	t.Parallel()
 	// Stress test: concurrent track on different channels should not panic.
 	broker := &controllableBroker{}
 	opts := SharedPollChannelOptions{
@@ -2052,6 +2095,7 @@ func TestSharedPollManager_ConcurrentTrackNoPanic(t *testing.T) {
 }
 
 func TestSharedPollManager_ScheduleShutdownImmediate(t *testing.T) {
+	t.Parallel()
 	// When ChannelShutdownDelay is 0, scheduleShutdown calls doShutdown immediately.
 	broker := &controllableBroker{}
 	opts := SharedPollChannelOptions{
@@ -2082,6 +2126,7 @@ func TestSharedPollManager_ScheduleShutdownImmediate(t *testing.T) {
 }
 
 func TestSharedPollManager_ScheduleShutdownDelayed(t *testing.T) {
+	t.Parallel()
 	// When ChannelShutdownDelay > 0, scheduleShutdown defers shutdown.
 	// doShutdownLocked is called from the timer callback.
 	broker := &controllableBroker{}
@@ -2113,6 +2158,7 @@ func TestSharedPollManager_ScheduleShutdownDelayed(t *testing.T) {
 }
 
 func TestSharedPollManager_ShutdownCancelledByRetrack(t *testing.T) {
+	t.Parallel()
 	// If a key is re-tracked during shutdown delay, shutdown is cancelled.
 	broker := &controllableBroker{}
 	opts := SharedPollChannelOptions{
@@ -2143,6 +2189,7 @@ func TestSharedPollManager_ShutdownCancelledByRetrack(t *testing.T) {
 // --- sharedPollKeyChannel / parseSharedPollKeyChannel tests ---
 
 func TestSharedPollKeyChannel_RoundTrip(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		channel string
 		key     string
@@ -2165,6 +2212,7 @@ func TestSharedPollKeyChannel_RoundTrip(t *testing.T) {
 }
 
 func TestParseSharedPollKeyChannel_Invalid(t *testing.T) {
+	t.Parallel()
 	tests := []string{
 		"normal_channel",      // no colon prefix
 		"abc:xyz",             // non-numeric prefix
@@ -2189,6 +2237,7 @@ func TestParseSharedPollKeyChannel_Invalid(t *testing.T) {
 // --- trackKeys tests ---
 
 func TestSharedPollManager_TrackKeys_Basic(t *testing.T) {
+	t.Parallel()
 	broker := &controllableBroker{}
 	opts := SharedPollChannelOptions{
 		RefreshInterval:      30 * time.Second,
@@ -2232,6 +2281,7 @@ func TestSharedPollManager_TrackKeys_Basic(t *testing.T) {
 }
 
 func TestSharedPollManager_TrackKeys_MixedNewAndExisting(t *testing.T) {
+	t.Parallel()
 	broker := &controllableBroker{}
 	opts := SharedPollChannelOptions{
 		RefreshInterval:      30 * time.Second,
@@ -2261,6 +2311,7 @@ func TestSharedPollManager_TrackKeys_MixedNewAndExisting(t *testing.T) {
 }
 
 func TestSharedPollManager_TrackKeys_NoPublishEnabled(t *testing.T) {
+	t.Parallel()
 	broker := &controllableBroker{}
 	opts := SharedPollChannelOptions{
 		RefreshInterval:      30 * time.Second,
@@ -2281,6 +2332,7 @@ func TestSharedPollManager_TrackKeys_NoPublishEnabled(t *testing.T) {
 }
 
 func TestSharedPollManager_TrackKeys_SubscribeFailureCleanup(t *testing.T) {
+	t.Parallel()
 	broker := &controllableBroker{subscribeErr: errors.New("broker down")}
 	opts := SharedPollChannelOptions{
 		RefreshInterval:      30 * time.Second,
@@ -2302,6 +2354,7 @@ func TestSharedPollManager_TrackKeys_SubscribeFailureCleanup(t *testing.T) {
 }
 
 func TestSharedPollManager_TrackKeys_SubscribeFailurePartialCleanup(t *testing.T) {
+	t.Parallel()
 	// Pre-track key0 (succeeds), then batch-track key1+key2 (fails).
 	// key0 should survive, key1+key2 should be cleaned up.
 	var callCount atomic.Int32
@@ -2349,6 +2402,7 @@ func TestSharedPollManager_TrackKeys_SubscribeFailurePartialCleanup(t *testing.T
 }
 
 func TestSharedPollManager_TrackKeys_DuplicateKeys(t *testing.T) {
+	t.Parallel()
 	broker := &controllableBroker{}
 	opts := SharedPollChannelOptions{
 		RefreshInterval:      30 * time.Second,
@@ -2380,6 +2434,7 @@ func TestSharedPollManager_TrackKeys_DuplicateKeys(t *testing.T) {
 }
 
 func TestSharedPollManager_TrackKeys_Empty(t *testing.T) {
+	t.Parallel()
 	broker := &controllableBroker{}
 	opts := SharedPollChannelOptions{
 		RefreshInterval:      30 * time.Second,
@@ -2407,6 +2462,7 @@ func TestSharedPollManager_TrackKeys_Empty(t *testing.T) {
 }
 
 func TestSharedPollManager_TrackKeys_ConcurrentBatch(t *testing.T) {
+	t.Parallel()
 	// Two concurrent trackKeys calls on the same channel should not lose keys.
 	broker := &controllableBroker{}
 	opts := SharedPollChannelOptions{

--- a/shared_poll_test.go
+++ b/shared_poll_test.go
@@ -1,6 +1,7 @@
 package centrifuge
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"sync"
@@ -742,12 +743,13 @@ func TestSharedPollPublish_FreshFromPublish_SkipsTimerPoll(t *testing.T) {
 	err := node.SharedPollPublish(context.Background(), "test:channel", "key1", 10, "", []byte(`{"v":10}`))
 	require.NoError(t, err)
 
-	// Next timer poll should only include key2 (key1 is fresh).
+	// Next timer poll should only include key2 (key1 is fresh). Under -race
+	// the 200ms cycle can stretch, so allow a generous deadline.
 	select {
 	case event := <-callCh:
 		require.Len(t, event.Items, 1)
 		require.Equal(t, "key2", event.Items[0].Key)
-	case <-time.After(2 * time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("expected timer poll after publish")
 	}
 
@@ -755,7 +757,7 @@ func TestSharedPollPublish_FreshFromPublish_SkipsTimerPoll(t *testing.T) {
 	select {
 	case event := <-callCh:
 		require.Len(t, event.Items, 2)
-	case <-time.After(2 * time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("expected full timer poll after flag cleared")
 	}
 }
@@ -1289,10 +1291,23 @@ func TestSharedPoll_EqualVersionPublishNoOverwrite(t *testing.T) {
 	err := node.SharedPollPublish(context.Background(), "test:channel", "key1", 5, "", dataB)
 	require.NoError(t, err)
 
-	// Give time for publish to be processed.
-	time.Sleep(50 * time.Millisecond)
+	// Assert (Never, over a window) that entry.data stays dataA — equal
+	// version should be a silent skip, no overwrite.
+	require.Never(t, func() bool {
+		node.sharedPollManager.mu.RLock()
+		s := node.sharedPollManager.channels["test:channel"]
+		node.sharedPollManager.mu.RUnlock()
+		if s == nil {
+			return false
+		}
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		entry := s.itemIndex["key1"]
+		return entry != nil && !bytes.Equal(entry.data, dataA)
+	}, 300*time.Millisecond, 20*time.Millisecond,
+		"equal-version publish should not overwrite data")
 
-	// Assert: entry.data should still be dataA (equal version → skip, no overwrite).
+	// Also assert the version did not move.
 	node.sharedPollManager.mu.RLock()
 	s := node.sharedPollManager.channels["test:channel"]
 	node.sharedPollManager.mu.RUnlock()
@@ -2697,6 +2712,81 @@ func TestSharedPoll_Track_AfterShutdown(t *testing.T) {
 	// Replace shutdownCh with a fresh open channel so the t.Cleanup → Shutdown
 	// → close() doesn't double-close.
 	node.sharedPollManager.shutdownCh = make(chan struct{})
+}
+
+// TestSharedPollManager_ShutdownRetrackChaos stresses the rapid
+// shutdown/retrack/notify cycle. It exercises two race classes:
+//
+//  1. audit finding 4: notify() captures `s := m.channels[ch]` and then
+//     sends on `s.notifCh`. The send must happen while m.mu is held so a
+//     concurrent shutdown cannot replace the state with a dead one.
+//
+//  2. The track()/trackKeys() "s.removed → replace" path: two callers
+//     that both observe `removed=true` must not both overwrite
+//     m.channels[ch] unconditionally. The second overwrite would orphan
+//     the first goroutine's freshly-created state — and its just-started
+//     worker — leaking a goroutine that nothing outside m.channels can
+//     cancel.
+//
+// ChannelShutdownDelay=-1 + PublishEnabled=true reliably reaches both
+// races: the immediate shutdown ensures most cycles see removed=true,
+// and broker subscribe/unsubscribe via the dissolver provides extra
+// scheduling jitter that surfaces the orphaned-state path under -race.
+// On the original (pre-fix) code this test reliably hangs in
+// m.wg.Wait() during cleanup.
+func TestSharedPollManager_ShutdownRetrackChaos(t *testing.T) {
+	t.Parallel()
+	broker := &controllableBroker{}
+	opts := SharedPollChannelOptions{
+		RefreshInterval:      time.Hour, // disable timer-driven polls
+		RefreshBatchSize:     100,
+		MaxKeysPerConnection: 100,
+		PublishEnabled:       true,
+		ChannelShutdownDelay: -1, // immediate shutdown — drives the removed→replace path
+	}
+	node := newTestNodeWithControllableBroker(t, broker, opts)
+	m := node.sharedPollManager
+
+	const iterations = 200
+	channel := "test:retrack_chaos"
+
+	var wg sync.WaitGroup
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := "k" + string(rune('0'+i%8)) // small key set => high reuse rate
+			_, _, _ = m.track(channel, opts, key)
+			// Notify can race with shutdown; the lock ordering in notify()
+			// must prevent sending on a dead notifCh.
+			m.notify(channel, key)
+			m.untrack(channel, key)
+		}(i)
+	}
+	wg.Wait()
+
+	// After activity drains, the manager must converge: either the
+	// channel is gone (shutdown completed) or it has no tracked keys.
+	require.Eventually(t, func() bool {
+		m.mu.RLock()
+		s, ok := m.channels[channel]
+		m.mu.RUnlock()
+		if !ok {
+			return true
+		}
+		s.mu.Lock()
+		empty := len(s.itemIndex) == 0
+		s.mu.Unlock()
+		return empty
+	}, 5*time.Second, 25*time.Millisecond,
+		"manager did not converge: channel state still has tracked keys")
+
+	// Convergence proven above — but the orphan-worker bug ONLY shows up
+	// when node.Shutdown's m.close() walks m.channels to cancel workers.
+	// If any worker was started on a state that got overwritten in
+	// m.channels, close() can't reach it and m.wg.Wait blocks forever.
+	// The t.Cleanup-driven Shutdown thus serves as the leak detector;
+	// the test framework's overall timeout will catch the regression.
 }
 
 // TestSharedPoll_Stats covers the stats() helper.

--- a/shared_poll_test.go
+++ b/shared_poll_test.go
@@ -1919,6 +1919,7 @@ func TestSharedPollManager_BrokerUnsubscribeViaDissolver(t *testing.T) {
 }
 
 func TestSharedPollManager_BrokerUnsubscribeRetryOnFailure(t *testing.T) {
+	t.Parallel()
 	// When broker.Unsubscribe fails, dissolver should retry until success.
 	var failCount atomic.Int32
 	broker := &controllableBroker{

--- a/writer_test.go
+++ b/writer_test.go
@@ -157,6 +157,7 @@ func (t *fakeTransport) write(_ queue.Item) error {
 }
 
 func TestWriter(t *testing.T) {
+	t.Parallel()
 	transport := newFakeTransport(nil)
 	w := newWriter(writerConfig{
 		WriteFn:     transport.write,
@@ -177,6 +178,7 @@ func TestWriter(t *testing.T) {
 }
 
 func TestWriterWriteMany(t *testing.T) {
+	t.Parallel()
 	transport := newFakeTransport(nil)
 
 	w := newWriter(writerConfig{
@@ -208,6 +210,7 @@ func TestWriterWriteMany(t *testing.T) {
 }
 
 func TestWriterWriteRemaining(t *testing.T) {
+	t.Parallel()
 	transport := newFakeTransport(nil)
 
 	w := newWriter(writerConfig{
@@ -237,6 +240,7 @@ func TestWriterWriteRemaining(t *testing.T) {
 }
 
 func TestWriterDisconnectSlow(t *testing.T) {
+	t.Parallel()
 	transport := newFakeTransport(nil)
 
 	w := newWriter(writerConfig{
@@ -251,6 +255,7 @@ func TestWriterDisconnectSlow(t *testing.T) {
 }
 
 func TestWriterDisconnectNormalOnClosedQueue(t *testing.T) {
+	t.Parallel()
 	transport := newFakeTransport(nil)
 
 	w := newWriter(writerConfig{
@@ -266,6 +271,7 @@ func TestWriterDisconnectNormalOnClosedQueue(t *testing.T) {
 }
 
 func TestWriterWriteError(t *testing.T) {
+	t.Parallel()
 	errWrite := errors.New("write error")
 	transport := newFakeTransport(errWrite)
 


### PR DESCRIPTION
Fix flaky tests and improve timing of non-integration tests (65s -> 10s).