### PR TITLE
Implement inline untrack to avoid unneeded updates

### DIFF
--- a/broker_memory.go
+++ b/broker_memory.go
@@ -37,7 +37,7 @@ type MemoryBroker struct {
 
 	nextExpireCheck   int64
 	resultExpireQueue priority.Queue
-	resultCache       map[string]StreamPosition
+	resultCache       map[string]resultCacheEntry
 	resultCacheMu     sync.RWMutex
 }
 
@@ -62,7 +62,7 @@ func NewMemoryBroker(n *Node, _ MemoryBrokerConfig) (*MemoryBroker, error) {
 		historyHub:  newHistoryHub(n.config.HistoryMetaTTL, closeCh),
 		pubLocks:    pubLocks,
 		closeCh:     closeCh,
-		resultCache: map[string]StreamPosition{},
+		resultCache: make(map[string]resultCacheEntry),
 	}
 	return b, nil
 }
@@ -148,15 +148,18 @@ func (b *MemoryBroker) getResultFromCache(ch string, key string) (StreamPosition
 	b.resultCacheMu.RLock()
 	defer b.resultCacheMu.RUnlock()
 	res, ok := b.resultCache[ch+"_"+key]
-	return res, ok
+	if !ok || res.ExpireAt <= time.Now().UnixMilli() {
+		return StreamPosition{}, false
+	}
+	return res.Position, true
 }
 
 func (b *MemoryBroker) saveResultToCache(ch string, key string, sp StreamPosition, resultExpireSeconds int64) {
 	b.resultCacheMu.Lock()
 	defer b.resultCacheMu.Unlock()
 	cacheKey := ch + "_" + key
-	b.resultCache[cacheKey] = sp
-	expireAt := time.Now().Unix() + resultExpireSeconds
+	expireAt := time.Now().UnixMilli() + resultExpireSeconds*1000
+	b.resultCache[cacheKey] = resultCacheEntry{Position: sp, ExpireAt: expireAt}
 	heap.Push(&b.resultExpireQueue, &priority.Item{Value: cacheKey, Priority: expireAt})
 	if b.nextExpireCheck == 0 || b.nextExpireCheck > expireAt {
 		b.nextExpireCheck = expireAt
@@ -164,32 +167,51 @@ func (b *MemoryBroker) saveResultToCache(ch string, key string, sp StreamPositio
 }
 
 func (b *MemoryBroker) expireResultCache() {
+	tm := time.NewTimer(time.Second)
+	defer tm.Stop()
 	var nextExpireCheck int64
 	for {
 		select {
-		case <-time.After(time.Second):
+		case <-tm.C:
 		case <-b.closeCh:
 			return
 		}
 		b.resultCacheMu.Lock()
-		if b.nextExpireCheck == 0 || b.nextExpireCheck > time.Now().Unix() {
+		now := time.Now().UnixMilli()
+		if b.nextExpireCheck == 0 || b.nextExpireCheck > now {
 			b.resultCacheMu.Unlock()
+			tm.Reset(time.Second)
 			continue
 		}
 		nextExpireCheck = 0
 		for b.resultExpireQueue.Len() > 0 {
 			item := heap.Pop(&b.resultExpireQueue).(*priority.Item)
 			expireAt := item.Priority
-			if expireAt > time.Now().Unix() {
+			if expireAt > now {
 				heap.Push(&b.resultExpireQueue, item)
 				nextExpireCheck = expireAt
 				break
 			}
-			key := item.Value
-			delete(b.resultCache, key)
+			cacheKey := item.Value
+			if entry, ok := b.resultCache[cacheKey]; ok && entry.ExpireAt <= now {
+				delete(b.resultCache, cacheKey)
+			}
+		}
+		// Compact heap when stale entries accumulate from repeated publishes
+		// with the same idempotency key — each call pushes a new heap item
+		// without removing the old one.
+		if b.resultExpireQueue.Len() > 2*len(b.resultCache)+100 {
+			b.resultExpireQueue = priority.MakeQueue()
+			for k, entry := range b.resultCache {
+				heap.Push(&b.resultExpireQueue, &priority.Item{Value: k, Priority: entry.ExpireAt})
+			}
+			if b.resultExpireQueue.Len() > 0 {
+				nextExpireCheck = b.resultExpireQueue[0].Priority
+			}
 		}
 		b.nextExpireCheck = nextExpireCheck
 		b.resultCacheMu.Unlock()
+		tm.Reset(time.Second)
 	}
 }
 

--- a/broker_memory_test.go
+++ b/broker_memory_test.go
@@ -139,6 +139,31 @@ func TestMemoryBrokerResultCacheExpires(t *testing.T) {
 	}, 10*time.Second, 50*time.Millisecond, "result cache should expire after TTL")
 }
 
+// TestMemoryBrokerResultCacheHeapCompaction verifies that publishing many times
+// with the same idempotency key does not cause the expire heap to grow without
+// bound. After expiry the heap must be no larger than the cache itself.
+func TestMemoryBrokerResultCacheHeapCompaction(t *testing.T) {
+	t.Parallel()
+	e := testMemoryBroker()
+	defer func() { _ = e.node.Shutdown(context.Background()) }()
+
+	const repeats = 300 // well above the 2*mapSize+100 compaction threshold
+	for i := 0; i < repeats; i++ {
+		_, err := e.Publish("channel", testPublicationData(), PublishOptions{
+			IdempotencyKey:      "key",
+			IdempotentResultTTL: 10 * time.Second,
+		})
+		require.NoError(t, err)
+	}
+
+	// Wait for the cleanup goroutine to run at least once and compact.
+	require.Eventually(t, func() bool {
+		e.resultCacheMu.Lock()
+		defer e.resultCacheMu.Unlock()
+		return e.resultExpireQueue.Len() <= len(e.resultCache)
+	}, 10*time.Second, 50*time.Millisecond, "heap should be compacted to map size")
+}
+
 func TestMemoryBrokerPublishIdempotent(t *testing.T) {
 	t.Parallel()
 	e := testMemoryBroker()

--- a/client.go
+++ b/client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/centrifugal/centrifuge/internal/queue"
 	"github.com/centrifugal/centrifuge/internal/recovery"
 	"github.com/centrifugal/centrifuge/internal/saferand"
+	"github.com/centrifugal/centrifuge/internal/timers"
 
 	"github.com/centrifugal/protocol"
 	"github.com/google/uuid"
@@ -4104,15 +4105,18 @@ func (c *Client) unsubscribe(channel string, unsubscribe Unsubscribe, disconnect
 		// of server malfunction since long subscribes should not happen. In this case,
 		// we disconnect client to let it re-init the state from scratch.
 		maxWaitTimeout := 5 * time.Second
+		tm := timers.AcquireTimer(maxWaitTimeout)
 		select {
 		case <-subscribingCh:
+			timers.ReleaseTimer(tm)
 			c.mu.RLock()
 			chCtx, ok = c.channels[channel]
 			c.mu.RUnlock()
 			if !ok {
 				return nil
 			}
-		case <-time.After(maxWaitTimeout):
+		case <-tm.C:
+			timers.ReleaseTimer(tm)
 			c.mu.Lock()
 			currentChCtx, ok := c.channels[channel]
 			if ok && currentChCtx.subscribingCh != nil {
@@ -4132,15 +4136,18 @@ func (c *Client) unsubscribe(channel string, unsubscribe Unsubscribe, disconnect
 	// Wait for map subscription in progress.
 	if hasKeyedState && mapSubscribingCh != nil {
 		maxWaitTimeout := 5 * time.Second
+		tm := timers.AcquireTimer(maxWaitTimeout)
 		select {
 		case <-mapSubscribingCh:
+			timers.ReleaseTimer(tm)
 			c.mu.RLock()
 			chCtx, ok = c.channels[channel]
 			c.mu.RUnlock()
 			if !ok {
 				return nil
 			}
-		case <-time.After(maxWaitTimeout):
+		case <-tm.C:
+			timers.ReleaseTimer(tm)
 			// Identity-match: only close/delete if the entry still corresponds to
 			// the *mapSubscribeState we were waiting on. A fresh resubscribe may
 			// have replaced it between the RUnlock and this Lock — clobbering

--- a/client_keyed.go
+++ b/client_keyed.go
@@ -99,8 +99,16 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 		return ErrorBadRequest
 	}
 
-	// Optimistic limit check — counts DISTINCT keys not already tracked.
-	// Re-checked under the write lock inside the callback.
+	// Build a set of keys that will be immediately removed by Step 8 (inline
+	// untrack). Both limit checks below net these out so a replay that tracks
+	// N keys but untracks M of them only consumes N-M slots — not N.
+	inlineUntrackSet := make(map[string]struct{}, len(req.Untrack))
+	for _, k := range req.Untrack {
+		inlineUntrackSet[k] = struct{}{}
+	}
+
+	// Optimistic limit check — counts DISTINCT new keys minus those that will
+	// be immediately removed via inline untrack. Re-checked under write lock.
 	c.mu.RLock()
 	var currentCount, newKeyCountOpt int
 	if c.keyed != nil {
@@ -108,11 +116,17 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 		currentCount = len(chanKeys)
 		for _, f := range flat {
 			if _, exists := chanKeys[f.key]; !exists {
-				newKeyCountOpt++
+				if _, willUntrack := inlineUntrackSet[f.key]; !willUntrack {
+					newKeyCountOpt++
+				}
 			}
 		}
 	} else {
-		newKeyCountOpt = len(flat)
+		for _, f := range flat {
+			if _, willUntrack := inlineUntrackSet[f.key]; !willUntrack {
+				newKeyCountOpt++
+			}
+		}
 	}
 	c.mu.RUnlock()
 
@@ -218,11 +232,13 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 		chanKeys := c.keyed.trackedKeys[channel]
 
 		// Re-tracking an existing key is a version update, not a new slot —
-		// only count keys not already present.
+		// only count new keys, and exclude those being inline-untracked.
 		var newKeyCount int
 		for _, f := range flat {
 			if _, exists := chanKeys[f.key]; !exists {
-				newKeyCount++
+				if _, willUntrack := inlineUntrackSet[f.key]; !willUntrack {
+					newKeyCount++
+				}
 			}
 		}
 		if len(chanKeys)+newKeyCount > maxTracked {
@@ -384,6 +400,51 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 		if c.node.sharedPollManager != nil && len(deferredWarmKeys) > 0 {
 			c.node.sharedPollManager.markNeedsBroadcast(channel, deferredWarmKeys)
 		}
+
+		// Step 8: Process inline untrack — keys that were part of the signed
+		// batch but have been locally untracked by the client since the
+		// signature was obtained. HMAC validation above covers the full batch;
+		// we remove these keys now so the client receives no broadcasts for them.
+		// Placed after addSubscriber (step 5) so hub state is coherent: we add
+		// then immediately remove, never leaving a gap where a key is absent.
+		// Only keys that were actually tracked are acted on — random keys sent
+		// by the client are silently ignored.
+		if len(req.Untrack) > 0 {
+			var actualUntrack []string
+			c.mu.Lock()
+			if c.keyed != nil {
+				chanKeys := c.keyed.trackedKeys[channel]
+				if chanKeys != nil {
+					for _, key := range req.Untrack {
+						if _, exists := chanKeys[key]; exists {
+							delete(chanKeys, key)
+							actualUntrack = append(actualUntrack, key)
+						}
+					}
+					if len(chanKeys) == 0 {
+						delete(c.keyed.trackedKeys, channel)
+						if c.keyed.minTrackExpireAt != nil {
+							delete(c.keyed.minTrackExpireAt, channel)
+						}
+					}
+				}
+			}
+			c.mu.Unlock()
+
+			for _, key := range actualUntrack {
+				keyEmpty := hub.removeSubscriber(key, c)
+				if c.node.sharedPollManager != nil && keyEmpty {
+					c.node.sharedPollManager.untrack(channel, key)
+				}
+			}
+
+			if len(actualUntrack) > 0 && c.eventHub.untrackHandler != nil {
+				c.eventHub.untrackHandler(UntrackEvent{
+					Channel: channel,
+					Keys:    actualUntrack,
+				})
+			}
+		}
 	})
 	return nil
 }
@@ -396,12 +457,16 @@ func (c *Client) handleUntrack(req *protocol.SubRefreshRequest, cmd *protocol.Co
 		return ErrorBadRequest
 	}
 
+	var actualUntrack []string
 	c.mu.Lock()
 	if c.keyed != nil {
 		chanKeys := c.keyed.trackedKeys[channel]
 		if chanKeys != nil {
 			for _, key := range req.Untrack {
-				delete(chanKeys, key)
+				if _, exists := chanKeys[key]; exists {
+					delete(chanKeys, key)
+					actualUntrack = append(actualUntrack, key)
+				}
 			}
 			if len(chanKeys) == 0 {
 				delete(c.keyed.trackedKeys, channel)
@@ -415,7 +480,7 @@ func (c *Client) handleUntrack(req *protocol.SubRefreshRequest, cmd *protocol.Co
 
 	hub := c.node.keyedManager.getHub(channel)
 	if hub != nil {
-		for _, key := range req.Untrack {
+		for _, key := range actualUntrack {
 			keyEmpty := hub.removeSubscriber(key, c)
 			if c.node.sharedPollManager != nil && keyEmpty {
 				c.node.sharedPollManager.untrack(channel, key)
@@ -423,10 +488,10 @@ func (c *Client) handleUntrack(req *protocol.SubRefreshRequest, cmd *protocol.Co
 		}
 	}
 
-	if c.eventHub.untrackHandler != nil {
+	if len(actualUntrack) > 0 && c.eventHub.untrackHandler != nil {
 		c.eventHub.untrackHandler(UntrackEvent{
 			Channel: channel,
-			Keys:    req.Untrack,
+			Keys:    actualUntrack,
 		})
 	}
 

--- a/client_shared_poll_test.go
+++ b/client_shared_poll_test.go
@@ -4437,3 +4437,191 @@ func TestSharedPollSubscribe_PresenceFlags(t *testing.T) {
 	require.True(t, channelHasFlag(ctx.flags, flagMapClientPresence))
 	require.True(t, channelHasFlag(ctx.flags, flagMapUserPresence))
 }
+
+// TestSharedPollTrack_InlineUntrack verifies that when a sub_refresh type=1
+// (track) frame includes non-empty Untrack keys, the server validates the
+// full HMAC batch and immediately removes those keys in the same handler —
+// no separate untrack round-trip is needed.
+func TestSharedPollTrack_InlineUntrack(t *testing.T) {
+	t.Parallel()
+	node := newTestNodeWithSharedPoll(t)
+
+	var mu sync.Mutex
+	var capturedUntrack *UntrackEvent
+
+	node.OnConnecting(func(ctx context.Context, e ConnectEvent) (ConnectReply, error) {
+		return ConnectReply{}, nil
+	})
+	node.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
+			cb(SubscribeReply{
+				Options: SubscribeOptions{
+					ExpireAt: time.Now().Unix() + 3600,
+				},
+				ClientSideRefresh: true,
+			}, nil)
+		})
+		client.OnTrack(func(e TrackEvent, cb TrackCallback) {
+			cb(TrackReply{}, nil)
+		})
+		client.OnUntrack(func(e UntrackEvent) {
+			mu.Lock()
+			evt := e
+			capturedUntrack = &evt
+			mu.Unlock()
+		})
+		client.OnSubRefresh(func(e SubRefreshEvent, cb SubRefreshCallback) {
+			cb(SubRefreshReply{}, nil)
+		})
+	})
+
+	client := newTestClientV2(t, node, "user1")
+	connectClientV2(t, client)
+	subscribeSharedPollClient(t, client, "test:channel")
+
+	// Combined track+untrack frame: track keyA, keyB, keyC but inline-untrack keyB.
+	rwWrapper := testReplyWriterWrapper()
+	err := client.handleSubRefresh(&protocol.SubRefreshRequest{
+		Channel: "test:channel",
+		Type:    typeTrack,
+		Track: []*protocol.TrackBatch{{
+			Items: []*protocol.KeyedItem{
+				{Key: "keyA"},
+				{Key: "keyB"},
+				{Key: "keyC"},
+			},
+		}},
+		Untrack: []string{"keyB"},
+	}, &protocol.Command{Id: 2}, time.Now(), rwWrapper.rw)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return len(rwWrapper.replies) > 0
+	}, time.Second, time.Millisecond)
+	require.Nil(t, rwWrapper.replies[0].Error)
+
+	// keyA and keyC must be tracked; keyB must have been removed inline.
+	client.mu.RLock()
+	_, hasA := client.keyed.trackedKeys["test:channel"]["keyA"]
+	_, hasB := client.keyed.trackedKeys["test:channel"]["keyB"]
+	_, hasC := client.keyed.trackedKeys["test:channel"]["keyC"]
+	client.mu.RUnlock()
+	require.True(t, hasA, "keyA should be tracked")
+	require.True(t, hasC, "keyC should be tracked")
+	require.False(t, hasB, "keyB should have been removed by inline untrack")
+
+	// untrackHandler must have fired with keyB.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return capturedUntrack != nil
+	}, time.Second, time.Millisecond)
+	mu.Lock()
+	evt := *capturedUntrack
+	mu.Unlock()
+	require.Equal(t, "test:channel", evt.Channel)
+	require.Equal(t, []string{"keyB"}, evt.Keys)
+}
+
+// TestSharedPollTrack_InlineUntrack_RandomKeysIgnored verifies that random keys
+// sent in the Untrack field of a track frame (not covered by HMAC) are silently
+// dropped: untrackHandler must not fire, and hub/sharedPoll state is unchanged.
+func TestSharedPollTrack_InlineUntrack_RandomKeysIgnored(t *testing.T) {
+	t.Parallel()
+	node := newTestNodeWithSharedPoll(t)
+
+	untrackFired := atomic.Bool{}
+
+	node.OnConnecting(func(ctx context.Context, e ConnectEvent) (ConnectReply, error) {
+		return ConnectReply{}, nil
+	})
+	node.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
+			cb(SubscribeReply{Options: SubscribeOptions{ExpireAt: time.Now().Unix() + 3600}, ClientSideRefresh: true}, nil)
+		})
+		client.OnTrack(func(e TrackEvent, cb TrackCallback) {
+			cb(TrackReply{}, nil)
+		})
+		client.OnUntrack(func(e UntrackEvent) {
+			untrackFired.Store(true)
+		})
+	})
+
+	client := newTestClientV2(t, node, "user1")
+	connectClientV2(t, client)
+	subscribeSharedPollClient(t, client, "test:channel")
+
+	// Track only keyA, then inline-untrack a completely random key never tracked.
+	rwWrapper := testReplyWriterWrapper()
+	err := client.handleSubRefresh(&protocol.SubRefreshRequest{
+		Channel: "test:channel",
+		Type:    typeTrack,
+		Track: []*protocol.TrackBatch{{
+			Items: []*protocol.KeyedItem{{Key: "keyA"}},
+		}},
+		Untrack: []string{"never-tracked-key"},
+	}, &protocol.Command{Id: 2}, time.Now(), rwWrapper.rw)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return len(rwWrapper.replies) > 0
+	}, time.Second, time.Millisecond)
+	require.Nil(t, rwWrapper.replies[0].Error)
+
+	// keyA must be tracked; random key must not appear in trackedKeys.
+	client.mu.RLock()
+	_, hasA := client.keyed.trackedKeys["test:channel"]["keyA"]
+	_, hasRandom := client.keyed.trackedKeys["test:channel"]["never-tracked-key"]
+	client.mu.RUnlock()
+	require.True(t, hasA)
+	require.False(t, hasRandom)
+
+	// untrackHandler must not have fired.
+	require.False(t, untrackFired.Load(), "untrackHandler must not fire for keys that were never tracked")
+}
+
+// TestSharedPollUntrack_RandomKeysIgnored verifies that a standalone untrack
+// frame (type=2) with keys the client never tracked is a server-side no-op:
+// untrackHandler must not fire.
+func TestSharedPollUntrack_RandomKeysIgnored(t *testing.T) {
+	t.Parallel()
+	node := newTestNodeWithSharedPoll(t)
+
+	untrackFired := atomic.Bool{}
+
+	node.OnConnecting(func(ctx context.Context, e ConnectEvent) (ConnectReply, error) {
+		return ConnectReply{}, nil
+	})
+	node.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
+			cb(SubscribeReply{Options: SubscribeOptions{ExpireAt: time.Now().Unix() + 3600}, ClientSideRefresh: true}, nil)
+		})
+		client.OnTrack(func(e TrackEvent, cb TrackCallback) {
+			cb(TrackReply{}, nil)
+		})
+		client.OnUntrack(func(e UntrackEvent) {
+			untrackFired.Store(true)
+		})
+	})
+
+	client := newTestClientV2(t, node, "user1")
+	connectClientV2(t, client)
+	subscribeSharedPollClient(t, client, "test:channel")
+
+	// Send standalone untrack for a key that was never tracked.
+	rwWrapper := testReplyWriterWrapper()
+	err := client.handleSubRefresh(&protocol.SubRefreshRequest{
+		Channel: "test:channel",
+		Type:    typeUntrack,
+		Untrack: []string{"never-tracked-key"},
+	}, &protocol.Command{Id: 2}, time.Now(), rwWrapper.rw)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return len(rwWrapper.replies) > 0
+	}, time.Second, time.Millisecond)
+	require.Nil(t, rwWrapper.replies[0].Error)
+
+	// untrackHandler must not have fired.
+	require.False(t, untrackFired.Load(), "untrackHandler must not fire for keys that were never tracked")
+}

--- a/map_broker_memory.go
+++ b/map_broker_memory.go
@@ -255,7 +255,10 @@ func (e *MemoryMapBroker) getResultFromCache(ch string, key string) (StreamPosit
 		return StreamPosition{}, false
 	}
 	entry, ok := chCache[key]
-	return entry.Position, ok
+	if !ok || entry.ExpireAt <= time.Now().UnixMilli() {
+		return StreamPosition{}, false
+	}
+	return entry.Position, true
 }
 
 func (e *MemoryMapBroker) saveResultToCache(ch string, key string, sp StreamPosition, resultExpireMs int64) {
@@ -292,7 +295,8 @@ func (e *MemoryMapBroker) expireResultCache() {
 			return
 		}
 		e.resultCacheMu.Lock()
-		if e.nextExpireCheck == 0 || e.nextExpireCheck > time.Now().UnixMilli() {
+		now := time.Now().UnixMilli()
+		if e.nextExpireCheck == 0 || e.nextExpireCheck > now {
 			e.resultCacheMu.Unlock()
 			timer.Reset(time.Second)
 			continue
@@ -301,7 +305,7 @@ func (e *MemoryMapBroker) expireResultCache() {
 		for e.resultExpireQueue.Len() > 0 {
 			item := heap.Pop(&e.resultExpireQueue).(*priority.Item)
 			expireAt := item.Priority
-			if expireAt > time.Now().UnixMilli() {
+			if expireAt > now {
 				heap.Push(&e.resultExpireQueue, item)
 				nextExpireCheck = expireAt
 				break
@@ -311,9 +315,11 @@ func (e *MemoryMapBroker) expireResultCache() {
 				ch := combined[:idx]
 				key := combined[idx+1:]
 				if chCache, ok := e.resultCache[ch]; ok {
-					delete(chCache, key)
-					if len(chCache) == 0 {
-						delete(e.resultCache, ch)
+					if entry, keyOk := chCache[key]; keyOk && entry.ExpireAt <= now {
+						delete(chCache, key)
+						if len(chCache) == 0 {
+							delete(e.resultCache, ch)
+						}
 					}
 				}
 			}

--- a/map_broker_memory_test.go
+++ b/map_broker_memory_test.go
@@ -3300,6 +3300,45 @@ func TestMemoryMapBroker_IdempotencyCacheExpiration(t *testing.T) {
 	}, 5*time.Second, 200*time.Millisecond, "idempotency cache should expire")
 }
 
+// TestMemoryMapBroker_ResultCacheHeapCompaction verifies that publishing many times
+// with the same idempotency key does not cause the expire heap to grow without bound.
+func TestMemoryMapBroker_ResultCacheHeapCompaction(t *testing.T) {
+	t.Parallel()
+	node, _ := New(Config{})
+	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
+		return MapChannelOptions{
+			Mode:       MapModeRecoverable,
+			StreamSize: 100,
+			StreamTTL:  300 * time.Second,
+			KeyTTL:     300 * time.Second,
+		}
+	}
+	broker := newTestMemoryMapBroker(t, node)
+	ctx := context.Background()
+	ch := "test_heap_compact"
+
+	const repeats = 300 // well above the 2*mapSize+100 compaction threshold
+	for i := 0; i < repeats; i++ {
+		_, err := broker.Publish(ctx, ch, "key1", MapPublishOptions{
+			Data:                []byte("v"),
+			IdempotencyKey:      "ik",
+			IdempotentResultTTL: 10 * time.Second,
+		})
+		require.NoError(t, err)
+	}
+
+	// Wait for the cleanup goroutine to compact the heap.
+	require.Eventually(t, func() bool {
+		broker.resultCacheMu.Lock()
+		defer broker.resultCacheMu.Unlock()
+		var total int
+		for _, chCache := range broker.resultCache {
+			total += len(chCache)
+		}
+		return broker.resultExpireQueue.Len() <= total
+	}, 10*time.Second, 50*time.Millisecond, "heap should be compacted to map size")
+}
+
 // TestMemoryMapBroker_ReadStreamEpochMismatch tests epoch mismatch in ReadStream.
 func TestMemoryMapBroker_ReadStreamEpochMismatch(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Currently shared poll has a gap where keys untracked by client still sent by server (but dropped on client side). This PR removes this inefficiency by sending keys which client does not need anymore in track request itself.