### PR TITLE
Correctness audit for subscription types, channel medium

### DIFF
--- a/broker_redis_test.go
+++ b/broker_redis_test.go
@@ -2859,6 +2859,185 @@ func TestRedisClusterMultipleChannelsTwoNodes(t *testing.T) {
 	}
 }
 
+// TestSharedPollPublish_CrossNodeDelivery_TwoNodes proves end-to-end
+// that SharedPollPublish on one node reaches subscribers tracking the
+// key on a different node. This is the contract the publish() refactor
+// guarantees: routing is a function of PublishEnabled, not local
+// subscriber state, so a publisher node that has never tracked the key
+// still delivers via the broker.
+//
+// Setup: two Nodes (node1, node2) share a Redis broker. node1's client
+// subscribes + tracks key1 — its broker.Subscribe registers node1's
+// callback for the key-scoped channel. node2 has no tracks, no broker
+// subscription for that key. node2 calls SharedPollPublish; the broker
+// fans it out to subscribed nodes, node1 receives via its callback,
+// and node1's client gets the publication on its transport sink.
+//
+// Pre-fix: node2's publish() would read its own brokerSubChans (empty
+// for key1, since node2 never tracked it), fall back to
+// handlePublishedData locally, and silently no-op. node1's client
+// would never see the publication.
+func TestSharedPollPublish_CrossNodeDelivery_TwoNodes(t *testing.T) {
+	t.Parallel()
+	for _, tt := range excludeNoHistoryClusterTests(noHistoryRedisTests) {
+		t.Run(tt.Name, func(t *testing.T) {
+			redisConf := testSingleRedisConf(tt.Port)
+			prefix := getUniquePrefix()
+
+			pollOpts := SharedPollChannelOptions{
+				Mode:                 SharedPollModeVersioned,
+				RefreshInterval:      30 * time.Second,
+				RefreshBatchSize:     100,
+				MaxKeysPerConnection: 100,
+				PublishEnabled:       true,
+			}
+			pollHandler := func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
+				return SharedPollResult{}, nil
+			}
+			cfg := Config{
+				LogLevel:   LogLevelTrace,
+				LogHandler: func(entry LogEntry) {},
+				SharedPoll: SharedPollConfig{
+					GetSharedPollChannelOptions: func(channel string) (SharedPollChannelOptions, bool) {
+						return pollOpts, true
+					},
+				},
+			}
+
+			// Subscriber node: hosts the client tracking key1.
+			node1, err := New(cfg)
+			require.NoError(t, err)
+			node1.OnSharedPoll(pollHandler)
+			setupSharedPollHandlers(node1)
+			shard1, err := NewRedisShard(node1, redisConf)
+			require.NoError(t, err)
+			b1, err := NewRedisBroker(node1, RedisBrokerConfig{
+				Prefix: prefix,
+				Shards: []*RedisShard{shard1},
+			})
+			require.NoError(t, err)
+			node1.SetBroker(b1)
+			require.NoError(t, node1.Run())
+			t.Cleanup(func() { _ = node1.Shutdown(context.Background()) })
+			t.Cleanup(func() { stopRedisBroker(b1) })
+
+			// Publisher node: never tracks the key, only calls SharedPollPublish.
+			node2, err := New(cfg)
+			require.NoError(t, err)
+			node2.OnSharedPoll(pollHandler)
+			setupSharedPollHandlers(node2)
+			shard2, err := NewRedisShard(node2, redisConf)
+			require.NoError(t, err)
+			b2, err := NewRedisBroker(node2, RedisBrokerConfig{
+				Prefix: prefix,
+				Shards: []*RedisShard{shard2},
+			})
+			require.NoError(t, err)
+			node2.SetBroker(b2)
+			require.NoError(t, node2.Run())
+			t.Cleanup(func() { _ = node2.Shutdown(context.Background()) })
+			t.Cleanup(func() { stopRedisBroker(b2) })
+
+			// Connect a client to node1 with a sink-backed transport so we
+			// can observe publications.
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			transport := newTestTransport(cancel)
+			transport.setProtocolVersion(ProtocolVersion2)
+			transport.setProtocolType(ProtocolTypeProtobuf)
+			sink := make(chan []byte, 100)
+			transport.sink = sink
+			credCtx := SetCredentials(ctx, &Credentials{UserID: "user1"})
+			client, err := newClient(credCtx, node1, transport)
+			require.NoError(t, err)
+			connectClientV2(t, client)
+
+			channel := "test:xnode_" + prefix
+			subscribeSharedPollClient(t, client, channel)
+			trackSharedPollClient(t, client, channel, []*protocol.KeyedItem{
+				{Key: "key1", Version: 0},
+			})
+
+			// Wait until node1 has the broker subscription for key1 — this
+			// is what makes node1's broker callback actually fire for
+			// publications on the key-scoped channel.
+			require.Eventually(t, func() bool {
+				keyCh := sharedPollKeyChannel(channel, "key1")
+				node1.sharedPollManager.brokerSubMu.RLock()
+				defer node1.sharedPollManager.brokerSubMu.RUnlock()
+				_, ok := node1.sharedPollManager.brokerSubChans[keyCh]
+				return ok
+			}, 5*time.Second, 25*time.Millisecond,
+				"node1 must have registered a broker subscription for key1 before the cross-node publish")
+
+			// Confirm node2 has no local state / broker subscription for
+			// key1 — the property we're testing depends on the publisher
+			// node NOT having tracked the key.
+			node2.sharedPollManager.mu.RLock()
+			_, n2HasChannel := node2.sharedPollManager.channels[channel]
+			node2.sharedPollManager.mu.RUnlock()
+			require.False(t, n2HasChannel,
+				"node2 must not have shared-poll channel state for this channel")
+			node2.sharedPollManager.brokerSubMu.RLock()
+			_, n2HasKey := node2.sharedPollManager.brokerSubChans[sharedPollKeyChannel(channel, "key1")]
+			node2.sharedPollManager.brokerSubMu.RUnlock()
+			require.False(t, n2HasKey,
+				"node2 must not have a broker subscription for key1")
+
+			// Drain any earlier messages (connect reply, subscribe reply,
+			// initial cold-key auto-poll, etc.) so we read only the
+			// cross-node publication below.
+		drainPre:
+			for {
+				select {
+				case <-sink:
+				case <-time.After(50 * time.Millisecond):
+					break drainPre
+				}
+			}
+
+			// Cross-node publish from node2.
+			payload := []byte(`"hello-from-node2"`)
+			require.NoError(t, node2.SharedPollPublish(
+				context.Background(), channel, "key1", 100, "", payload,
+			))
+
+			// node1's client must receive the publication on its transport.
+			deadline := time.After(5 * time.Second)
+			received := false
+		recv:
+			for !received {
+				select {
+				case msg := <-sink:
+					reply := &protocol.Reply{}
+					if err := reply.UnmarshalVT(msg); err != nil {
+						continue
+					}
+					if reply.Push == nil || reply.Push.Pub == nil {
+						continue
+					}
+					pub := reply.Push.Pub
+					if pub.Key != "key1" {
+						continue
+					}
+					if !strings.Contains(string(pub.Data), "hello-from-node2") {
+						continue
+					}
+					require.EqualValues(t, 100, pub.Version)
+					received = true
+				case <-deadline:
+					break recv
+				}
+			}
+			require.True(t, received,
+				"BUG: node1's subscriber did not receive the publication that "+
+					"node2 published cross-node. publish() must route through "+
+					"the broker on PublishEnabled channels regardless of whether "+
+					"node2 has locally tracked the key.")
+		})
+	}
+}
+
 // TestNewRedisBrokerErrors covers input-validation branches in NewRedisBroker.
 // These tests don't actually connect to Redis since the failures occur before any
 // connection attempt, but they live with the rest of the integration-tagged tests

--- a/channel_medium.go
+++ b/channel_medium.go
@@ -282,6 +282,15 @@ func (c *channelMedium) checkPositionOnce(historyMetaTTL time.Duration, clientPo
 
 func (c *channelMedium) close() {
 	close(c.closeCh)
+	// Unblock the writer goroutine. publicationQueue.Wait sleeps on a
+	// sync.Cond and is woken only by an Add (cnt > 0) or Close (broadcast).
+	// closeCh is checked only inside the broadcastDelay timer branch, which
+	// is unreachable until Wait returns — so without closing the queue the
+	// writer goroutine sits forever on an empty channel and leaks for every
+	// channelMedium that ever existed.
+	if c.messages != nil {
+		c.messages.Close()
+	}
 }
 
 type queuedPublication struct {

--- a/channel_medium_test.go
+++ b/channel_medium_test.go
@@ -3,6 +3,7 @@ package centrifuge
 import (
 	"errors"
 	"math"
+	"runtime"
 	"strconv"
 	"sync"
 	"testing"
@@ -347,6 +348,59 @@ func TestChannelMediumClose(t *testing.T) {
 	default:
 		t.Fatal("close did not signal closeCh")
 	}
+}
+
+// TestChannelMediumCloseStopsWriterGoroutine asserts that when a queue-enabled
+// channelMedium is closed, its writer goroutine actually exits — not just that
+// closeCh is signalled.
+//
+// Bug: medium.close() closes c.closeCh but never closes c.messages. The
+// writer goroutine sits in c.messages.Wait() (sync.Cond) on an empty queue,
+// and Wait only returns when the queue itself is closed (which broadcasts the
+// cond). closeCh is checked only INSIDE the broadcastDelay timer branch,
+// which is unreachable until Wait returns. Result: every channelMedium that
+// is closed with an empty queue leaks one writer goroutine — and each
+// channelMedium is created per channel (addSubscription) and closed when the
+// last subscriber leaves (removeSubscription), so this leaks one goroutine
+// per channel lifecycle on any server using queue/delay channel-medium
+// options.
+//
+// The test detects the leak by creating many mediums, closing them, and
+// checking the goroutine count returns to baseline (with a small allowance
+// for noise from runtime). Not t.Parallel because runtime.NumGoroutine is
+// process-global.
+func TestChannelMediumCloseStopsWriterGoroutine(t *testing.T) {
+	const numMediums = 50
+
+	// Settle to a stable baseline.
+	time.Sleep(20 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	mediums := make([]*channelMedium, 0, numMediums)
+	for i := 0; i < numMediums; i++ {
+		m, err := newChannelMedium("test-close-writer-"+strconv.Itoa(i), &mockNode{}, ChannelMediumOptions{
+			enableQueue: true,
+		})
+		require.NoError(t, err)
+		mediums = append(mediums, m)
+	}
+
+	// Writer goroutines are scheduled; goroutine count should be well above baseline.
+	require.Eventually(t, func() bool {
+		return runtime.NumGoroutine() >= before+numMediums
+	}, time.Second, 10*time.Millisecond, "writer goroutines never started (got %d, expected ≥ %d)", runtime.NumGoroutine(), before+numMediums)
+
+	for _, m := range mediums {
+		m.close()
+	}
+
+	// All writer goroutines must exit. With the bug they sit in
+	// publicationQueue.Wait() on empty queues. Allow some slack (5) for
+	// unrelated runtime goroutines that may come and go.
+	require.Eventually(t, func() bool {
+		return runtime.NumGoroutine() <= before+5
+	}, 2*time.Second, 20*time.Millisecond,
+		"writer goroutines did not exit after close (got %d, baseline %d) — medium.close() does not close the queue, so writers are stuck in messages.Wait()", runtime.NumGoroutine(), before)
 }
 
 // TestNewChannelMediumBroadcastDelayWithoutQueueRejected ensures the constructor

--- a/client.go
+++ b/client.go
@@ -4178,11 +4178,13 @@ func (c *Client) unsubscribe(channel string, unsubscribe Unsubscribe, disconnect
 
 	c.mu.Lock()
 	// Clean up normal subscription.
+	removedNow := false
 	if currentChCtx, exists := c.channels[channel]; exists {
 		if currentChCtx.subscribingCh != nil {
 			close(currentChCtx.subscribingCh)
 		}
 		delete(c.channels, channel)
+		removedNow = true
 	}
 	// Clean up map subscribing state. Identity-match against the snapshot so we
 	// don't close a fresh entry installed by a concurrent resubscribe.
@@ -4192,12 +4194,26 @@ func (c *Client) unsubscribe(channel string, unsubscribe Unsubscribe, disconnect
 				close(state.subscribingCh)
 			}
 			delete(c.mapSubscribing, channel)
+			removedNow = true
 		}
 	}
-	if disconnect == nil && c.perChannelWriter != nil {
+	if removedNow && disconnect == nil && c.perChannelWriter != nil {
 		c.perChannelWriter.delWriter(channel, false)
 	}
 	c.mu.Unlock()
+
+	// Multiple goroutines can reach this point for the same channel — e.g. the
+	// presence ticker spawns a fresh handleAsyncUnsubscribe goroutine on every
+	// tick until the channel is actually removed, and ticks can overlap if the
+	// first goroutine is still blocked on a network call or the write lock.
+	// Each goroutine captured its own chCtx snapshot under RLock and would
+	// otherwise re-run presence/leave/removeSubscription/unsubscribeHandler
+	// (which double-fires user callbacks and panics on patterns like a single
+	// `close(doneCh)` in OnUnsubscribe). Only the goroutine that won the delete
+	// race owns the cleanup; the rest exit here.
+	if !removedNow {
+		return nil
+	}
 
 	// Remove presence and/or run map cleanup on unsubscribe.
 	hasMapPresenceOrCleanup := channelHasFlag(chCtx.flags, flagMapClientPresence) ||

--- a/client.go
+++ b/client.go
@@ -1930,7 +1930,12 @@ func (c *Client) handleSubscribe(req *protocol.SubscribeRequest, cmd *protocol.C
 
 		if ctx.clientInfo != nil {
 			if channelHasFlag(ctx.channelContext.flags, flagEmitJoinLeave) || ctx.channelContext.mapClientPresenceChannel != "" || ctx.channelContext.mapUserPresenceChannel != "" {
-				go c.publishJoinAndPresence(req.Channel, ctx.channelContext, ctx.clientInfo)
+				// Synchronous (NOT `go`) so publishJoin reaches the broker before
+				// this subscribe callback returns. If we spawned a goroutine, a
+				// quick client disconnect could fire the synchronous publishLeave
+				// (from close → unsubscribe loop) ahead of our Join, leaving
+				// observers with [leave, join] on the wire.
+				c.publishJoinAndPresence(req.Channel, ctx.channelContext, ctx.clientInfo)
 			}
 		}
 	}
@@ -2903,7 +2908,10 @@ func (c *Client) connectCmd(req *protocol.ConnectRequest, cmd *protocol.Command,
 
 	for channel, subCtx := range subCtxMap {
 		if subCtx.clientInfo != nil {
-			go c.publishJoinAndPresence(channel, subCtx.channelContext, subCtx.clientInfo)
+			// Synchronous: see comment on the same call in handleSubscribe.
+			// A spawned goroutine racing a disconnect's publishLeave can land
+			// Join after Leave on the wire.
+			c.publishJoinAndPresence(channel, subCtx.channelContext, subCtx.clientInfo)
 		}
 	}
 

--- a/client_keyed.go
+++ b/client_keyed.go
@@ -364,6 +364,12 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 				}
 				c.mu.Unlock()
 			}
+			// addSubscribers has not run on this path, so drop the trackKeys
+			// reservation here — otherwise pendingHubJoin stays >0 and the
+			// itemIndex entries leak forever (untrack refuses to delete while
+			// pending>0). Encode failure is not reachable in current code,
+			// but the release is a one-line guard against future regressions.
+			releaseTrackReservation()
 			c.logWriteInternalErrorFlush(channel, protocol.FrameTypeSubRefresh, cmd, err, "error encoding sub refresh", started, rw)
 			return
 		}
@@ -455,6 +461,13 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 		// Only keys that were actually tracked are acted on — random keys sent
 		// by the client are silently ignored.
 		if len(req.Untrack) > 0 {
+			// c.mu is held across the hub.removeSubscriber loop so a
+			// concurrent handleTrack callback (with async TrackHandler this
+			// CAN run in parallel for the same client) cannot land its
+			// chanKeys insert + addSubscribers between our chanKeys delete
+			// and our hub remove. See cleanupKeyed for the wider rationale.
+			// Released before the untrackHandler callback so user code does
+			// not run under c.mu.
 			var actualUntrack []string
 			c.mu.Lock()
 			if c.keyed != nil {
@@ -474,7 +487,10 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 					}
 				}
 			}
-			c.mu.Unlock()
+
+			if testHookKeyedHubRemoveStart != nil {
+				testHookKeyedHubRemoveStart()
+			}
 
 			for _, key := range actualUntrack {
 				keyEmpty := hub.removeSubscriber(key, c)
@@ -482,6 +498,7 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 					c.node.sharedPollManager.untrack(channel, key)
 				}
 			}
+			c.mu.Unlock()
 
 			if len(actualUntrack) > 0 && c.eventHub.untrackHandler != nil {
 				c.eventHub.untrackHandler(UntrackEvent{
@@ -495,6 +512,13 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 }
 
 // handleUntrack processes SubRefreshRequest with type=2 (untrack).
+//
+// c.mu is held across the hub.removeSubscriber loop so a concurrent
+// handleTrack callback completion cannot land its chanKeys insert +
+// addSubscribers between our chanKeys delete and our hub remove. See
+// cleanupKeyed for the orphan-in-hub race the wider lock guards against.
+// Released before the untrackHandler callback so user code does not run
+// under c.mu.
 func (c *Client) handleUntrack(req *protocol.SubRefreshRequest, cmd *protocol.Command, started time.Time, rw *replyWriter) error {
 	channel := req.Channel
 
@@ -521,7 +545,10 @@ func (c *Client) handleUntrack(req *protocol.SubRefreshRequest, cmd *protocol.Co
 			}
 		}
 	}
-	c.mu.Unlock()
+
+	if testHookKeyedHubRemoveStart != nil {
+		testHookKeyedHubRemoveStart()
+	}
 
 	hub := c.node.keyedManager.getHub(channel)
 	if hub != nil {
@@ -532,6 +559,7 @@ func (c *Client) handleUntrack(req *protocol.SubRefreshRequest, cmd *protocol.Co
 			}
 		}
 	}
+	c.mu.Unlock()
 
 	if len(actualUntrack) > 0 && c.eventHub.untrackHandler != nil {
 		c.eventHub.untrackHandler(UntrackEvent{
@@ -552,16 +580,31 @@ func (c *Client) handleUntrack(req *protocol.SubRefreshRequest, cmd *protocol.Co
 	return nil
 }
 
+// testHookKeyedHubRemoveStart, if non-nil, is invoked from cleanupKeyed /
+// handleUntrack / checkTrackExpiration / handleTrack Step 8 AFTER
+// per-connection state has been mutated but BEFORE the hub.removeSubscriber
+// loop runs. Used by tests to deterministically inject a concurrent re-track
+// and reproduce the orphan-in-hub race. Production sets nil; overhead is one
+// nil check per cleanup call.
+var testHookKeyedHubRemoveStart func()
+
 // cleanupKeyed removes all keyed tracking for a channel when a client
 // unsubscribes or disconnects.
+//
+// c.mu is held across the hub.removeSubscriber loop so a concurrent
+// handleTrack callback completion (which takes c.mu before chanKeys insert
+// and then calls addSubscribers) cannot race between our chanKeys delete and
+// our hub remove — that race would leave chanKeys claiming the key tracked
+// while the hub no longer has this client, silently dropping all future
+// broadcasts. Lock order c.mu → sharedPollManager.mu → s.mu → hub.mu is
+// consistent with broadcast paths, which release hub.mu before taking c.mu.
 func (c *Client) cleanupKeyed(channel string) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.keyed == nil {
-		c.mu.Unlock()
 		return
 	}
 	chanKeys := c.keyed.trackedKeys[channel]
-	// Copy keys to avoid holding lock during cleanup.
 	keys := make([]string, 0, len(chanKeys))
 	for k := range chanKeys {
 		keys = append(keys, k)
@@ -571,7 +614,10 @@ func (c *Client) cleanupKeyed(channel string) {
 	if c.keyed.minTrackExpireAt != nil {
 		delete(c.keyed.minTrackExpireAt, channel)
 	}
-	c.mu.Unlock()
+
+	if testHookKeyedHubRemoveStart != nil {
+		testHookKeyedHubRemoveStart()
+	}
 
 	hub := c.node.keyedManager.getHub(channel)
 	if hub == nil {
@@ -638,13 +684,20 @@ func (c *Client) checkTrackExpiration(channel string, delay time.Duration) {
 			delete(c.keyed.minTrackExpireAt, channel)
 		}
 	}
-	c.mu.Unlock()
 
 	if len(expiredKeys) == 0 {
+		c.mu.Unlock()
 		return
 	}
 
+	if testHookKeyedHubRemoveStart != nil {
+		testHookKeyedHubRemoveStart()
+	}
+
 	// Clean up hub and SharedPollManager (no removal publications sent).
+	// c.mu is held across the loop — see cleanupKeyed for the orphan-in-hub
+	// race rationale. Released before the log call so user logger code does
+	// not run under c.mu.
 	hub := c.node.keyedManager.getHub(channel)
 	if hub != nil {
 		for _, key := range expiredKeys {
@@ -654,6 +707,7 @@ func (c *Client) checkTrackExpiration(channel string, delay time.Duration) {
 			}
 		}
 	}
+	c.mu.Unlock()
 
 	if c.node.logger.enabled(LogLevelInfo) {
 		c.node.logger.log(newLogEntry(LogLevelInfo, "track keys expired",

--- a/client_keyed.go
+++ b/client_keyed.go
@@ -108,9 +108,11 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 	}
 
 	// Optimistic limit check — counts DISTINCT new keys minus those that will
-	// be immediately removed via inline untrack. Re-checked under write lock.
+	// be immediately removed via inline untrack. Also subtracts already-tracked
+	// keys appearing in inlineUntrackSet, since Step 8 removes them and frees
+	// slots. Re-checked under write lock.
 	c.mu.RLock()
-	var currentCount, newKeyCountOpt int
+	var currentCount, newKeyCountOpt, inlineRemovedExistingOpt int
 	if c.keyed != nil {
 		chanKeys := c.keyed.trackedKeys[channel]
 		currentCount = len(chanKeys)
@@ -119,6 +121,11 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 				if _, willUntrack := inlineUntrackSet[f.key]; !willUntrack {
 					newKeyCountOpt++
 				}
+			}
+		}
+		for k := range inlineUntrackSet {
+			if _, exists := chanKeys[k]; exists {
+				inlineRemovedExistingOpt++
 			}
 		}
 	} else {
@@ -131,7 +138,7 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 	c.mu.RUnlock()
 
 	maxTracked := c.node.keyedManager.maxTrackedPerConnection(channel)
-	if currentCount+newKeyCountOpt > maxTracked {
+	if currentCount-inlineRemovedExistingOpt+newKeyCountOpt > maxTracked {
 		return ErrorLimitExceeded
 	}
 
@@ -232,8 +239,10 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 		chanKeys := c.keyed.trackedKeys[channel]
 
 		// Re-tracking an existing key is a version update, not a new slot —
-		// only count new keys, and exclude those being inline-untracked.
-		var newKeyCount int
+		// only count new keys, and exclude those being inline-untracked. Also
+		// subtract already-tracked keys that will be removed by Step 8, since
+		// they free up slots.
+		var newKeyCount, inlineRemovedExisting int
 		for _, f := range flat {
 			if _, exists := chanKeys[f.key]; !exists {
 				if _, willUntrack := inlineUntrackSet[f.key]; !willUntrack {
@@ -241,7 +250,12 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 				}
 			}
 		}
-		if len(chanKeys)+newKeyCount > maxTracked {
+		for k := range inlineUntrackSet {
+			if _, exists := chanKeys[k]; exists {
+				inlineRemovedExisting++
+			}
+		}
+		if len(chanKeys)-inlineRemovedExisting+newKeyCount > maxTracked {
 			c.mu.Unlock()
 			// Roll back the server-side track from Step 1 so we don't leak
 			// per-channel itemIndex entries for keys the client doesn't hold.
@@ -274,27 +288,6 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 			}
 		}
 		c.mu.Unlock()
-
-		// Compute warm key delivery plan. KeepLatestData → direct delivery
-		// from cache (zero backend calls). Otherwise → deferred via notify
-		// + needsBroadcast (one backend call per key per reconnect wave).
-		// Actual delivery happens after addSubscriber (steps 5.5 and 7).
-		var warmCachedData []warmKeyData
-		var deferredWarmKeys []string
-		if c.node.sharedPollManager != nil && len(warmKeys) > 0 {
-			warmCachedData = c.node.sharedPollManager.getWarmKeyData(channel, warmKeys)
-			if len(warmCachedData) < len(warmKeys) {
-				directKeys := make(map[string]struct{}, len(warmCachedData))
-				for _, wd := range warmCachedData {
-					directKeys[wd.key] = struct{}{}
-				}
-				for _, key := range warmKeys {
-					if _, ok := directKeys[key]; !ok {
-						deferredWarmKeys = append(deferredWarmKeys, key)
-					}
-				}
-			}
-		}
 
 		// Step 2: Collect cached data for items where server has newer version.
 		var cachedItems []*protocol.Publication
@@ -372,9 +365,47 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 		// Response is already enqueued, so broadcasts are ordered after it.
 		// keyedWritePublication checks pubVersion <= keyState.version, so cached
 		// items won't be re-delivered.
+		//
+		// keyedManager.addSubscribers performs "ensure-state-then-add"
+		// atomically under the manager's lock. This is required because a
+		// concurrent finalizeShutdown of an older sharedPollChannelState may
+		// race here: a non-atomic getOrCreateChannel + addSubscriber
+		// sequence could end up with the client subscribed to a hub that
+		// the finalizeShutdown then deletes from the manager, leaving the
+		// client orphaned from future broadcasts (which look up via
+		// getHub).
+		c.node.keyedManager.addSubscribers(channel, allKeys, c, keyedOpts)
 		hub := c.node.keyedManager.getHub(channel)
-		for _, key := range allKeys {
-			hub.addSubscriber(key, c)
+
+		// Compute warm key delivery plan AFTER addSubscriber. KeepLatestData →
+		// direct delivery from cache (zero backend calls). Otherwise → deferred
+		// via notify + needsBroadcast (one backend call per key per reconnect
+		// wave).
+		//
+		// Snapshotting after addSubscriber closes a race: if a publish lands
+		// between the snapshot and addSubscriber, the broadcast goes only to
+		// existing subscribers (not us yet), so we would deliver a stale
+		// snapshot and the version filter would suppress later same-version
+		// broadcasts — silently pinning the client to a stale value until the
+		// next entry update. With the snapshot taken after addSubscriber, any
+		// concurrent broadcast reaches us via the hub and advances the per-
+		// connection version; our direct-delivery call then no-ops, leaving
+		// client and server in sync.
+		var warmCachedData []warmKeyData
+		var deferredWarmKeys []string
+		if c.node.sharedPollManager != nil && len(warmKeys) > 0 {
+			warmCachedData = c.node.sharedPollManager.getWarmKeyData(channel, warmKeys)
+			if len(warmCachedData) < len(warmKeys) {
+				directKeys := make(map[string]struct{}, len(warmCachedData))
+				for _, wd := range warmCachedData {
+					directKeys[wd.key] = struct{}{}
+				}
+				for _, key := range warmKeys {
+					if _, ok := directKeys[key]; !ok {
+						deferredWarmKeys = append(deferredWarmKeys, key)
+					}
+				}
+			}
 		}
 
 		// Step 5.5: Direct delivery for warm keys with cached data.
@@ -621,6 +652,24 @@ func (c *Client) checkTrackExpiration(channel string, delay time.Duration) {
 // version is newer. Updates per-connection version on delivery.
 // Handles per-key delta readiness: first publication per key is always full,
 // subsequent publications may use delta if available.
+//
+// Encoding runs outside c.mu so a slow encode does not block other client
+// operations. The version re-check, the enqueue, and the per-connection
+// state update all run under c.mu in a single critical section: this
+// serializes concurrent broadcasts to the same client at the queue
+// boundary, so anything that lands in the wire queue is the freshest
+// version observed under the lock and any concurrent broadcast carrying an
+// older-or-equal version is filtered out — preventing wire-order inversion
+// where a slower-encoding older version would otherwise enqueue behind a
+// faster-encoding newer one.
+//
+// State (keyState.version / keyState.deltaReady) is updated only after the
+// publication is successfully enqueued. If encode fails, no-write conditions
+// trigger, or enqueue returns an error, state stays unchanged — otherwise
+// the client would silently miss the publication and subsequent broadcasts
+// at lower/equal versions would be filtered out, leaving server and client
+// out of sync (and, for delta channels, the next broadcast would send a
+// delta against a base the client never received).
 func (c *Client) keyedWritePublication(channel string, key string, pubVersion uint64, pub *protocol.Publication, prep preparedData) {
 	c.mu.Lock()
 	if c.keyed == nil {
@@ -638,20 +687,43 @@ func (c *Client) keyedWritePublication(channel string, key string, pubVersion ui
 		return
 	}
 
-	// Determine delta behavior for this client+key.
+	// Compute tentative delta decision against current state — do NOT mutate
+	// state yet. The final decision is re-checked under the lock in Phase 3
+	// because keyState.version can advance between phases.
 	chState := c.keyed.channels[channel]
 	channelDelta := chState != nil && chState.deltaType != deltaTypeNone
-	sendDelta := channelDelta && prep.deltaSub && keyState.deltaReady
-	if channelDelta && !keyState.deltaReady {
-		keyState.deltaReady = true
-	}
-	keyState.version = pubVersion
+	deltaPossible := channelDelta && prep.deltaSub && keyState.deltaReady
 	c.mu.Unlock()
 
 	isJSON := c.transport.Protocol().toProto() == protocol.TypeJSON
 
-	if sendDelta {
-		// Delta path: lazily encode delta publication per-client protocol.
+	// Encode outside the lock. Encoding can JSON-escape large payloads or
+	// build a delta frame — keeping it outside c.mu avoids stalling other
+	// operations on this client. Two concurrent broadcasts for the same key
+	// can therefore encode in parallel; the lock-protected enqueue below
+	// resolves their ordering.
+	//
+	// We always encode the FULL form so Phase 3 can fall back to it without
+	// re-encoding under the lock. The fallback is needed when the delta's
+	// base version (prep.keyedDeltaPrevVersion) doesn't match the client's
+	// current keyState.version — a sign that an intermediate broadcast was
+	// missed, so applying this patch would produce garbage.
+	pubFullToEncode := pub
+	if channelDelta && isJSON {
+		// JSON+delta: must JSON-escape data so client stores bytes for delta base.
+		pubFullToEncode = &protocol.Publication{
+			Data:    json.Escape(convert.BytesToString(pub.Data)),
+			Key:     pub.Key,
+			Version: pub.Version,
+		}
+	}
+	encodedFull, err := c.encodeKeyedPush(channel, pubFullToEncode)
+	if err != nil {
+		return
+	}
+
+	var encodedDelta []byte
+	if deltaPossible {
 		deltaData := prep.keyedDeltaPatch
 		if isJSON {
 			deltaData = json.Escape(convert.BytesToString(deltaData))
@@ -662,36 +734,90 @@ func (c *Client) keyedWritePublication(channel string, key string, pubVersion ui
 			Key:     pub.Key,
 			Version: pub.Version,
 		}
-		var err error
-		prep.localDeltaData, err = c.encodeKeyedPush(channel, deltaPub)
-		if err != nil {
+		data, encErr := c.encodeKeyedPush(channel, deltaPub)
+		if encErr != nil {
 			return
 		}
-		// prep.deltaSub already true from buildPreparedPollData.
-	} else {
-		// Full path.
-		prep.deltaSub = false
-		pubToEncode := pub
-		if channelDelta && isJSON {
-			// JSON+delta: must JSON-escape data so client stores bytes for delta base.
-			pubToEncode = &protocol.Publication{
-				Data:    json.Escape(convert.BytesToString(pub.Data)),
-				Key:     pub.Key,
-				Version: pub.Version,
-			}
-		}
-		var err error
-		prep.fullData, err = c.encodeKeyedPush(channel, pubToEncode)
-		if err != nil {
-			return
-		}
+		encodedDelta = data
 	}
 
+	// Mirror writePublication's no-write conditions so we don't enqueue or
+	// advance state when the publication would be dropped (these return nil
+	// from writePublication, indistinguishable from a real write).
+	if hasFlag(c.transport.DisabledPushFlags(), PushFlagPublication) {
+		return
+	}
+	if prep.wasFiltered && !deltaPossible {
+		return
+	}
+
+	// Resolve batch config — user-supplied callback, must run outside c.mu.
 	var batchConfig ChannelBatchConfig
 	if c.node.config.GetChannelBatchConfig != nil {
 		batchConfig = c.node.config.GetChannelBatchConfig(channel)
 	}
-	_ = c.writePublication(channel, pub, prep, StreamPosition{}, false, batchConfig)
+
+	// Trace before the critical section to avoid a c.mu.RLock acquisition
+	// inside traceOutPush while we're holding c.mu.Lock below. Tracing
+	// before enqueue is consistent with writePublication's existing pattern.
+	if c.node.logEnabled(LogLevelTrace) {
+		c.traceOutPush(&protocol.Push{Channel: channel, Pub: pub})
+	}
+
+	// Critical section: re-check version, decide delta-vs-full, enqueue,
+	// and update state under c.mu. Holding the lock through enqueue is what
+	// serializes concurrent broadcasts to this client and preserves causal
+	// version order on the wire. writeEncodedPushData uses messageWriter /
+	// perChannelWriter, each of which has its own internal mutex that does
+	// NOT touch c.mu — safe to call while holding it. (Going through
+	// writePublication here would deadlock on its c.mu.RLock for the
+	// deltaSub branch.)
+	c.mu.Lock()
+	if c.keyed == nil {
+		c.mu.Unlock()
+		return
+	}
+	chanKeys, ok = c.keyed.trackedKeys[channel]
+	if !ok {
+		c.mu.Unlock()
+		return
+	}
+	keyState, tracked = chanKeys[key]
+	if !tracked || pubVersion <= keyState.version {
+		// A concurrent broadcast already delivered this or a newer version.
+		c.mu.Unlock()
+		return
+	}
+
+	// Decide delta vs full under the lock. The delta is only safe to send
+	// when the client's current keyState.version equals the version of the
+	// bytes the patch was computed against — otherwise the client doesn't
+	// hold the right base and applying the patch yields garbage. This
+	// condition is broken by concurrent broadcasts that update the server's
+	// entry between when this broadcast's prep was built and when we
+	// observe keyState here.
+	useDelta := deltaPossible && encodedDelta != nil && keyState.deltaReady && keyState.version == prep.keyedDeltaPrevVersion
+	var dataToSend []byte
+	if useDelta {
+		dataToSend = encodedDelta
+	} else {
+		dataToSend = encodedFull
+	}
+
+	if err := c.writeEncodedPushData(dataToSend, channel, pub.Key, protocol.FrameTypePushPublication, batchConfig); err != nil {
+		// Enqueue failed (queue closed/overflow); client is being torn down.
+		// Don't advance state — cleanupKeyed on close will drop it anyway.
+		c.mu.Unlock()
+		return
+	}
+
+	// Advance state. For delta channels, a successful FULL delivery also
+	// flips deltaReady so subsequent broadcasts can use delta.
+	if channelDelta && !keyState.deltaReady {
+		keyState.deltaReady = true
+	}
+	keyState.version = pubVersion
+	c.mu.Unlock()
 }
 
 // keyedWriteRemoval writes a removal publication and removes the key from

--- a/client_keyed.go
+++ b/client_keyed.go
@@ -201,14 +201,22 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 		//         direct delivery from cache if KeepLatestData, else notify +
 		//         needsBroadcast for near-immediate backend poll.
 		//   (none): existing key, client up to date → no action.
+		//
+		// trackKeys takes a pendingHubJoin reservation for each tracked key
+		// that the returned releaseTrackReservation closure MUST drop — either
+		// after addSubscribers (Step 5) on success, or in the rollback path
+		// below. Without that release, a concurrent client's rollback would
+		// orphan our caller in the hub.
 		var coldKeys []string
 		var warmKeys []string
+		releaseTrackReservation := func() {}
 		if c.node.sharedPollManager != nil {
-			trackResults, err := c.node.sharedPollManager.trackKeys(channel, opts, allKeys)
+			trackResults, release, err := c.node.sharedPollManager.trackKeys(channel, opts, allKeys)
 			if err != nil {
 				c.writeDisconnectOrErrorFlush(channel, protocol.FrameTypeSubRefresh, cmd, ErrorInternal, started, rw)
 				return
 			}
+			releaseTrackReservation = release
 			for i, f := range flat {
 				tr := trackResults[i]
 				if tr.isNew && f.version == 0 {
@@ -257,13 +265,15 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 		}
 		if len(chanKeys)-inlineRemovedExisting+newKeyCount > maxTracked {
 			c.mu.Unlock()
-			// Roll back the server-side track from Step 1 so we don't leak
-			// per-channel itemIndex entries for keys the client doesn't hold.
-			if c.node.sharedPollManager != nil {
-				for _, key := range allKeys {
-					c.node.sharedPollManager.untrack(channel, key)
-				}
-			}
+			// Roll back the server-side track from Step 1. Release the
+			// reservation BEFORE calling untrack: release decrements
+			// pendingHubJoin and, if no concurrent caller still holds it
+			// and the hub has no subscribers, deletes the entry itself.
+			// The subsequent untrack covers the case where another caller
+			// joined the hub between trackKeys and now — release leaves
+			// the entry alive (pending or hub.count > 0) and untrack is a
+			// no-op for keys the caller didn't own.
+			releaseTrackReservation()
 			c.writeDisconnectOrErrorFlush(channel, protocol.FrameTypeSubRefresh, cmd, ErrorLimitExceeded, started, rw)
 			return
 		}
@@ -375,6 +385,10 @@ func (c *Client) handleTrack(req *protocol.SubRefreshRequest, cmd *protocol.Comm
 		// client orphaned from future broadcasts (which look up via
 		// getHub).
 		c.node.keyedManager.addSubscribers(channel, allKeys, c, keyedOpts)
+		// Release the pendingHubJoin reservation now that we're in the hub.
+		// hub.subscriberCount(key) is now >= 1 for each key we tracked, so
+		// release just decrements the counter — no entries are deleted.
+		releaseTrackReservation()
 		hub := c.node.keyedManager.getHub(channel)
 
 		// Compute warm key delivery plan AFTER addSubscriber. KeepLatestData →

--- a/client_keyed_test.go
+++ b/client_keyed_test.go
@@ -2,6 +2,7 @@ package centrifuge
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -346,4 +347,176 @@ func TestCheckTrackExpiration_EarlyReturns(t *testing.T) {
 
 	// minTrackExpireAt[channel] is unset (TrackReply{} had no ExpireAt) → fast path returns.
 	client.checkTrackExpiration("test:channel", time.Second)
+}
+
+// keyedOrphanInHubScenario is the shared body for the cleanup-vs-retrack race
+// tests covering cleanupKeyed, handleUntrack, and checkTrackExpiration.
+//
+// All three paths (cleanupKeyed, handleUntrack, checkTrackExpiration) follow
+// the same shape: under c.mu they delete the per-connection tracking entries,
+// release c.mu, then call hub.removeSubscriber outside the lock. A concurrent
+// handleTrack completion can land between unlock and hub-remove, re-inserting
+// chanKeys[K] and calling addSubscribers(K). The trailing hub.removeSubscriber
+// then strips the freshly-rejoined client — leaving chanKeys claiming the key
+// tracked while the hub no longer has this client, and all future broadcasts
+// silently skip it until disconnect or another re-track.
+//
+// The test wires testHookKeyedHubRemoveStart to spawn a re-track goroutine at
+// the race point and waits briefly so it can land. After the cleanup path
+// returns, it joins the re-track goroutine and asserts that chanKeys[K]
+// presence agrees with hub subscription. Pre-fix the assertion fails:
+// chanKeys[K] is set, hub.hasSubscriber returns false.
+func keyedOrphanInHubScenario(t *testing.T, trigger func(client *Client, channel, key string)) {
+	const channel = "test:orphan"
+	const key = "k1"
+
+	node := newTestNodeWithSharedPoll(t)
+	// OnTrack returns immediately with a short-but-valid ExpireAt so
+	// checkTrackExpiration triggers expiry on the first call.
+	setupSharedPollHandlersWithExpiry(node, time.Now().Unix()-3600)
+
+	client := newTestClientV2(t, node, "user1")
+	connectClientV2(t, client)
+	subscribeSharedPollClient(t, client, channel)
+	trackSharedPollClient(t, client, channel, []*protocol.KeyedItem{
+		{Key: key, Version: 0},
+	})
+
+	// Sanity: client is in chanKeys and in the hub for `key`.
+	client.mu.RLock()
+	_, before := client.keyed.trackedKeys[channel][key]
+	client.mu.RUnlock()
+	require.True(t, before, "setup: client should be in chanKeys for key")
+	hub := node.keyedManager.getHub(channel)
+	require.NotNil(t, hub)
+	require.True(t, hub.hasSubscriber(key, client), "setup: client should be in hub for key")
+
+	// Install hook fired at the race point. We spawn a re-track in a goroutine.
+	// Pre-fix: the goroutine acquires c.mu (cleanupKeyed has already released
+	// it), runs the full handleTrack including addSubscribers, then signals
+	// done — and the cleanup path's still-pending hub.removeSubscriber then
+	// strips the freshly added client. Post-fix: c.mu is held across the hub
+	// loop, so the goroutine parks on c.mu until cleanup completes.
+	var retrackWG sync.WaitGroup
+	retrackWG.Add(1)
+	var retrackErr error
+	var hookOnce sync.Once
+	testHookKeyedHubRemoveStart = func() {
+		hookOnce.Do(func() {
+			retrackStarted := make(chan struct{})
+			go func() {
+				defer retrackWG.Done()
+				close(retrackStarted)
+				// Re-track the same key — this exercises the full handleTrack
+				// flow including chanKeys insertion and addSubscribers.
+				rwWrapper := testReplyWriterWrapper()
+				if err := client.handleSubRefresh(&protocol.SubRefreshRequest{
+					Channel: channel,
+					Type:    typeTrack,
+					Track:   []*protocol.TrackBatch{{Items: []*protocol.KeyedItem{{Key: key, Version: 0}}}},
+				}, &protocol.Command{Id: 99}, time.Now(), rwWrapper.rw); err != nil {
+					retrackErr = err
+					return
+				}
+				// Wait for the track callback's reply so handleTrack has fully
+				// finished (chanKeys committed, hub.addSubscribers fired).
+				deadline := time.Now().Add(2 * time.Second)
+				for time.Now().Before(deadline) {
+					if len(rwWrapper.replies) > 0 {
+						return
+					}
+					time.Sleep(time.Millisecond)
+				}
+			}()
+			// Park briefly so the goroutine has a chance to acquire c.mu and
+			// land its re-track. Pre-fix: 100ms is more than enough for it to
+			// complete fully. Post-fix: 100ms passes with the goroutine
+			// blocked on c.mu (which is still held by cleanup), then the hook
+			// returns and cleanup proceeds.
+			<-retrackStarted
+			time.Sleep(100 * time.Millisecond)
+		})
+	}
+	t.Cleanup(func() { testHookKeyedHubRemoveStart = nil })
+
+	// Drive the cleanup path under test.
+	trigger(client, channel, key)
+
+	// Wait for the spawned re-track goroutine to finish.
+	retrackWG.Wait()
+	require.NoError(t, retrackErr)
+
+	// Invariant: chanKeys[K] present iff hub has c for K.
+	client.mu.RLock()
+	_, inChanKeys := client.keyed.trackedKeys[channel][key]
+	client.mu.RUnlock()
+	inHub := hub.hasSubscriber(key, client)
+
+	require.Equal(t, inChanKeys, inHub,
+		"orphan-in-hub race: chanKeys[K]=%v, hub.hasSubscriber=%v. "+
+			"A concurrent re-track was undone by the cleanup path's "+
+			"after-unlock hub.removeSubscriber — future broadcasts will "+
+			"silently miss this client even though it thinks K is tracked.",
+		inChanKeys, inHub)
+}
+
+// TestKeyed_CleanupKeyedVsRetrack_NoOrphanInHub covers cleanupKeyed (the
+// path invoked on client unsubscribe/disconnect).
+//
+// All three NoOrphanInHub tests share the package-level
+// testHookKeyedHubRemoveStart hook, so they cannot run with t.Parallel —
+// otherwise one test's hook would fire from another test's cleanup path.
+func TestKeyed_CleanupKeyedVsRetrack_NoOrphanInHub(t *testing.T) {
+	keyedOrphanInHubScenario(t, func(c *Client, channel, _ string) {
+		c.cleanupKeyed(channel)
+	})
+}
+
+// TestKeyed_HandleUntrackVsRetrack_NoOrphanInHub covers handleUntrack (the
+// SDK-initiated untrack path).
+func TestKeyed_HandleUntrackVsRetrack_NoOrphanInHub(t *testing.T) {
+	keyedOrphanInHubScenario(t, func(c *Client, channel, key string) {
+		untrackSharedPollClient(t, c, channel, []string{key})
+	})
+}
+
+// TestKeyed_CheckTrackExpirationVsRetrack_NoOrphanInHub covers
+// checkTrackExpiration (the server-side timer-driven expiry path). Setup uses
+// setupSharedPollHandlersWithExpiry with ExpireAt in the past so the very
+// first checkTrackExpiration call sweeps the key.
+func TestKeyed_CheckTrackExpirationVsRetrack_NoOrphanInHub(t *testing.T) {
+	keyedOrphanInHubScenario(t, func(c *Client, channel, _ string) {
+		// delay=0 makes the comparison nowUnix > expireAt+0 true immediately
+		// (expireAt is in the past).
+		c.checkTrackExpiration(channel, 0)
+	})
+}
+
+// TestKeyed_InlineUntrackVsRetrack_NoOrphanInHub covers handleTrack Step 8
+// (the inline-untrack path). The SDK can replay a signed batch that
+// includes a key in both req.Track and req.Untrack (or include any key in
+// req.Untrack alongside other tracked keys), and the server removes those
+// keys after Step 5's addSubscribers. Trackhandlers that invoke the
+// callback asynchronously allow two handleTrack callbacks for the same
+// client to interleave: A's Step 8 (delete chanKeys[K] then
+// hub.removeSubscriber(K)) can race a concurrent B's Step 2 + Step 5
+// (insert chanKeys[K] then addSubscribers([K])) — A's hub remove then
+// strips B's freshly-added subscription, orphaning B in hub state.
+//
+// Trigger fires a SubRefresh with Track:[K] and Untrack:[K]: re-tracking
+// K (no state change) then immediately untracking it through Step 8.
+func TestKeyed_InlineUntrackVsRetrack_NoOrphanInHub(t *testing.T) {
+	keyedOrphanInHubScenario(t, func(c *Client, channel, key string) {
+		rwWrapper := testReplyWriterWrapper()
+		err := c.handleSubRefresh(&protocol.SubRefreshRequest{
+			Channel: channel,
+			Type:    typeTrack,
+			Track:   []*protocol.TrackBatch{{Items: []*protocol.KeyedItem{{Key: key, Version: 0}}}},
+			Untrack: []string{key},
+		}, &protocol.Command{Id: 4}, time.Now(), rwWrapper.rw)
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			return len(rwWrapper.replies) > 0
+		}, 2*time.Second, time.Millisecond)
+	})
 }

--- a/client_keyed_test.go
+++ b/client_keyed_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/centrifugal/protocol"
+	fdelta "github.com/shadowspore/fossil-delta"
 	"github.com/stretchr/testify/require"
 )
 
@@ -157,6 +158,171 @@ func TestCleanupKeyed_NoKeyedState(t *testing.T) {
 
 	// Should be a no-op with no keyed state.
 	client.cleanupKeyed("anything")
+}
+
+// TestKeyedWritePublication_DeltaFallsBackToFullWhenBaseMismatches asserts
+// that when the prep's delta base-version doesn't match the client's
+// keyState.version, keyedWritePublication sends the FULL publication instead
+// of a delta — otherwise the client would apply the delta against the wrong
+// base and produce garbage.
+//
+// Background: a shared-poll delta patch is computed from entry.data BEFORE
+// the publish (prevData), versioned at entry.version BEFORE the bump
+// (prevVersion). The client can only apply the delta correctly if it
+// currently holds the bytes corresponding to prevVersion. Concurrent
+// broadcasts for the same key can race past the per-client version check
+// such that the client receives a delta whose prevVersion ≠ keyState.version
+// — its previous data doesn't match the patch's base. The fix tags prep
+// with prevVersion and falls back to FULL when the base wouldn't apply.
+//
+// The test simulates the race by directly building a prep with a fabricated
+// "stale" base version, then asserting the wire bytes are a FULL publication
+// (Delta=false) carrying the full payload, not a delta patch.
+func TestKeyedWritePublication_DeltaFallsBackToFullWhenBaseMismatches(t *testing.T) {
+	t.Parallel()
+	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
+		RefreshInterval:      time.Hour,
+		RefreshBatchSize:     100,
+		MaxKeysPerConnection: 100,
+		KeepLatestData:       true,
+		Mode:                 SharedPollModeVersioned,
+	})
+	setupSharedPollDeltaHandlers(node)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	transport := newTestTransport(cancel)
+	transport.setProtocolVersion(ProtocolVersion2)
+	transport.setProtocolType(ProtocolTypeProtobuf)
+	sink := make(chan []byte, 32)
+	transport.sink = sink
+	newCtx := SetCredentials(ctx, &Credentials{UserID: "user1"})
+	client, _ := newClient(newCtx, node, transport)
+	connectClientV2(t, client)
+	subscribeSharedPollClientDelta(t, client, "test:channel")
+	trackSharedPollClient(t, client, "test:channel", []*protocol.KeyedItem{
+		{Key: "k", Version: 0},
+	})
+
+	// Force the client into a known steady state: keyState.version=10,
+	// deltaReady=true — as if a prior FULL publication at v=10 was already
+	// delivered. We bypass the broadcast plumbing to set this up directly.
+	client.mu.Lock()
+	client.keyed.trackedKeys["test:channel"]["k"] = &keyedKeyState{
+		version:    10,
+		deltaReady: true,
+	}
+	client.mu.Unlock()
+
+	// Drain any startup frames.
+	drainStart := time.Now()
+	for time.Since(drainStart) < 50*time.Millisecond {
+		select {
+		case <-sink:
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// Build a prep that simulates a concurrent broadcast that won the race:
+	// the patch is computed from a previous-version snapshot (v=15) that
+	// this client never received — the client still holds v=10's data.
+	// Without the fix, keyedWritePublication would forward the delta as-is
+	// and the client would apply garbage. With the fix, it must fall back
+	// to FULL.
+	clientHas := []byte(`{"value":"data at v=10"}`)
+	staleBase := []byte(`{"value":"data at v=15 (client never saw)"}`)
+	newData := []byte(`{"value":"data at v=20"}`)
+	patch := fdelta.Create(staleBase, newData)
+	prep := preparedData{
+		deltaSub:         true,
+		keyedDeltaPatch:  patch,
+		keyedDeltaIsReal: len(patch) < len(newData),
+	}
+	pub := &protocol.Publication{Key: "k", Data: newData, Version: 20}
+
+	client.keyedWritePublication("test:channel", "k", 20, pub, prep)
+
+	// Read the wire publication for v=20.
+	var got *protocol.Publication
+	timeout := time.After(2 * time.Second)
+	for got == nil {
+		select {
+		case data := <-sink:
+			reply := &protocol.Reply{}
+			if err := reply.UnmarshalVT(data); err != nil {
+				continue
+			}
+			if reply.Push != nil && reply.Push.Pub != nil && reply.Push.Pub.Version == 20 {
+				got = reply.Push.Pub
+			}
+		case <-timeout:
+			t.Fatal("timeout waiting for publication v=20")
+		}
+	}
+
+	require.False(t, got.Delta,
+		"server must NOT send a delta whose base doesn't match client's keyState.version — "+
+			"client has v=10 but prep delta is from v=15. Got Delta=true with data %q", got.Data)
+	require.Equal(t, string(newData), string(got.Data),
+		"server must send the FULL payload when delta base wouldn't apply")
+	_ = clientHas
+}
+
+// TestKeyedWritePublication_StateNotAdvancedWhenWriteSkipped asserts that
+// keyedWritePublication does NOT update keyState.version or keyState.deltaReady
+// when the publication ultimately wasn't delivered.
+//
+// Repro: pass prep.wasFiltered=true. keyedWritePublication takes the full path
+// (deltaReady starts false → sendDelta=false), sets prep.deltaSub=false, and
+// then calls writePublication. writePublication early-returns at
+// `if prep.wasFiltered && !prep.deltaSub { return nil }` without enqueuing
+// anything. The client never sees the publication, but the buggy code has
+// already bumped keyState.version to pubVersion AND flipped
+// keyState.deltaReady to true. Subsequent broadcasts at lower or equal
+// versions are filtered out, and (when delta is enabled) the next broadcast
+// picks the delta path against a base the SDK never received.
+//
+// The test is synthetic — shared-poll publications don't currently set
+// wasFiltered — but the contract violation is real: any future code path
+// that legitimately filters a publication after the eager state update will
+// silently corrupt per-connection state. The same ordering bug also triggers
+// today on writePublication's other no-write paths (DisabledPushFlags,
+// encode failure) and on enqueue overflow before the async close races.
+func TestKeyedWritePublication_StateNotAdvancedWhenWriteSkipped(t *testing.T) {
+	t.Parallel()
+	node := defaultNodeNoHandlers()
+	defer func() { _ = node.Shutdown(context.Background()) }()
+
+	client := newTestClientV2(t, node, "u1")
+	connectClientV2(t, client)
+
+	// Manually set up keyed state: channel with delta enabled, one key tracked
+	// at version 0 with deltaReady=false.
+	client.mu.Lock()
+	client.keyed = &keyedState{
+		channels: map[string]*keyedChannelDeltaState{
+			"ch": {deltaType: DeltaTypeFossil},
+		},
+		trackedKeys: map[string]map[string]*keyedKeyState{
+			"ch": {"K": {version: 0, deltaReady: false}},
+		},
+	}
+	client.mu.Unlock()
+
+	// Call with prep.wasFiltered=true → writePublication will skip the write.
+	pub := &protocol.Publication{
+		Key: "K", Data: []byte(`{"v":1}`), Version: 1,
+	}
+	client.keyedWritePublication("ch", "K", 1, pub, preparedData{wasFiltered: true})
+
+	client.mu.RLock()
+	finalState := client.keyed.trackedKeys["ch"]["K"]
+	client.mu.RUnlock()
+	require.NotNil(t, finalState)
+	require.Equal(t, uint64(0), finalState.version,
+		"version must not advance when the publication was not actually delivered")
+	require.False(t, finalState.deltaReady,
+		"deltaReady must remain false when the first full publication was not delivered")
 }
 
 // TestCheckTrackExpiration_EarlyReturns covers the three early-return branches

--- a/client_map.go
+++ b/client_map.go
@@ -1255,7 +1255,11 @@ func (c *Client) setupMapPresenceAndJoin(channel string, opts SubscribeOptions) 
 		}
 	}
 
-	// Emit join event if enabled.
+	// Emit join event if enabled. Synchronous (NOT `go`) so publishJoin
+	// reaches the broker before this function returns. If we spawned a
+	// goroutine, a quick disconnect's synchronous publishLeave could win
+	// the race to the broker — observers would see [leave, join] on the
+	// wire, corrupting any membership state derived from join/leave events.
 	if opts.EmitJoinLeave {
 		info := &ClientInfo{
 			ClientID: c.uid,
@@ -1263,7 +1267,7 @@ func (c *Client) setupMapPresenceAndJoin(channel string, opts SubscribeOptions) 
 			ConnInfo: c.info,
 			ChanInfo: opts.ChannelInfo,
 		}
-		go func() { _ = c.node.publishJoin(channel, info) }()
+		_ = c.node.publishJoin(channel, info)
 	}
 }
 

--- a/client_map_test.go
+++ b/client_map_test.go
@@ -81,6 +81,44 @@ func drainSink(sink chan []byte) [][]byte {
 	}
 }
 
+// waitMapSinkContains waits until wantSub appears in a sink message (or waitFor elapses),
+// then continues reading for graceExtra to detect whether negativeSub also appears.
+// Returns (wantSeen, negativeSeen).
+func waitMapSinkContains(t testing.TB, sink chan []byte, wantSub, negativeSub string, waitFor, graceExtra time.Duration) (bool, bool) {
+	t.Helper()
+	deadline := time.NewTimer(waitFor)
+	defer deadline.Stop()
+	wantSeen := false
+	negativeSeen := false
+	for !wantSeen {
+		select {
+		case msg := <-sink:
+			s := string(msg)
+			if strings.Contains(s, wantSub) {
+				wantSeen = true
+			}
+			if negativeSub != "" && strings.Contains(s, negativeSub) {
+				negativeSeen = true
+			}
+		case <-deadline.C:
+			return wantSeen, negativeSeen
+		}
+	}
+	grace := time.NewTimer(graceExtra)
+	defer grace.Stop()
+	for {
+		select {
+		case msg := <-sink:
+			s := string(msg)
+			if negativeSub != "" && strings.Contains(s, negativeSub) {
+				negativeSeen = true
+			}
+		case <-grace.C:
+			return wantSeen, negativeSeen
+		}
+	}
+}
+
 // subscribeMapClientExpectError performs a keyed subscribe request expecting an error.
 func subscribeMapClientExpectError(t testing.TB, client *Client, req *protocol.SubscribeRequest) *protocol.Error {
 	rwWrapper := testReplyWriterWrapper()
@@ -4283,22 +4321,8 @@ func TestMapSubscribe_ServerTagsFilter_LiveDelivery(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Wait for delivery.
-	time.Sleep(50 * time.Millisecond)
-
-	// Check what was delivered — only eng_item should arrive.
-	messages := drainSink(transport.sink)
-	engFound := false
-	salesFound := false
-	for _, msg := range messages {
-		s := string(msg)
-		if strings.Contains(s, "eng_item") {
-			engFound = true
-		}
-		if strings.Contains(s, "sales_item") {
-			salesFound = true
-		}
-	}
+	// Wait until eng_item is delivered, then ensure sales_item never arrives.
+	engFound, salesFound := waitMapSinkContains(t, transport.sink, "eng_item", "sales_item", 2*time.Second, 100*time.Millisecond)
 	require.True(t, engFound, "eng_item should be delivered")
 	require.False(t, salesFound, "sales_item should be filtered out")
 }
@@ -4424,21 +4448,8 @@ func TestMapSubscribe_ServerTagsFilter_RemovalFiltering(t *testing.T) {
 	_, err = broker.Remove(ctx, channel, "sales_item", MapRemoveOptions{})
 	require.NoError(t, err)
 
-	time.Sleep(50 * time.Millisecond)
-
 	// Subscriber should receive removal for eng_item but NOT for sales_item.
-	messages := drainSink(transport.sink)
-	engRemoval := false
-	salesRemoval := false
-	for _, msg := range messages {
-		s := string(msg)
-		if strings.Contains(s, "eng_item") {
-			engRemoval = true
-		}
-		if strings.Contains(s, "sales_item") {
-			salesRemoval = true
-		}
-	}
+	engRemoval, salesRemoval := waitMapSinkContains(t, transport.sink, "eng_item", "sales_item", 2*time.Second, 100*time.Millisecond)
 	require.True(t, engRemoval, "eng_item removal should be delivered")
 	require.False(t, salesRemoval, "sales_item removal should be filtered out")
 }

--- a/client_shared_poll_test.go
+++ b/client_shared_poll_test.go
@@ -5146,11 +5146,12 @@ drain:
 // TestSharedPollTrackKeys_RollbackDoesNotOrphanConcurrentTrack.
 type controllableSubscribeBroker struct {
 	*MemoryBroker
-	mu         sync.Mutex
-	callCount  int
-	startedCh  chan int   // signals when call N begins (N is sent on the chan)
-	blockUntil map[int]chan struct{}
-	errOnCall  map[int]error
+	mu           sync.Mutex
+	callCount    int
+	startedCh    chan int // signals when call N begins (N is sent on the chan)
+	blockUntil   map[int]chan struct{}
+	errOnCall    map[int]error
+	publishCount atomic.Int32
 }
 
 func (b *controllableSubscribeBroker) Subscribe(channels ...string) error {
@@ -5174,6 +5175,11 @@ func (b *controllableSubscribeBroker) Subscribe(channels ...string) error {
 		return err
 	}
 	return b.MemoryBroker.Subscribe(channels...)
+}
+
+func (b *controllableSubscribeBroker) Publish(ch string, data []byte, opts PublishOptions) (PublishResult, error) {
+	b.publishCount.Add(1)
+	return b.MemoryBroker.Publish(ch, data, opts)
 }
 
 // TestSharedPollTrackKeys_RollbackDoesNotOrphanConcurrentTrack exercises the
@@ -5246,14 +5252,15 @@ func TestSharedPollTrackKeys_RollbackDoesNotOrphanConcurrentTrack(t *testing.T) 
 
 	type res struct {
 		keyResults []trackKeyResult
+		release    func()
 		err        error
 	}
 	resA := make(chan res, 1)
 	resB := make(chan res, 1)
 
 	go func() {
-		r, err := node.sharedPollManager.trackKeys("test:channel", opts, []string{"key1"})
-		resA <- res{r, err}
+		r, release, err := node.sharedPollManager.trackKeys("test:channel", opts, []string{"key1"})
+		resA <- res{r, release, err}
 	}()
 
 	// Wait for A to enter broker.Subscribe call #1.
@@ -5271,8 +5278,8 @@ func TestSharedPollTrackKeys_RollbackDoesNotOrphanConcurrentTrack(t *testing.T) 
 	// With the fix (hold s.mu across broker.Subscribe): A is blocked in
 	// broker.Subscribe with s.mu still held; B blocks on s.mu instead.
 	go func() {
-		r, err := node.sharedPollManager.trackKeys("test:channel", opts, []string{"key1"})
-		resB <- res{r, err}
+		r, release, err := node.sharedPollManager.trackKeys("test:channel", opts, []string{"key1"})
+		resB <- res{r, release, err}
 	}()
 
 	// Give B a window to enter trackKeys and (with buggy code) finish.
@@ -5295,6 +5302,10 @@ func TestSharedPollTrackKeys_RollbackDoesNotOrphanConcurrentTrack(t *testing.T) 
 	}
 
 	require.Error(t, aResult.err, "A's trackKeys must surface the broker subscribe failure")
+	// On error trackKeys self-releases reservations; the returned release
+	// is a no-op closure. Calling it keeps the contract symmetric.
+	aResult.release()
+	defer bResult.release()
 
 	// Core invariant: if B's trackKeys returned success, the manager must
 	// still be tracking key1 — both in itemIndex (so notify/poll cover it)
@@ -5321,4 +5332,676 @@ func TestSharedPollTrackKeys_RollbackDoesNotOrphanConcurrentTrack(t *testing.T) 
 			"BUG: B's trackKeys succeeded but no broker subscription exists for key1 — "+
 				"A's failed subscribe + entry rollback left the key unsubscribed at the broker")
 	}
+}
+
+// TestSharedPollTrackKeys_LimitRollback_DoesNotOrphanConcurrentHubJoin
+// exercises the race between Client A's handleTrack limit-rollback (which
+// calls untrack BEFORE addSubscribers) and a concurrent Client B that
+// rode on the back of A's trackKeys (saw the entry already present,
+// returned success without doing its own broker.Subscribe) and is about
+// to call addSubscribers.
+//
+// Sequence (deterministic via the controllable broker):
+//
+//  1. A.trackKeys(K) — A creates the itemIndex entry and begins
+//     broker.Subscribe (blocks).
+//  2. B.trackKeys(K) — B sees the entry already present and waits on
+//     A's subscribeReady chan.
+//  3. A's broker.Subscribe is released and succeeds.
+//  4. Both A and B return from trackKeys with success.
+//  5. A's handleTrack hits the limit-rollback branch and calls
+//     untrack(K). hub.subscriberCount(K) == 0 here (neither A nor B has
+//     reached addSubscribers yet), so untrack deletes the itemIndex
+//     entry and queues broker unsubscribe.
+//  6. B's handleTrack calls addSubscribers(K, B). B is now in the hub
+//     for K — but itemIndex has no K and broker.Unsubscribe is queued.
+//
+// Bug symptom: B is silently orphaned. Cross-node publishes never reach
+// this node for K (broker unsubscribed). Local SharedPollPublish for K
+// no-ops because entry is gone.
+//
+// Invariant asserted below: after B's addSubscribers, the itemIndex
+// entry and the broker subscription must still exist.
+func TestSharedPollTrackKeys_LimitRollback_DoesNotOrphanConcurrentHubJoin(t *testing.T) {
+	t.Parallel()
+
+	node, err := New(Config{
+		LogLevel:   LogLevelTrace,
+		LogHandler: func(entry LogEntry) {},
+		SharedPoll: SharedPollConfig{
+			GetSharedPollChannelOptions: func(channel string) (SharedPollChannelOptions, bool) {
+				return SharedPollChannelOptions{
+					Mode:                 SharedPollModeVersioned,
+					RefreshInterval:      30 * time.Second,
+					RefreshBatchSize:     100,
+					MaxKeysPerConnection: 100,
+					PublishEnabled:       true,
+				}, true
+			},
+		},
+	})
+	require.NoError(t, err)
+	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
+		return SharedPollResult{}, nil
+	})
+
+	memBroker, err := NewMemoryBroker(node, MemoryBrokerConfig{})
+	require.NoError(t, err)
+	ctrlBroker := &controllableSubscribeBroker{
+		MemoryBroker: memBroker,
+		startedCh:    make(chan int, 8),
+		blockUntil:   map[int]chan struct{}{},
+		errOnCall:    map[int]error{},
+	}
+	// Call 1 (goroutine A): block until released, then succeed.
+	call1Block := make(chan struct{})
+	ctrlBroker.blockUntil[1] = call1Block
+
+	node.SetBroker(ctrlBroker)
+	require.NoError(t, node.Run())
+	t.Cleanup(func() { _ = node.Shutdown(context.Background()) })
+
+	opts := SharedPollChannelOptions{
+		Mode:                 SharedPollModeVersioned,
+		RefreshInterval:      30 * time.Second,
+		RefreshBatchSize:     100,
+		MaxKeysPerConnection: 100,
+		PublishEnabled:       true,
+	}
+
+	channel := "test:channel"
+	key := "key1"
+
+	type trackRes struct {
+		results []trackKeyResult
+		release func()
+		err     error
+	}
+	resA := make(chan trackRes, 1)
+	resB := make(chan trackRes, 1)
+
+	// Goroutine A: first to call trackKeys; broker.Subscribe blocks.
+	go func() {
+		r, release, err := node.sharedPollManager.trackKeys(channel, opts, []string{key})
+		resA <- trackRes{r, release, err}
+	}()
+
+	// Wait for A's broker.Subscribe to be in flight.
+	select {
+	case n := <-ctrlBroker.startedCh:
+		require.Equal(t, 1, n)
+	case <-time.After(2 * time.Second):
+		t.Fatal("A's broker.Subscribe never started")
+	}
+
+	// Goroutine B: second trackKeys. The entry already exists with
+	// subscribeReady; B waits on it.
+	go func() {
+		r, release, err := node.sharedPollManager.trackKeys(channel, opts, []string{key})
+		resB <- trackRes{r, release, err}
+	}()
+
+	// Give B time to enter trackKeys and reach the wait.
+	time.Sleep(50 * time.Millisecond)
+
+	// Release A's broker.Subscribe. Both A and B should now return success.
+	close(call1Block)
+
+	var aResult, bResult trackRes
+	select {
+	case aResult = <-resA:
+	case <-time.After(2 * time.Second):
+		t.Fatal("A's trackKeys never returned")
+	}
+	require.NoError(t, aResult.err)
+	select {
+	case bResult = <-resB:
+	case <-time.After(2 * time.Second):
+		t.Fatal("B's trackKeys never returned")
+	}
+	require.NoError(t, bResult.err)
+
+	// Simulate A's handleTrack limit-rollback: release A's reservation
+	// BEFORE B has joined the hub. With the fix, A's release decrements
+	// pendingHubJoin (B still holds one) and the entry stays. Without the
+	// fix (untrack called blindly), the entry is deleted here.
+	aResult.release()
+
+	// Belt-and-braces: even if some unrelated path called untrack now
+	// (e.g., another connection's cleanupKeyed run from a different
+	// channel that shares the key string), it must respect B's reservation.
+	// Pre-fix untrack would delete unconditionally because hub.count==0.
+	node.sharedPollManager.untrack(channel, key)
+
+	// Now simulate B's addSubscribers (Step 5 in handleTrack).
+	clientB := newTestClient(t, node, "userB")
+	node.keyedManager.addSubscribers(channel, []string{key}, clientB, opts.toKeyedChannelOptions())
+
+	// Invariant: B is in the hub, so the manager MUST still be tracking
+	// the key — both itemIndex (so notify/poll cover it) and broker
+	// subscription (so cross-node publishes reach this node).
+	node.sharedPollManager.mu.RLock()
+	s := node.sharedPollManager.channels[channel]
+	node.sharedPollManager.mu.RUnlock()
+	require.NotNil(t, s, "channel state must exist when B is in the hub")
+	s.mu.Lock()
+	entry := s.itemIndex[key]
+	s.mu.Unlock()
+	require.NotNil(t, entry,
+		"BUG: B is in the hub but itemIndex no longer has the key — A's "+
+			"limit-rollback released its reservation while B's hub join was "+
+			"still in flight, and untrack deleted the entry. B is silently "+
+			"orphaned: cross-node publishes won't reach this node, and local "+
+			"SharedPollPublish will no-op (entry==nil).")
+
+	keyCh := sharedPollKeyChannel(channel, key)
+	node.sharedPollManager.brokerSubMu.RLock()
+	_, brokerSubbed := node.sharedPollManager.brokerSubChans[keyCh]
+	node.sharedPollManager.brokerSubMu.RUnlock()
+	require.True(t, brokerSubbed,
+		"BUG: B is in the hub but broker subscription was queued for "+
+			"unsubscribe by A's rollback — cross-node publishes for the key "+
+			"will be lost for B.")
+
+	// Finally release B's reservation (B has joined the hub; release is a
+	// no-op cleanup since hub.subscriberCount>0).
+	bResult.release()
+}
+
+// TestSharedPollRevokeKeys_UnsubscribesBroker demonstrates that
+// SharedPollRevokeKeys must also drop the broker subscription for any
+// key it removes from itemIndex. Before the fix, revoke deleted the
+// itemIndex entry but left brokerSubChans populated — the broker kept
+// pushing cross-node publications for the key, all of which were
+// silently no-op'd by handlePublishedData (entry == nil). On heavy
+// revoke workloads the wasted cross-node traffic accumulates and the
+// broker subscription persists until the entire channel state is shut
+// down.
+//
+// Invariant under test: after revoking a key, the per-key broker
+// subscription is gone (queued via the dissolver).
+func TestSharedPollRevokeKeys_UnsubscribesBroker(t *testing.T) {
+	t.Parallel()
+
+	node, err := New(Config{
+		LogLevel:   LogLevelTrace,
+		LogHandler: func(entry LogEntry) {},
+		SharedPoll: SharedPollConfig{
+			GetSharedPollChannelOptions: func(channel string) (SharedPollChannelOptions, bool) {
+				return SharedPollChannelOptions{
+					Mode:                 SharedPollModeVersioned,
+					RefreshInterval:      30 * time.Second,
+					RefreshBatchSize:     100,
+					MaxKeysPerConnection: 100,
+					PublishEnabled:       true,
+				}, true
+			},
+		},
+	})
+	require.NoError(t, err)
+	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
+		items := make([]SharedPollRefreshItem, len(event.Items))
+		for i, it := range event.Items {
+			items[i] = SharedPollRefreshItem{Key: it.Key, Data: []byte(`"data"`), Version: 1}
+		}
+		return SharedPollResult{Items: items}, nil
+	})
+	setupSharedPollHandlers(node)
+	memBroker, err := NewMemoryBroker(node, MemoryBrokerConfig{})
+	require.NoError(t, err)
+	node.SetBroker(memBroker)
+	require.NoError(t, node.Run())
+	t.Cleanup(func() { _ = node.Shutdown(context.Background()) })
+
+	channel := "test:revoke_broker"
+	key := "key1"
+	otherKey := "key2"
+
+	client := newTestClientV2(t, node, "user1")
+	connectClientV2(t, client)
+	subscribeSharedPollClient(t, client, channel)
+	trackSharedPollClient(t, client, channel, []*protocol.KeyedItem{
+		{Key: key, Version: 0},
+		{Key: otherKey, Version: 0},
+	})
+
+	// Confirm broker subscriptions exist for both keys before revoke.
+	keyCh := sharedPollKeyChannel(channel, key)
+	otherKeyCh := sharedPollKeyChannel(channel, otherKey)
+	node.sharedPollManager.brokerSubMu.RLock()
+	_, hasKey := node.sharedPollManager.brokerSubChans[keyCh]
+	_, hasOther := node.sharedPollManager.brokerSubChans[otherKeyCh]
+	node.sharedPollManager.brokerSubMu.RUnlock()
+	require.True(t, hasKey, "broker must be subscribed for key1 before revoke")
+	require.True(t, hasOther, "broker must be subscribed for key2 before revoke")
+
+	// Revoke key1 from all users (so itemIndex entry is removed).
+	node.sharedPollManager.SharedPollRevokeKeys(channel, []string{key}, nil, nil)
+
+	// Invariant: broker subscription for the revoked key must be dropped
+	// (queued via the dissolver — wait for it to clear).
+	require.Eventually(t, func() bool {
+		node.sharedPollManager.brokerSubMu.RLock()
+		defer node.sharedPollManager.brokerSubMu.RUnlock()
+		_, exists := node.sharedPollManager.brokerSubChans[keyCh]
+		return !exists
+	}, 2*time.Second, 10*time.Millisecond,
+		"BUG: SharedPollRevokeKeys deleted the itemIndex entry but left "+
+			"the broker subscription in place. Cross-node publications for "+
+			"the revoked key continue arriving and are silently dropped by "+
+			"handlePublishedData — wasted broker traffic until the entire "+
+			"channel state shuts down.")
+
+	// Sanity: untouched keys must remain subscribed at the broker.
+	node.sharedPollManager.brokerSubMu.RLock()
+	_, stillSubscribedOther := node.sharedPollManager.brokerSubChans[otherKeyCh]
+	node.sharedPollManager.brokerSubMu.RUnlock()
+	require.True(t, stillSubscribedOther,
+		"untouched key must keep its broker subscription after revoke")
+}
+
+// TestSharedPollSubscribeToBrokerKeys_PublishDuringWindow exercises a
+// contract violation where established subscribers on OTHER nodes
+// silently miss a publication. Sequence:
+//
+//   - Node B's user calls SharedPollPublish for K1 while Node B's own
+//     cold-key trackKeys for K1 is in the broker.Subscribe window
+//     (broker.Subscribe returned or in flight, brokerSubChans not yet
+//     updated).
+//   - publish() on Node B reads brokerSubChans -> empty -> falls back
+//     to handlePublishedData (local-only). broker.Publish is never
+//     called.
+//   - On other nodes (modelled here by the assertion that broker.Publish
+//     fires), any client already subscribed to K1 never receives the
+//     publication. That breaks the "subscribed clients receive
+//     notifications" contract.
+//
+// The fix holds brokerSubMu across broker.Subscribe so publishes block
+// on the RLock until brokerSubChans is consistent, then route through
+// the broker as intended.
+func TestSharedPollSubscribeToBrokerKeys_PublishDuringWindow(t *testing.T) {
+	t.Parallel()
+
+	node, err := New(Config{
+		LogLevel:   LogLevelTrace,
+		LogHandler: func(entry LogEntry) {},
+		SharedPoll: SharedPollConfig{
+			GetSharedPollChannelOptions: func(channel string) (SharedPollChannelOptions, bool) {
+				return SharedPollChannelOptions{
+					Mode:                 SharedPollModeVersioned,
+					RefreshInterval:      30 * time.Second,
+					RefreshBatchSize:     100,
+					MaxKeysPerConnection: 100,
+					PublishEnabled:       true,
+				}, true
+			},
+		},
+	})
+	require.NoError(t, err)
+	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
+		return SharedPollResult{}, nil
+	})
+
+	memBroker, err := NewMemoryBroker(node, MemoryBrokerConfig{})
+	require.NoError(t, err)
+	ctrlBroker := &controllableSubscribeBroker{
+		MemoryBroker: memBroker,
+		startedCh:    make(chan int, 8),
+		blockUntil:   map[int]chan struct{}{},
+		errOnCall:    map[int]error{},
+	}
+	call1Block := make(chan struct{})
+	ctrlBroker.blockUntil[1] = call1Block
+
+	node.SetBroker(ctrlBroker)
+	require.NoError(t, node.Run())
+	t.Cleanup(func() { _ = node.Shutdown(context.Background()) })
+
+	opts := SharedPollChannelOptions{
+		Mode:                 SharedPollModeVersioned,
+		RefreshInterval:      30 * time.Second,
+		RefreshBatchSize:     100,
+		MaxKeysPerConnection: 100,
+		PublishEnabled:       true,
+	}
+	channel := "test:subscribe_window"
+	key := "key1"
+
+	type trackRes struct {
+		results []trackKeyResult
+		release func()
+		err     error
+	}
+	resCh := make(chan trackRes, 1)
+
+	go func() {
+		r, release, err := node.sharedPollManager.trackKeys(channel, opts, []string{key})
+		resCh <- trackRes{r, release, err}
+	}()
+
+	select {
+	case n := <-ctrlBroker.startedCh:
+		require.Equal(t, 1, n)
+	case <-time.After(2 * time.Second):
+		t.Fatal("broker.Subscribe was not invoked")
+	}
+
+	publishDone := make(chan error, 1)
+	go func() {
+		publishDone <- node.SharedPollPublish(context.Background(), channel, key, 1, "", []byte(`"x"`))
+	}()
+
+	// Give the publish goroutine time to either complete (bug path) or
+	// block on brokerSubMu (fix path).
+	time.Sleep(100 * time.Millisecond)
+
+	close(call1Block)
+
+	var aResult trackRes
+	select {
+	case aResult = <-resCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("trackKeys never returned")
+	}
+	require.NoError(t, aResult.err)
+	defer aResult.release()
+
+	select {
+	case err := <-publishDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("publish goroutine never returned")
+	}
+
+	require.EqualValues(t, 1, ctrlBroker.publishCount.Load(),
+		"BUG: SharedPollPublish landed during the window between "+
+			"broker.Subscribe and the brokerSubChans update. publish() saw "+
+			"empty brokerSubChans and fell back to local-only delivery — "+
+			"established subscribers on other nodes would silently miss the "+
+			"publication.")
+}
+
+// TestSharedPollPublish_RoutesToBrokerWithoutLocalTrack proves the new
+// publish contract: when the channel is configured with PublishEnabled,
+// SharedPollPublish routes through the broker regardless of whether the
+// publishing node has tracked the key locally. Previously, publish()
+// used brokerSubChans (a side-effect of subscribeToBrokerKeys) as the
+// gate — so a node that had never tracked the key silently fell back
+// to handlePublishedData, and subscribers on OTHER nodes never received
+// the publication. The fix decouples routing from local subscriber
+// state.
+//
+// We can't spin up two Nodes sharing a MemoryBroker in this test (memory
+// brokers are per-node), but we can directly verify the contract by
+// asserting broker.Publish was invoked when no local track exists.
+func TestSharedPollPublish_RoutesToBrokerWithoutLocalTrack(t *testing.T) {
+	t.Parallel()
+
+	node, err := New(Config{
+		LogLevel:   LogLevelTrace,
+		LogHandler: func(entry LogEntry) {},
+		SharedPoll: SharedPollConfig{
+			GetSharedPollChannelOptions: func(channel string) (SharedPollChannelOptions, bool) {
+				return SharedPollChannelOptions{
+					Mode:                 SharedPollModeVersioned,
+					RefreshInterval:      30 * time.Second,
+					RefreshBatchSize:     100,
+					MaxKeysPerConnection: 100,
+					PublishEnabled:       true,
+				}, true
+			},
+		},
+	})
+	require.NoError(t, err)
+	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
+		return SharedPollResult{}, nil
+	})
+
+	memBroker, err := NewMemoryBroker(node, MemoryBrokerConfig{})
+	require.NoError(t, err)
+	ctrlBroker := &controllableSubscribeBroker{
+		MemoryBroker: memBroker,
+		startedCh:    make(chan int, 8),
+		blockUntil:   map[int]chan struct{}{},
+		errOnCall:    map[int]error{},
+	}
+	node.SetBroker(ctrlBroker)
+	require.NoError(t, node.Run())
+	t.Cleanup(func() { _ = node.Shutdown(context.Background()) })
+
+	// Sanity: no channel state, no local track, no broker subscription.
+	channel := "test:publish_no_local_track"
+	key := "key1"
+	node.sharedPollManager.mu.RLock()
+	_, exists := node.sharedPollManager.channels[channel]
+	node.sharedPollManager.mu.RUnlock()
+	require.False(t, exists, "no channel state should exist before publish")
+	keyCh := sharedPollKeyChannel(channel, key)
+	node.sharedPollManager.brokerSubMu.RLock()
+	_, brokerSubbed := node.sharedPollManager.brokerSubChans[keyCh]
+	node.sharedPollManager.brokerSubMu.RUnlock()
+	require.False(t, brokerSubbed, "broker must not be subscribed before any track")
+
+	// Publish without any prior track on this node. With the old code,
+	// brokerSubChans is empty → publish() falls back to handlePublishedData
+	// → no-op. broker.Publish would NOT be called, and subscribers on
+	// other nodes would never receive this publication.
+	require.NoError(t, node.SharedPollPublish(
+		context.Background(), channel, key, 1, "", []byte(`"hello"`),
+	))
+
+	require.EqualValues(t, 1, ctrlBroker.publishCount.Load(),
+		"BUG: SharedPollPublish on a PublishEnabled channel must route "+
+			"through the broker even when this node has never tracked "+
+			"the key. Otherwise subscribers on other nodes would never "+
+			"receive the publication.")
+}
+
+// TestSharedPollPublish_LocalOnlyDoesNotUseBroker is the symmetric
+// case: when PublishEnabled is false, publish() must NOT call
+// broker.Publish — it stays local-only.
+func TestSharedPollPublish_LocalOnlyDoesNotUseBroker(t *testing.T) {
+	t.Parallel()
+
+	node, err := New(Config{
+		LogLevel:   LogLevelTrace,
+		LogHandler: func(entry LogEntry) {},
+		SharedPoll: SharedPollConfig{
+			GetSharedPollChannelOptions: func(channel string) (SharedPollChannelOptions, bool) {
+				return SharedPollChannelOptions{
+					Mode:                 SharedPollModeVersioned,
+					RefreshInterval:      30 * time.Second,
+					RefreshBatchSize:     100,
+					MaxKeysPerConnection: 100,
+					PublishEnabled:       false,
+				}, true
+			},
+		},
+	})
+	require.NoError(t, err)
+	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
+		return SharedPollResult{}, nil
+	})
+
+	memBroker, err := NewMemoryBroker(node, MemoryBrokerConfig{})
+	require.NoError(t, err)
+	ctrlBroker := &controllableSubscribeBroker{
+		MemoryBroker: memBroker,
+		startedCh:    make(chan int, 8),
+		blockUntil:   map[int]chan struct{}{},
+		errOnCall:    map[int]error{},
+	}
+	node.SetBroker(ctrlBroker)
+	require.NoError(t, node.Run())
+	t.Cleanup(func() { _ = node.Shutdown(context.Background()) })
+
+	require.NoError(t, node.SharedPollPublish(
+		context.Background(), "test:local_only", "key1", 1, "", []byte(`"x"`),
+	))
+	require.EqualValues(t, 0, ctrlBroker.publishCount.Load(),
+		"PublishEnabled=false must route locally — broker.Publish must not be called")
+}
+
+// TestSharedPollTrackKeys_PublishEnabledDrift demonstrates that track*()
+// must use the channel state's frozen opts.PublishEnabled, not the
+// caller-passed opts.PublishEnabled, when deciding whether to subscribe
+// the key at the broker.
+//
+// Scenario: the channel state is created by an earlier track call with
+// PublishEnabled=true (so publish() routes through the broker). A
+// concurrent caller later tracks a different (new) key on the same
+// channel but with PublishEnabled=false in its caller-passed opts. With
+// the bug, that second track does NOT call broker.Subscribe for its
+// new key — because the decision is gated on the caller's opts. The
+// channel state's publish routing still goes through the broker (per
+// s.opts), so cross-node publications to that key arrive at the broker
+// for delivery — but this node is not subscribed for it, so local
+// subscribers miss the notification.
+//
+// Invariant under test: when s.opts.PublishEnabled is true, every new
+// key gets a broker subscription regardless of the caller's opts.
+func TestSharedPollTrackKeys_PublishEnabledDrift(t *testing.T) {
+	t.Parallel()
+
+	node, err := New(Config{
+		LogLevel:   LogLevelTrace,
+		LogHandler: func(entry LogEntry) {},
+		SharedPoll: SharedPollConfig{
+			GetSharedPollChannelOptions: func(channel string) (SharedPollChannelOptions, bool) {
+				return SharedPollChannelOptions{
+					Mode:                 SharedPollModeVersioned,
+					RefreshInterval:      30 * time.Second,
+					RefreshBatchSize:     100,
+					MaxKeysPerConnection: 100,
+					PublishEnabled:       true,
+				}, true
+			},
+		},
+	})
+	require.NoError(t, err)
+	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
+		return SharedPollResult{}, nil
+	})
+	memBroker, err := NewMemoryBroker(node, MemoryBrokerConfig{})
+	require.NoError(t, err)
+	node.SetBroker(memBroker)
+	require.NoError(t, node.Run())
+	t.Cleanup(func() { _ = node.Shutdown(context.Background()) })
+
+	channel := "test:opts_drift"
+
+	// First track: sets up channel state with PublishEnabled=true.
+	optsTrue := SharedPollChannelOptions{
+		Mode:                 SharedPollModeVersioned,
+		RefreshInterval:      30 * time.Second,
+		RefreshBatchSize:     100,
+		MaxKeysPerConnection: 100,
+		PublishEnabled:       true,
+	}
+	_, release1, err := node.sharedPollManager.trackKeys(channel, optsTrue, []string{"key1"})
+	require.NoError(t, err)
+	defer release1()
+
+	// Sanity: s.opts.PublishEnabled is true. key1 is subscribed at broker.
+	keyCh1 := sharedPollKeyChannel(channel, "key1")
+	node.sharedPollManager.brokerSubMu.RLock()
+	_, hasKey1 := node.sharedPollManager.brokerSubChans[keyCh1]
+	node.sharedPollManager.brokerSubMu.RUnlock()
+	require.True(t, hasKey1, "key1 must be broker-subscribed by the first track")
+
+	// Second track for a NEW key, but the caller's opts mistakenly has
+	// PublishEnabled=false. The channel state's s.opts already says true.
+	// Track must follow s.opts, not the caller's opts — otherwise key2's
+	// broker subscription would be skipped and cross-node publications
+	// for key2 would silently miss this node's subscribers.
+	optsFalse := SharedPollChannelOptions{
+		Mode:                 SharedPollModeVersioned,
+		RefreshInterval:      30 * time.Second,
+		RefreshBatchSize:     100,
+		MaxKeysPerConnection: 100,
+		PublishEnabled:       false, // drift
+	}
+	_, release2, err := node.sharedPollManager.trackKeys(channel, optsFalse, []string{"key2"})
+	require.NoError(t, err)
+	defer release2()
+
+	keyCh2 := sharedPollKeyChannel(channel, "key2")
+	node.sharedPollManager.brokerSubMu.RLock()
+	_, hasKey2 := node.sharedPollManager.brokerSubChans[keyCh2]
+	node.sharedPollManager.brokerSubMu.RUnlock()
+	require.True(t, hasKey2,
+		"BUG: key2 was tracked on a channel whose frozen opts have "+
+			"PublishEnabled=true, but the caller-passed opts had "+
+			"PublishEnabled=false. track must use s.opts.PublishEnabled, "+
+			"not the caller's, so cross-node publications via broker reach "+
+			"this node's subscribers for key2.")
+}
+
+// TestSharedPollRevokeKeys_PartialUserFilter_KeepsBrokerSubscribed
+// guards the inverse: when revoke filters by user and other subscribers
+// for the key remain, the key stays in itemIndex AND the broker
+// subscription must stay.
+func TestSharedPollRevokeKeys_PartialUserFilter_KeepsBrokerSubscribed(t *testing.T) {
+	t.Parallel()
+
+	node, err := New(Config{
+		LogLevel:   LogLevelTrace,
+		LogHandler: func(entry LogEntry) {},
+		SharedPoll: SharedPollConfig{
+			GetSharedPollChannelOptions: func(channel string) (SharedPollChannelOptions, bool) {
+				return SharedPollChannelOptions{
+					Mode:                 SharedPollModeVersioned,
+					RefreshInterval:      30 * time.Second,
+					RefreshBatchSize:     100,
+					MaxKeysPerConnection: 100,
+					PublishEnabled:       true,
+				}, true
+			},
+		},
+	})
+	require.NoError(t, err)
+	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
+		items := make([]SharedPollRefreshItem, len(event.Items))
+		for i, it := range event.Items {
+			items[i] = SharedPollRefreshItem{Key: it.Key, Data: []byte(`"data"`), Version: 1}
+		}
+		return SharedPollResult{Items: items}, nil
+	})
+	setupSharedPollHandlers(node)
+	memBroker, err := NewMemoryBroker(node, MemoryBrokerConfig{})
+	require.NoError(t, err)
+	node.SetBroker(memBroker)
+	require.NoError(t, node.Run())
+	t.Cleanup(func() { _ = node.Shutdown(context.Background()) })
+
+	channel := "test:revoke_partial"
+	key := "shared"
+
+	client1 := newTestClientV2(t, node, "user1")
+	connectClientV2(t, client1)
+	subscribeSharedPollClient(t, client1, channel)
+	trackSharedPollClient(t, client1, channel, []*protocol.KeyedItem{{Key: key, Version: 0}})
+
+	client2 := newTestClientV2(t, node, "user2")
+	connectClientV2(t, client2)
+	subscribeSharedPollClient(t, client2, channel)
+	trackSharedPollClient(t, client2, channel, []*protocol.KeyedItem{{Key: key, Version: 0}})
+
+	keyCh := sharedPollKeyChannel(channel, key)
+	node.sharedPollManager.brokerSubMu.RLock()
+	_, before := node.sharedPollManager.brokerSubChans[keyCh]
+	node.sharedPollManager.brokerSubMu.RUnlock()
+	require.True(t, before)
+
+	// Revoke only user1 — user2 still subscribed to the key.
+	node.sharedPollManager.SharedPollRevokeKeys(channel, []string{key}, []string{"user1"}, nil)
+
+	// Broker subscription must stay (user2's needs cross-node publications).
+	require.Never(t, func() bool {
+		node.sharedPollManager.brokerSubMu.RLock()
+		defer node.sharedPollManager.brokerSubMu.RUnlock()
+		_, exists := node.sharedPollManager.brokerSubChans[keyCh]
+		return !exists
+	}, 300*time.Millisecond, 30*time.Millisecond,
+		"broker subscription must persist while at least one subscriber remains for the key")
 }

--- a/client_shared_poll_test.go
+++ b/client_shared_poll_test.go
@@ -3,6 +3,7 @@ package centrifuge
 import (
 	"bytes"
 	"context"
+	"errors"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -4951,5 +4952,373 @@ drain:
 		require.GreaterOrEqual(t, versions[i], versions[i-1],
 			"wire delivery out of order: index %d got v=%d after v=%d (full sequence: %v)",
 			i, versions[i], versions[i-1], versions)
+	}
+}
+
+// TestSharedPoll_NeedsBroadcast_StaleBackendAtBumpedVersion exercises the
+// race between SharedPollPublish (which bumps entry.version locally) and a
+// notified refresh whose backend response is stale relative to that publish.
+//
+// Setup: versioned, !KeepLatestData. A first client populates entry at v=1
+// via cold-key auto-poll. SharedPollPublish then bumps entry.version to 2.
+// A second client tracks the same key with version=0; because the key is
+// already known, it is a "warm" key, and !KeepLatestData routes it through
+// the deferred path that calls markNeedsBroadcast + notify.
+//
+// The notified poll handler returns the STALE backend state (v=1, "v1") —
+// simulating backend replication lag where the publish has not yet been
+// ingested. applyRefreshResponse then enters the "unchanged" branch
+// (e.Version=1 <= entry.version=2) with entry.needsBroadcast=true.
+//
+// Bug: the branch builds the broadcast as `(version: entry.version=2,
+// data: e.Data="v1")` — a fresh version with stale data. The second
+// client's per-connection keyState.version advances to 2; any future
+// broadcast at v=2 is then filtered by `pubVersion <= keyState.version`,
+// so the client is silently pinned to wrong data until a publish at v>=3.
+//
+// Correct behavior: in !KeepLatestData mode the entry has no cached data,
+// so the only valid (version, data) pair we can emit is the backend's
+// (e.Version, e.Data); needsBroadcast must remain set so a subsequent
+// fresh poll re-broadcasts at the bumped version. Asserted below by
+// checking that the second client's keyState.version does NOT advance to
+// the bumped version on the stale poll.
+func TestSharedPoll_NeedsBroadcast_StaleBackendAtBumpedVersion(t *testing.T) {
+	t.Parallel()
+
+	// Poll handler returns whatever pollResult is currently set to. Starts
+	// returning v=1 (the stale value). Tests may swap it later.
+	var pollResult atomic.Value // *SharedPollResult
+	pollResult.Store(&SharedPollResult{
+		Items: []SharedPollRefreshItem{
+			{Key: "key1", Data: []byte("v1"), Version: 1},
+		},
+	})
+
+	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
+		Mode:                 SharedPollModeVersioned,
+		RefreshInterval:      30 * time.Second, // disable timer; we drive via notify
+		RefreshBatchSize:     100,
+		MaxKeysPerConnection: 100,
+		PublishEnabled:       false, // local-only; SharedPollPublish → handlePublishedData
+		// Notification batching intentionally disabled (both fields zero) so
+		// each notify fires the backend handler immediately. With batching
+		// enabled, NotificationBatchMaxDelay defaults to RefreshInterval (30s),
+		// which would stall the test waiting for the batch window.
+		// KeepLatestData intentionally false — exercises the deferred warm-key path.
+	})
+
+	var pollCount atomic.Int32
+	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
+		pollCount.Add(1)
+		return *(pollResult.Load().(*SharedPollResult)), nil
+	})
+	setupSharedPollHandlers(node)
+
+	// First client + cold-key auto-poll establishes entry at v=1.
+	client1 := newTestClientV2(t, node, "user1")
+	connectClientV2(t, client1)
+	subscribeSharedPollClient(t, client1, "test:channel")
+	trackSharedPollClient(t, client1, "test:channel", []*protocol.KeyedItem{
+		{Key: "key1", Version: 0},
+	})
+
+	require.Eventually(t, func() bool {
+		node.sharedPollManager.mu.RLock()
+		s := node.sharedPollManager.channels["test:channel"]
+		node.sharedPollManager.mu.RUnlock()
+		if s == nil {
+			return false
+		}
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		e := s.itemIndex["key1"]
+		return e != nil && e.version == 1
+	}, 2*time.Second, 10*time.Millisecond, "first client's cold-key auto-poll never populated entry at v=1")
+
+	// SharedPollPublish bumps entry.version to 2. PublishEnabled=false means
+	// broker is not consulted — publish() routes directly to
+	// handlePublishedData on this node.
+	require.NoError(t, node.SharedPollPublish(context.Background(), "test:channel", "key1", 2, "", []byte("v2-fresh")))
+
+	require.Eventually(t, func() bool {
+		node.sharedPollManager.mu.RLock()
+		s := node.sharedPollManager.channels["test:channel"]
+		node.sharedPollManager.mu.RUnlock()
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return s.itemIndex["key1"].version == 2
+	}, time.Second, 10*time.Millisecond, "SharedPollPublish did not bump entry.version to 2")
+
+	pollsBeforeClient2 := pollCount.Load()
+
+	// Second client subscribes and tracks the same key at version=0. Because
+	// the key already exists in itemIndex (isNew=false) and the client passes
+	// version=0, this is a warm key. !KeepLatestData → deferredWarmKeys →
+	// markNeedsBroadcast → notified refresh with items[i].Version=0.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	transport := newTestTransport(cancel)
+	transport.setProtocolVersion(ProtocolVersion2)
+	transport.setProtocolType(ProtocolTypeProtobuf)
+	sink := make(chan []byte, 100)
+	transport.sink = sink
+	credCtx := SetCredentials(ctx, &Credentials{UserID: "user2"})
+	client2, err := newClient(credCtx, node, transport)
+	require.NoError(t, err)
+	connectClientV2(t, client2)
+	subscribeSharedPollClient(t, client2, "test:channel")
+	trackSharedPollClient(t, client2, "test:channel", []*protocol.KeyedItem{
+		{Key: "key1", Version: 0},
+	})
+
+	// Wait for the notified poll triggered by markNeedsBroadcast to fire.
+	require.Eventually(t, func() bool {
+		return pollCount.Load() > pollsBeforeClient2
+	}, 2*time.Second, 10*time.Millisecond, "notified poll for warm key never fired (markNeedsBroadcast path not exercised)")
+
+	// Give applyRefreshResponse + broadcast a brief window to land.
+	time.Sleep(50 * time.Millisecond)
+
+	client2.mu.RLock()
+	var got *keyedKeyState
+	if client2.keyed != nil {
+		got = client2.keyed.trackedKeys["test:channel"]["key1"]
+	}
+	client2.mu.RUnlock()
+
+	if got != nil {
+		require.NotEqual(t, uint64(2), got.version,
+			"BUG: client2's keyState.version advanced to the bumped entry.version (2), "+
+				"but the broadcast carried stale backend data v=1 — future legitimate "+
+				"broadcasts at v=2 will be filtered, silently pinning client2 to wrong data")
+	}
+
+	// Stronger wire-level check: scan everything client2 received and verify
+	// no publication arrived with Version=2 in this stale phase. The buggy
+	// code would have enqueued exactly such a publication.
+drain:
+	for {
+		select {
+		case data := <-sink:
+			reply := &protocol.Reply{}
+			if err := reply.UnmarshalVT(data); err != nil {
+				continue
+			}
+			if reply.Push == nil || reply.Push.Pub == nil {
+				continue
+			}
+			pub := reply.Push.Pub
+			if pub.Key != "key1" {
+				continue
+			}
+			require.NotEqual(t, uint64(2), pub.Version,
+				"BUG: stale-backend broadcast delivered a Pub(version=2) to client2 — data is the backend's v=1 bytes, but the version label is the fresh entry.version")
+		case <-time.After(50 * time.Millisecond):
+			break drain
+		}
+	}
+
+	// FIX verification: backend catches up to v=2 with the real bytes. A
+	// fresh notify should now trigger a broadcast that delivers v=2 with
+	// correct data. (With the buggy code, needsBroadcast was already
+	// cleared on the stale response, so this poll would do nothing.)
+	pollResult.Store(&SharedPollResult{
+		Items: []SharedPollRefreshItem{
+			{Key: "key1", Data: []byte("v2-fresh"), Version: 2},
+		},
+	})
+	node.sharedPollManager.notify("test:channel", "key1")
+
+	require.Eventually(t, func() bool {
+		client2.mu.RLock()
+		defer client2.mu.RUnlock()
+		if client2.keyed == nil {
+			return false
+		}
+		ks := client2.keyed.trackedKeys["test:channel"]["key1"]
+		return ks != nil && ks.version == 2
+	}, 2*time.Second, 10*time.Millisecond, "client2 never received v=2 after backend caught up — needsBroadcast was cleared on the stale response, so the fresh poll silently dropped the broadcast")
+}
+
+// controllableSubscribeBroker wraps MemoryBroker and lets a test drive each
+// broker.Subscribe call by hand: call N can be made to block on a chan and/or
+// return a specific error. Used to construct the race in
+// TestSharedPollTrackKeys_RollbackDoesNotOrphanConcurrentTrack.
+type controllableSubscribeBroker struct {
+	*MemoryBroker
+	mu         sync.Mutex
+	callCount  int
+	startedCh  chan int   // signals when call N begins (N is sent on the chan)
+	blockUntil map[int]chan struct{}
+	errOnCall  map[int]error
+}
+
+func (b *controllableSubscribeBroker) Subscribe(channels ...string) error {
+	b.mu.Lock()
+	b.callCount++
+	n := b.callCount
+	block := b.blockUntil[n]
+	err := b.errOnCall[n]
+	startedCh := b.startedCh
+	b.mu.Unlock()
+	if startedCh != nil {
+		select {
+		case startedCh <- n:
+		default:
+		}
+	}
+	if block != nil {
+		<-block
+	}
+	if err != nil {
+		return err
+	}
+	return b.MemoryBroker.Subscribe(channels...)
+}
+
+// TestSharedPollTrackKeys_RollbackDoesNotOrphanConcurrentTrack exercises the
+// race between a failing broker.Subscribe in one trackKeys call and a
+// concurrent trackKeys call for the same key that sees the entry already
+// present.
+//
+// Without the fix, trackKeys creates an itemIndex entry under s.mu, releases
+// s.mu, then calls broker.Subscribe outside the lock. A second goroutine
+// arriving during that window sees the entry, considers itself a no-op
+// (isNewKey=false), and returns success — without ever attempting its own
+// broker.Subscribe. When the first goroutine's broker.Subscribe fails, its
+// rollback deletes the itemIndex entry, leaving the second goroutine's
+// caller with a "tracked" key that has no server-side state and no broker
+// subscription. Future SharedPollPublish on other nodes is silently lost
+// for that caller; future polls won't include the key either.
+//
+// Invariant under test: if trackKeys returned success, the corresponding
+// itemIndex entry MUST still be present after the race resolves.
+func TestSharedPollTrackKeys_RollbackDoesNotOrphanConcurrentTrack(t *testing.T) {
+	t.Parallel()
+
+	node, err := New(Config{
+		LogLevel:   LogLevelTrace,
+		LogHandler: func(entry LogEntry) {},
+		SharedPoll: SharedPollConfig{
+			GetSharedPollChannelOptions: func(channel string) (SharedPollChannelOptions, bool) {
+				return SharedPollChannelOptions{
+					Mode:                 SharedPollModeVersioned,
+					RefreshInterval:      30 * time.Second,
+					RefreshBatchSize:     100,
+					MaxKeysPerConnection: 100,
+					PublishEnabled:       true, // exercise the broker subscribe path
+				}, true
+			},
+		},
+	})
+	require.NoError(t, err)
+	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
+		return SharedPollResult{}, nil
+	})
+
+	memBroker, err := NewMemoryBroker(node, MemoryBrokerConfig{})
+	require.NoError(t, err)
+	ctrlBroker := &controllableSubscribeBroker{
+		MemoryBroker: memBroker,
+		startedCh:    make(chan int, 8),
+		blockUntil:   map[int]chan struct{}{},
+		errOnCall:    map[int]error{},
+	}
+
+	// Call 1 (goroutine A) blocks until we release it, then fails. Subsequent
+	// calls (whichever goroutine arrives) run normally — so a correct fix
+	// that has B retry its own subscribe completes.
+	call1Block := make(chan struct{})
+	ctrlBroker.blockUntil[1] = call1Block
+	ctrlBroker.errOnCall[1] = errors.New("simulated broker subscribe failure")
+
+	node.SetBroker(ctrlBroker)
+	require.NoError(t, node.Run())
+	t.Cleanup(func() { _ = node.Shutdown(context.Background()) })
+
+	opts := SharedPollChannelOptions{
+		Mode:                 SharedPollModeVersioned,
+		RefreshInterval:      30 * time.Second,
+		RefreshBatchSize:     100,
+		MaxKeysPerConnection: 100,
+		PublishEnabled:       true,
+	}
+
+	type res struct {
+		keyResults []trackKeyResult
+		err        error
+	}
+	resA := make(chan res, 1)
+	resB := make(chan res, 1)
+
+	go func() {
+		r, err := node.sharedPollManager.trackKeys("test:channel", opts, []string{"key1"})
+		resA <- res{r, err}
+	}()
+
+	// Wait for A to enter broker.Subscribe call #1.
+	select {
+	case n := <-ctrlBroker.startedCh:
+		require.Equal(t, 1, n, "expected the first broker.Subscribe call to be from A")
+	case <-time.After(2 * time.Second):
+		t.Fatal("A never entered broker.Subscribe")
+	}
+
+	// With the buggy code: A is blocked in broker.Subscribe with s.mu
+	// already released. B enters trackKeys, sees the entry exists, returns
+	// success without calling broker.Subscribe.
+	//
+	// With the fix (hold s.mu across broker.Subscribe): A is blocked in
+	// broker.Subscribe with s.mu still held; B blocks on s.mu instead.
+	go func() {
+		r, err := node.sharedPollManager.trackKeys("test:channel", opts, []string{"key1"})
+		resB <- res{r, err}
+	}()
+
+	// Give B a window to enter trackKeys and (with buggy code) finish.
+	time.Sleep(50 * time.Millisecond)
+
+	// Release A's blocked broker.Subscribe — it will return the simulated
+	// error and trigger the rollback path that deletes the entry.
+	close(call1Block)
+
+	var aResult, bResult res
+	select {
+	case aResult = <-resA:
+	case <-time.After(2 * time.Second):
+		t.Fatal("A's trackKeys never returned")
+	}
+	select {
+	case bResult = <-resB:
+	case <-time.After(2 * time.Second):
+		t.Fatal("B's trackKeys never returned")
+	}
+
+	require.Error(t, aResult.err, "A's trackKeys must surface the broker subscribe failure")
+
+	// Core invariant: if B's trackKeys returned success, the manager must
+	// still be tracking key1 — both in itemIndex (so notify/poll cover it)
+	// and at the broker level (so cross-node publishes reach this node).
+	if bResult.err == nil {
+		node.sharedPollManager.mu.RLock()
+		s := node.sharedPollManager.channels["test:channel"]
+		node.sharedPollManager.mu.RUnlock()
+		require.NotNil(t, s, "channel state must exist when B reported success")
+		s.mu.Lock()
+		entry := s.itemIndex["key1"]
+		s.mu.Unlock()
+		require.NotNil(t, entry,
+			"BUG: B's trackKeys succeeded (no error) but itemIndex no longer has key1 — "+
+				"A's broker-subscribe rollback deleted the entry B was relying on. Future "+
+				"cross-node publishes for key1 will be silently lost for B's caller.")
+
+		// Broker subscription invariant: subscribeToBrokerKeys recorded the key.
+		keyCh := sharedPollKeyChannel("test:channel", "key1")
+		node.sharedPollManager.brokerSubMu.RLock()
+		_, brokerSubbed := node.sharedPollManager.brokerSubChans[keyCh]
+		node.sharedPollManager.brokerSubMu.RUnlock()
+		require.True(t, brokerSubbed,
+			"BUG: B's trackKeys succeeded but no broker subscription exists for key1 — "+
+				"A's failed subscribe + entry rollback left the key unsubscribed at the broker")
 	}
 }

--- a/client_shared_poll_test.go
+++ b/client_shared_poll_test.go
@@ -778,7 +778,7 @@ func TestSharedPollRefresh_PublicationFields(t *testing.T) {
 	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
 		return SharedPollResult{
 			Items: []SharedPollRefreshItem{
-				{Key: "key1", Data: []byte(`test_data`), Version: 42},
+				{Key: "key1", Data: []byte(`"test_data"`), Version: 42},
 			},
 		}, nil
 	})
@@ -821,7 +821,7 @@ func TestSharedPollRefresh_ExplicitRemoval(t *testing.T) {
 		if count == 1 {
 			return SharedPollResult{
 				Items: []SharedPollRefreshItem{
-					{Key: "key1", Data: []byte(`data`), Version: 1},
+					{Key: "key1", Data: []byte(`"data"`), Version: 1},
 				},
 			}, nil
 		}
@@ -869,7 +869,7 @@ func TestSharedPollRevokeKeys_Basic(t *testing.T) {
 		// Return data so items stay alive.
 		items := make([]SharedPollRefreshItem, len(event.Items))
 		for i, it := range event.Items {
-			items[i] = SharedPollRefreshItem{Key: it.Key, Data: []byte(`data`), Version: 1}
+			items[i] = SharedPollRefreshItem{Key: it.Key, Data: []byte(`"data"`), Version: 1}
 		}
 		return SharedPollResult{Items: items}, nil
 	})
@@ -901,7 +901,7 @@ func TestSharedPollRevokeKeys_UserFilter(t *testing.T) {
 	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
 		items := make([]SharedPollRefreshItem, len(event.Items))
 		for i, it := range event.Items {
-			items[i] = SharedPollRefreshItem{Key: it.Key, Data: []byte(`data`), Version: 1}
+			items[i] = SharedPollRefreshItem{Key: it.Key, Data: []byte(`"data"`), Version: 1}
 		}
 		return SharedPollResult{Items: items}, nil
 	})
@@ -953,7 +953,7 @@ func TestSharedPollVersionedMode_VersionsInRequest(t *testing.T) {
 			// First call: return version 5.
 			return SharedPollResult{
 				Items: []SharedPollRefreshItem{
-					{Key: "key1", Data: []byte(`data`), Version: 5},
+					{Key: "key1", Data: []byte(`"data"`), Version: 5},
 				},
 			}, nil
 		}
@@ -964,7 +964,7 @@ func TestSharedPollVersionedMode_VersionsInRequest(t *testing.T) {
 		pollMu.Unlock()
 		return SharedPollResult{
 			Items: []SharedPollRefreshItem{
-				{Key: "key1", Data: []byte(`data`), Version: 5},
+				{Key: "key1", Data: []byte(`"data"`), Version: 5},
 			},
 		}, nil
 	})
@@ -1007,7 +1007,7 @@ func TestSharedPollVersionedMode_AlwaysSendsVersions(t *testing.T) {
 		if count == 1 {
 			return SharedPollResult{
 				Items: []SharedPollRefreshItem{
-					{Key: "key1", Data: []byte(`data`), Version: 5},
+					{Key: "key1", Data: []byte(`"data"`), Version: 5},
 				},
 			}, nil
 		}
@@ -1017,7 +1017,7 @@ func TestSharedPollVersionedMode_AlwaysSendsVersions(t *testing.T) {
 		pollMu.Unlock()
 		return SharedPollResult{
 			Items: []SharedPollRefreshItem{
-				{Key: "key1", Data: []byte(`data`), Version: 5},
+				{Key: "key1", Data: []byte(`"data"`), Version: 5},
 			},
 		}, nil
 	})
@@ -1049,7 +1049,7 @@ func TestSharedPollDisconnect_Cleanup(t *testing.T) {
 	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
 		items := make([]SharedPollRefreshItem, len(event.Items))
 		for i, it := range event.Items {
-			items[i] = SharedPollRefreshItem{Key: it.Key, Data: []byte(`data`), Version: 1}
+			items[i] = SharedPollRefreshItem{Key: it.Key, Data: []byte(`"data"`), Version: 1}
 		}
 		return SharedPollResult{Items: items}, nil
 	})
@@ -1079,7 +1079,7 @@ func TestSharedPollUnsubscribe_Cleanup(t *testing.T) {
 	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
 		items := make([]SharedPollRefreshItem, len(event.Items))
 		for i, it := range event.Items {
-			items[i] = SharedPollRefreshItem{Key: it.Key, Data: []byte(`data`), Version: 1}
+			items[i] = SharedPollRefreshItem{Key: it.Key, Data: []byte(`"data"`), Version: 1}
 		}
 		return SharedPollResult{Items: items}, nil
 	})
@@ -1413,7 +1413,7 @@ func TestSharedPollRefresh_PerConnectionFilter(t *testing.T) {
 	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
 		return SharedPollResult{
 			Items: []SharedPollRefreshItem{
-				{Key: "key1", Data: []byte(`data`), Version: 5},
+				{Key: "key1", Data: []byte(`"data"`), Version: 5},
 			},
 		}, nil
 	})
@@ -1445,7 +1445,7 @@ func TestSharedPollRefresh_PerConnectionDelivery(t *testing.T) {
 	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
 		return SharedPollResult{
 			Items: []SharedPollRefreshItem{
-				{Key: "key1", Data: []byte(`new`), Version: 5},
+				{Key: "key1", Data: []byte(`"new"`), Version: 5},
 			},
 		}, nil
 	})
@@ -1480,7 +1480,7 @@ func TestSharedPollRefresh_TwoClientsOverlap(t *testing.T) {
 		v := version.Add(1)
 		return SharedPollResult{
 			Items: []SharedPollRefreshItem{
-				{Key: "key1", Data: []byte(`data`), Version: v},
+				{Key: "key1", Data: []byte(`"data"`), Version: v},
 			},
 		}, nil
 	})
@@ -1583,7 +1583,7 @@ func TestSharedPollRevokeKeys_ExcludeUsers(t *testing.T) {
 	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
 		items := make([]SharedPollRefreshItem, len(event.Items))
 		for i, it := range event.Items {
-			items[i] = SharedPollRefreshItem{Key: it.Key, Data: []byte(`data`), Version: 1}
+			items[i] = SharedPollRefreshItem{Key: it.Key, Data: []byte(`"data"`), Version: 1}
 		}
 		return SharedPollResult{Items: items}, nil
 	})
@@ -2260,8 +2260,8 @@ gotFirst:
 
 func TestBuildPreparedPollData_NoPrevData(t *testing.T) {
 	t.Parallel()
-	pub := &protocol.Publication{Data: []byte(`test`)}
-	prep := buildPreparedPollData(pub, nil)
+	pub := &protocol.Publication{Data: []byte(`"test"`)}
+	prep := buildPreparedPollData(pub, nil, 0)
 	require.False(t, prep.deltaSub)
 	require.Nil(t, prep.keyedDeltaPatch)
 }
@@ -2272,9 +2272,10 @@ func TestBuildPreparedPollData_WithPrevData(t *testing.T) {
 	prevData := []byte(`{"value":"this is a longer string so delta overhead is worth it","count":1}`)
 	newData := []byte(`{"value":"this is a longer string so delta overhead is worth it","count":2}`)
 	pub := &protocol.Publication{Data: newData}
-	prep := buildPreparedPollData(pub, prevData)
+	prep := buildPreparedPollData(pub, prevData, 5)
 	require.True(t, prep.deltaSub)
 	require.NotNil(t, prep.keyedDeltaPatch)
+	require.Equal(t, uint64(5), prep.keyedDeltaPrevVersion)
 	// The patch should be a real delta (smaller than full).
 	require.True(t, prep.keyedDeltaIsReal)
 	// Verify the patch is applicable.
@@ -2289,7 +2290,7 @@ func TestBuildPreparedPollData_LargePatch(t *testing.T) {
 	prevData := []byte(`a`)
 	newData := []byte(`completely different data here`)
 	pub := &protocol.Publication{Data: newData}
-	prep := buildPreparedPollData(pub, prevData)
+	prep := buildPreparedPollData(pub, prevData, 1)
 	require.True(t, prep.deltaSub)
 	// keyedDeltaIsReal may be false if patch >= full data.
 	if !prep.keyedDeltaIsReal {
@@ -2906,7 +2907,7 @@ func TestSharedPollAutoNotify_ColdKey(t *testing.T) {
 		pollMu.Unlock()
 		return SharedPollResult{
 			Items: []SharedPollRefreshItem{
-				{Key: "cold_key", Data: []byte(`data`), Version: 1},
+				{Key: "cold_key", Data: []byte(`"data"`), Version: 1},
 			},
 		}, nil
 	})
@@ -2946,7 +2947,7 @@ func TestSharedPollAutoNotify_ExistingKeyNoNotify(t *testing.T) {
 		callCount.Add(1)
 		return SharedPollResult{
 			Items: []SharedPollRefreshItem{
-				{Key: "key1", Data: []byte(`data`), Version: 1},
+				{Key: "key1", Data: []byte(`"data"`), Version: 1},
 			},
 		}, nil
 	})
@@ -3008,7 +3009,7 @@ func TestSharedPollAutoNotify_MultipleClientsSameColdKey(t *testing.T) {
 		pollCalled.Add(1)
 		return SharedPollResult{
 			Items: []SharedPollRefreshItem{
-				{Key: "key1", Data: []byte(`data`), Version: 1},
+				{Key: "key1", Data: []byte(`"data"`), Version: 1},
 			},
 		}, nil
 	})
@@ -3078,7 +3079,7 @@ func TestSharedPollAutoNotify_ColdKeyNonZeroVersionNoNotify(t *testing.T) {
 		pollCalled.Add(1)
 		return SharedPollResult{
 			Items: []SharedPollRefreshItem{
-				{Key: "key1", Data: []byte(`data`), Version: 5},
+				{Key: "key1", Data: []byte(`"data"`), Version: 5},
 			},
 		}, nil
 	})
@@ -3115,7 +3116,7 @@ func TestSharedPollAutoNotify_ColdKeyVersionZeroTriggersNotify(t *testing.T) {
 		pollCalled.Add(1)
 		return SharedPollResult{
 			Items: []SharedPollRefreshItem{
-				{Key: "key1", Data: []byte(`data`), Version: 1},
+				{Key: "key1", Data: []byte(`"data"`), Version: 1},
 			},
 		}, nil
 	})
@@ -4624,4 +4625,331 @@ func TestSharedPollUntrack_RandomKeysIgnored(t *testing.T) {
 
 	// untrackHandler must not have fired.
 	require.False(t, untrackFired.Load(), "untrackHandler must not fire for keys that were never tracked")
+}
+
+// TestSharedPollTrack_InlineUntrack_FreesExistingSlots asserts that when a
+// track frame inline-untracks keys that the client ALREADY has tracked from
+// a prior request, the limit check accounts for the slots being freed. A
+// signature-library replay typically re-tracks every known key, so if the
+// user has untracked some keys since the signatures were obtained, those
+// keys appear in both the chanKeys map (from the previous track) AND in
+// req.Untrack — Step 8 of handleTrack removes them, so the final tracked
+// count is (current + new - inline_untracked_existing).
+//
+// Concrete repro: MaxKeysPerConnection=3, chanKeys={A,B} already tracked,
+// then re-track [A,B,C,D,E] with Untrack=[A,B]. Final state is {C,D,E},
+// size 3, fits the limit. A correct limit check must allow this.
+func TestSharedPollTrack_InlineUntrack_FreesExistingSlots(t *testing.T) {
+	t.Parallel()
+	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
+		RefreshInterval:      100 * time.Millisecond,
+		MaxKeysPerConnection: 3,
+	})
+	setupSharedPollHandlers(node)
+	client := newTestClientV2(t, node, "user1")
+	connectClientV2(t, client)
+	subscribeSharedPollClient(t, client, "test:channel")
+
+	// First track: bring chanKeys to {A, B}.
+	trackSharedPollClient(t, client, "test:channel", []*protocol.KeyedItem{
+		{Key: "A"},
+		{Key: "B"},
+	})
+
+	client.mu.RLock()
+	preCount := len(client.keyed.trackedKeys["test:channel"])
+	client.mu.RUnlock()
+	require.Equal(t, 2, preCount)
+
+	// Re-track {A,B,C,D,E} with inline-untrack of A,B. Final state must be
+	// {C,D,E} = 3 keys, which fits MaxKeysPerConnection=3. The buggy limit
+	// check rejects this because it doesn't subtract |existing ∩ inline-untrack|.
+	rwWrapper := testReplyWriterWrapper()
+	err := client.handleSubRefresh(&protocol.SubRefreshRequest{
+		Channel: "test:channel",
+		Type:    typeTrack,
+		Track: []*protocol.TrackBatch{{Items: []*protocol.KeyedItem{
+			{Key: "A"}, {Key: "B"}, {Key: "C"}, {Key: "D"}, {Key: "E"},
+		}}},
+		Untrack: []string{"A", "B"},
+	}, &protocol.Command{Id: 3}, time.Now(), rwWrapper.rw)
+	require.NoError(t, err, "track with inline-untrack of existing keys must not return a top-level error")
+
+	require.Eventually(t, func() bool {
+		return len(rwWrapper.replies) > 0
+	}, time.Second, time.Millisecond)
+	require.Nil(t, rwWrapper.replies[0].Error,
+		"limit check must account for inline-untracked existing keys: got error %v", rwWrapper.replies[0].Error)
+
+	// Final state assertion: {C, D, E}.
+	client.mu.RLock()
+	defer client.mu.RUnlock()
+	chanKeys := client.keyed.trackedKeys["test:channel"]
+	require.Equal(t, 3, len(chanKeys), "final tracked count should be 3, got %d", len(chanKeys))
+	_, hasA := chanKeys["A"]
+	_, hasB := chanKeys["B"]
+	_, hasC := chanKeys["C"]
+	_, hasD := chanKeys["D"]
+	_, hasE := chanKeys["E"]
+	require.False(t, hasA, "A should be untracked")
+	require.False(t, hasB, "B should be untracked")
+	require.True(t, hasC, "C should be tracked")
+	require.True(t, hasD, "D should be tracked")
+	require.True(t, hasE, "E should be tracked")
+}
+
+// TestSharedPollTrack_WarmKey_DeliversLatestSnapshot is a sanity check for
+// the warm-key snapshot ordering fix: handleTrack now captures the warm-key
+// snapshot AFTER hub.addSubscriber so that a publish landing between the
+// snapshot and subscriber registration is delivered via the broadcast path
+// rather than missed.
+//
+// This test cannot deterministically reproduce the lost-update race (it
+// would need a sync hook between Step 5 addSubscriber and Step 5b
+// getWarmKeyData). Instead it asserts the happy path: a warm key with
+// cached data is delivered at the latest version available on the server.
+func TestSharedPollTrack_WarmKey_DeliversLatestSnapshot(t *testing.T) {
+	t.Parallel()
+	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
+		RefreshInterval:      100 * time.Millisecond,
+		RefreshBatchSize:     100,
+		MaxKeysPerConnection: 100,
+		KeepLatestData:       true,
+		Mode:                 SharedPollModeVersioned,
+	})
+
+	currentVersion := atomic.Uint64{}
+	currentVersion.Store(7)
+	node.OnSharedPoll(func(ctx context.Context, event SharedPollEvent) (SharedPollResult, error) {
+		v := currentVersion.Load()
+		return SharedPollResult{
+			Items: []SharedPollRefreshItem{
+				{Key: "key1", Data: []byte(`{"v":7}`), Version: v},
+			},
+		}, nil
+	})
+
+	setupSharedPollHandlers(node)
+
+	// First client tracks the key so the server has the entry registered
+	// and the refresh worker populates entry.data with v=7.
+	client1 := newTestClientV2(t, node, "user1")
+	connectClientV2(t, client1)
+	subscribeSharedPollClient(t, client1, "test:channel")
+	trackSharedPollClient(t, client1, "test:channel", []*protocol.KeyedItem{
+		{Key: "key1", Version: 0},
+	})
+
+	// Wait for client1 to receive v=7 so the server entry is stable.
+	require.Eventually(t, func() bool {
+		client1.mu.RLock()
+		defer client1.mu.RUnlock()
+		ks := client1.keyed.trackedKeys["test:channel"]["key1"]
+		return ks != nil && ks.version == 7
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Now a second client tracks the same key with version 0. The key is
+	// warm on the server (entry.version=7, data cached), so handleTrack
+	// takes the warm-key direct-delivery path. After the fix, the snapshot
+	// is captured after addSubscriber, so client2 must end up at v=7.
+	client2 := newTestClientV2(t, node, "user2")
+	connectClientV2(t, client2)
+	subscribeSharedPollClient(t, client2, "test:channel")
+	trackSharedPollClient(t, client2, "test:channel", []*protocol.KeyedItem{
+		{Key: "key1", Version: 0},
+	})
+
+	require.Eventually(t, func() bool {
+		client2.mu.RLock()
+		defer client2.mu.RUnlock()
+		ks := client2.keyed.trackedKeys["test:channel"]["key1"]
+		return ks != nil && ks.version == 7
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+// TestSharedPollTrack_RaceWithChannelShutdownStress stress-tests the race
+// between sharedPollChannelState's finalizeShutdown (which removes the
+// keyedManager state) and a new client's handleTrack (which calls
+// keyedManager.getOrCreateChannel followed later by getHub).
+//
+// Scenario:
+//   client A tracks → untracks (immediate shutdown removes both
+//   sharedPollManager state and keyedManager state)
+//   client B handleTrack runs concurrently — getOrCreateChannel may create
+//   the keyedManager state just before A's finalizeShutdown calls
+//   removeChannel, leaving B's later getHub returning nil → panic at
+//   addSubscriber.
+//
+// The test runs many iterations and expects no panic / no missed
+// broadcasts. With ChannelShutdownDelay=-1 (immediate), the race window
+// is the small time between sharedPollManager's deleting m.channels[ch]
+// and keyedManager.removeChannel(ch).
+func TestSharedPollTrack_RaceWithChannelShutdownStress(t *testing.T) {
+	t.Parallel()
+	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
+		RefreshInterval:      time.Hour,
+		RefreshBatchSize:     100,
+		MaxKeysPerConnection: 100,
+		ChannelShutdownDelay: -1, // immediate shutdown on last untrack
+	})
+	setupSharedPollHandlers(node)
+
+	const iterations = 200
+	for i := 0; i < iterations; i++ {
+		clientA := newTestClientV2(t, node, "userA")
+		connectClientV2(t, clientA)
+		subscribeSharedPollClient(t, clientA, "test:channel")
+		trackSharedPollClient(t, clientA, "test:channel", []*protocol.KeyedItem{
+			{Key: "k", Version: 0},
+		})
+
+		clientB := newTestClientV2(t, node, "userB")
+		connectClientV2(t, clientB)
+		subscribeSharedPollClient(t, clientB, "test:channel")
+
+		// Race A's untrack (triggers immediate shutdown of keyedManager state)
+		// against B's track (calls getOrCreateChannel then later getHub).
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			untrackSharedPollClient(t, clientA, "test:channel", []string{"k"})
+		}()
+		go func() {
+			defer wg.Done()
+			trackSharedPollClient(t, clientB, "test:channel", []*protocol.KeyedItem{
+				{Key: "k", Version: 0},
+			})
+		}()
+		wg.Wait()
+
+		// After the race, B must be in the keyedHub for k. If
+		// removeChannel deleted B's hub between getOrCreateChannel and
+		// getHub, addSubscriber would have hit a nil hub and we'd never
+		// reach this assertion (panic).
+		hub := node.keyedManager.getHub("test:channel")
+		require.NotNil(t, hub,
+			"iteration %d: keyedManager hub missing for test:channel — A's finalizeShutdown likely removed it after B's getOrCreateChannel",
+			i)
+		require.Equal(t, 1, hub.subscriberCount("k"),
+			"iteration %d: expected B in the hub for k but subscriberCount=%d",
+			i, hub.subscriberCount("k"))
+
+		// Tear down.
+		_ = clientA.close(DisconnectForceNoReconnect)
+		_ = clientB.close(DisconnectForceNoReconnect)
+	}
+}
+
+
+// TestKeyedBroadcast_OrderedDeliveryUnderConcurrentBroadcasts asserts that
+// concurrent broadcasts for the same key to the same client are delivered to
+// the wire in non-decreasing version order — i.e. no inversion where a lower
+// version arrives after a higher one.
+//
+// Bug: keyedWritePublication releases c.mu before encoding, then enters
+// writePublication (which calls into messageWriter.enqueue) without re-
+// acquiring c.mu. Two concurrent broadcasts for the same key can therefore
+// race past the version check, encode in parallel, and enqueue in arbitrary
+// order. If the higher-version broadcast finishes encoding first and
+// enqueues first, the lower-version broadcast still goes into the queue
+// behind it — the client SDK then receives newer-then-older bytes on the
+// wire. Per-connection state ends up correct (the re-check at update time
+// only bumps to the higher version) but the wire order does not.
+//
+// The fix serializes encode→enqueue→state-update for a single client via
+// c.mu (encoding stays outside; the lock wraps re-check + enqueue + bump),
+// guaranteeing that anything that lands in the queue is the freshest version
+// observed under the lock, and any later same-or-older broadcast is filtered
+// out under the same lock.
+func TestKeyedBroadcast_OrderedDeliveryUnderConcurrentBroadcasts(t *testing.T) {
+	t.Parallel()
+	node := newTestNodeWithSharedPoll(t)
+	setupSharedPollHandlers(node)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	transport := newTestTransport(cancel)
+	transport.setProtocolVersion(ProtocolVersion2)
+	transport.setProtocolType(ProtocolTypeProtobuf)
+	sink := make(chan []byte, 4096)
+	transport.sink = sink
+	newCtx := SetCredentials(ctx, &Credentials{UserID: "user1"})
+	client, _ := newClient(newCtx, node, transport)
+	connectClientV2(t, client)
+	subscribeSharedPollClient(t, client, "test:channel")
+	trackSharedPollClient(t, client, "test:channel", []*protocol.KeyedItem{
+		{Key: "K", Version: 0},
+	})
+
+	// Drain any startup frames so we only observe broadcast publications.
+	drainStart := time.Now()
+	for time.Since(drainStart) < 50*time.Millisecond {
+		select {
+		case <-sink:
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	hub := node.keyedManager.getHub("test:channel")
+	require.NotNil(t, hub)
+
+	const numBroadcasts = 200
+	var wg sync.WaitGroup
+	wg.Add(numBroadcasts)
+	startBarrier := make(chan struct{})
+	for i := 1; i <= numBroadcasts; i++ {
+		go func(v uint64) {
+			defer wg.Done()
+			<-startBarrier
+			pub := &protocol.Publication{
+				Key:     "K",
+				Data:    []byte(`{"v":1}`),
+				Version: v,
+			}
+			hub.broadcastToKey("test:channel", "K", v, pub, preparedData{})
+		}(uint64(i))
+	}
+	close(startBarrier)
+	wg.Wait()
+
+	// Drain the sink (with a short idle timeout) and collect publication
+	// versions in arrival order.
+	var versions []uint64
+	idle := time.NewTimer(200 * time.Millisecond)
+	defer idle.Stop()
+drain:
+	for {
+		select {
+		case data := <-sink:
+			reply := &protocol.Reply{}
+			if err := reply.UnmarshalVT(data); err != nil {
+				continue
+			}
+			if reply.Push == nil || reply.Push.Pub == nil {
+				continue
+			}
+			if reply.Push.Pub.Key != "K" {
+				continue
+			}
+			versions = append(versions, reply.Push.Pub.Version)
+			if !idle.Stop() {
+				select {
+				case <-idle.C:
+				default:
+				}
+			}
+			idle.Reset(200 * time.Millisecond)
+		case <-idle.C:
+			break drain
+		}
+	}
+
+	require.NotEmpty(t, versions, "expected at least one publication delivered to the wire")
+
+	for i := 1; i < len(versions); i++ {
+		require.GreaterOrEqual(t, versions[i], versions[i-1],
+			"wire delivery out of order: index %d got v=%d after v=%d (full sequence: %v)",
+			i, versions[i], versions[i-1], versions)
+	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -5092,3 +5092,255 @@ func TestClientOnMapPublishOnMapRemoveOnUntrackSetters(t *testing.T) {
 	client.OnUntrack(func(UntrackEvent) {})
 	require.NotNil(t, client.eventHub.untrackHandler)
 }
+
+// slowJoinBroker delays Broker.PublishJoin while passing PublishLeave
+// through unmodified — used to deterministically expose join-vs-leave
+// wire-order races.
+type slowJoinBroker struct {
+	*MemoryBroker
+	joinDelay time.Duration
+}
+
+func (b *slowJoinBroker) PublishJoin(ch string, info *ClientInfo) error {
+	time.Sleep(b.joinDelay)
+	return b.MemoryBroker.PublishJoin(ch, info)
+}
+
+// TestSubscribe_JoinLeaveWireOrderOnQuickDisconnect asserts that an observer
+// client sees join-then-leave (not the reverse) when a subscribing client
+// disconnects immediately after a successful subscribe.
+//
+// Bug: the regular subscribe path fires publishJoinAndPresence in a goroutine
+// (client.go around line 1933), while the synchronous unsubscribe-on-close
+// path calls publishLeave directly. The two race in the broker. If
+// PublishJoin is even slightly slow (network broker, busy host), the
+// synchronous Leave reaches the wire ahead of Join — observers see
+// [leave, join], which corrupts any member-state tracking that derives
+// from join/leave events. The same architectural issue exists in
+// setupMapPresenceAndJoin (used by map subscribe AND shared poll
+// subscribe), so map subscribers are exposed to the same wire-order bug.
+//
+// The test uses a custom broker that delays PublishJoin by 30ms while
+// leaving PublishLeave untouched — turning the race into a deterministic
+// failure on master.
+func TestSubscribe_JoinLeaveWireOrderOnQuickDisconnect(t *testing.T) {
+	t.Parallel()
+
+	node, err := New(Config{
+		LogLevel:   LogLevelError,
+		LogHandler: func(entry LogEntry) {},
+	})
+	require.NoError(t, err)
+
+	memBroker, err := NewMemoryBroker(node, MemoryBrokerConfig{})
+	require.NoError(t, err)
+	node.SetBroker(&slowJoinBroker{
+		MemoryBroker: memBroker,
+		joinDelay:    30 * time.Millisecond,
+	})
+	require.NoError(t, node.Run())
+	t.Cleanup(func() { _ = node.Shutdown(context.Background()) })
+
+	node.OnConnecting(func(ctx context.Context, e ConnectEvent) (ConnectReply, error) {
+		return ConnectReply{}, nil
+	})
+	node.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
+			cb(SubscribeReply{
+				Options: SubscribeOptions{
+					EmitJoinLeave: true,
+					PushJoinLeave: true,
+				},
+			}, nil)
+		})
+	})
+
+	// Observer B — receives join/leave for A.
+	ctxB, cancelB := context.WithCancel(context.Background())
+	defer cancelB()
+	transportB := newTestTransport(cancelB)
+	transportB.setProtocolVersion(ProtocolVersion2)
+	transportB.setProtocolType(ProtocolTypeProtobuf)
+	sinkB := make(chan []byte, 64)
+	transportB.sink = sinkB
+	ctxBWithCreds := SetCredentials(ctxB, &Credentials{UserID: "observer"})
+	clientB, err := newClient(ctxBWithCreds, node, transportB)
+	require.NoError(t, err)
+	connectClientV2(t, clientB)
+	subscribeClientV2(t, clientB, "shared:channel")
+
+	// Drain B's startup frames.
+	drainDeadline := time.Now().Add(50 * time.Millisecond)
+	for time.Now().Before(drainDeadline) {
+		select {
+		case <-sinkB:
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// Subscriber A — joins then disconnects immediately.
+	ctxA, cancelA := context.WithCancel(context.Background())
+	defer cancelA()
+	transportA := newTestTransport(cancelA)
+	transportA.setProtocolVersion(ProtocolVersion2)
+	transportA.setProtocolType(ProtocolTypeProtobuf)
+	ctxAWithCreds := SetCredentials(ctxA, &Credentials{UserID: "joiner"})
+	clientA, err := newClient(ctxAWithCreds, node, transportA)
+	require.NoError(t, err)
+	connectClientV2(t, clientA)
+	subscribeClientV2(t, clientA, "shared:channel")
+
+	// Disconnect A immediately. The async publishJoin goroutine spawned in
+	// subscribe is delayed by the slow broker, but the synchronous
+	// publishLeave in close → unsubscribe runs at full speed — so on the
+	// buggy code path Leave reaches B before Join.
+	_ = clientA.close(DisconnectForceNoReconnect)
+
+	// Collect frames from B until both Join and Leave for A have arrived.
+	var sawJoinAt, sawLeaveAt int
+	idx := 0
+	deadline := time.After(2 * time.Second)
+	for sawJoinAt == 0 || sawLeaveAt == 0 {
+		select {
+		case data := <-sinkB:
+			reply := &protocol.Reply{}
+			if err := reply.UnmarshalVT(data); err != nil {
+				continue
+			}
+			if reply.Push == nil {
+				continue
+			}
+			idx++
+			if reply.Push.Join != nil && reply.Push.Join.Info != nil && reply.Push.Join.Info.User == "joiner" {
+				if sawJoinAt == 0 {
+					sawJoinAt = idx
+				}
+			}
+			if reply.Push.Leave != nil && reply.Push.Leave.Info != nil && reply.Push.Leave.Info.User == "joiner" {
+				if sawLeaveAt == 0 {
+					sawLeaveAt = idx
+				}
+			}
+		case <-deadline:
+			t.Fatalf("timeout waiting for join/leave (sawJoinAt=%d sawLeaveAt=%d)", sawJoinAt, sawLeaveAt)
+		}
+	}
+
+	require.Less(t, sawJoinAt, sawLeaveAt,
+		"wire order violation: observer saw Leave (idx=%d) before Join (idx=%d) for the same client — "+
+			"publishJoinAndPresence runs in a goroutine while publishLeave on disconnect "+
+			"runs synchronously, so a slow PublishJoin lets Leave reach the wire first.",
+		sawLeaveAt, sawJoinAt)
+}
+
+// TestSubscribe_ReplyPrecedesSelfJoinOnJoinerWire is a sanity check for the
+// synchronous-publishJoin fix: the joining client's subscribe reply must
+// reach the wire BEFORE the self-join push.
+//
+// With the fix, publishJoinAndPresence runs synchronously in the subscribe
+// callback's goroutine AFTER subscribeCmd has enqueued the reply. The two
+// enqueues hit the same per-client messageWriter FIFO queue in that order,
+// so the writer goroutine drains them in that order. This test asserts
+// that contract holds even when PublishJoin is slow (here: a 30ms delay
+// in the broker, exercising the worst case where the sync call actually
+// blocks the cb goroutine for a noticeable amount of time).
+//
+// A regression — for example reintroducing `go` on the publishJoin call,
+// or moving the publishJoin call to BEFORE the reply is enqueued — would
+// invert this on at least some runs.
+func TestSubscribe_ReplyPrecedesSelfJoinOnJoinerWire(t *testing.T) {
+	t.Parallel()
+
+	node, err := New(Config{
+		LogLevel:   LogLevelError,
+		LogHandler: func(entry LogEntry) {},
+	})
+	require.NoError(t, err)
+
+	memBroker, err := NewMemoryBroker(node, MemoryBrokerConfig{})
+	require.NoError(t, err)
+	node.SetBroker(&slowJoinBroker{
+		MemoryBroker: memBroker,
+		joinDelay:    30 * time.Millisecond,
+	})
+	require.NoError(t, node.Run())
+	t.Cleanup(func() { _ = node.Shutdown(context.Background()) })
+
+	node.OnConnecting(func(ctx context.Context, e ConnectEvent) (ConnectReply, error) {
+		return ConnectReply{}, nil
+	})
+	node.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
+			cb(SubscribeReply{
+				Options: SubscribeOptions{
+					EmitJoinLeave: true,
+					PushJoinLeave: true, // The joiner itself also receives the join push.
+				},
+			}, nil)
+		})
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	transport := newTestTransport(cancel)
+	transport.setProtocolVersion(ProtocolVersion2)
+	transport.setProtocolType(ProtocolTypeProtobuf)
+	sink := make(chan []byte, 64)
+	transport.sink = sink
+	ctxWithCreds := SetCredentials(ctx, &Credentials{UserID: "joiner"})
+	client, err := newClient(ctxWithCreds, node, transport)
+	require.NoError(t, err)
+	connectClientV2(t, client)
+
+	// Drain connect-time frames so the test only observes subscribe-related ones.
+	drainDeadline := time.Now().Add(50 * time.Millisecond)
+	for time.Now().Before(drainDeadline) {
+		select {
+		case <-sink:
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	subCmdID := uint32(42)
+	rwWrapper := testReplyWriterWrapper()
+	err = client.handleSubscribe(&protocol.SubscribeRequest{
+		Channel: "ch",
+	}, &protocol.Command{Id: subCmdID}, time.Now(), rwWrapper.rw)
+	require.NoError(t, err)
+
+	// Read frames from the joiner's wire until both the subscribe reply
+	// (matching cmd.Id) and the self-join push have been observed.
+	var sawReplyAt, sawSelfJoinAt int
+	idx := 0
+	deadline := time.After(2 * time.Second)
+	for sawReplyAt == 0 || sawSelfJoinAt == 0 {
+		select {
+		case data := <-sink:
+			reply := &protocol.Reply{}
+			if err := reply.UnmarshalVT(data); err != nil {
+				continue
+			}
+			idx++
+			// Subscribe command reply: Id matches the command's Id and is
+			// not a Push frame. (The subscribe success reply has no Error
+			// and carries the subscribe result.)
+			if reply.Push == nil && reply.Id == subCmdID && sawReplyAt == 0 {
+				sawReplyAt = idx
+			}
+			if reply.Push != nil && reply.Push.Join != nil &&
+				reply.Push.Join.Info != nil &&
+				reply.Push.Join.Info.User == "joiner" &&
+				sawSelfJoinAt == 0 {
+				sawSelfJoinAt = idx
+			}
+		case <-deadline:
+			t.Fatalf("timeout waiting for reply/self-join (sawReplyAt=%d sawSelfJoinAt=%d)", sawReplyAt, sawSelfJoinAt)
+		}
+	}
+
+	require.Less(t, sawReplyAt, sawSelfJoinAt,
+		"wire order violation: joiner saw self-Join push (idx=%d) before its own subscribe reply (idx=%d). "+
+			"The synchronous publishJoinAndPresence must run AFTER subscribeCmd has enqueued the reply, "+
+			"so FIFO ordering of the messageWriter queue keeps reply-then-join on the wire.",
+		sawSelfJoinAt, sawReplyAt)
+}

--- a/hub.go
+++ b/hub.go
@@ -716,8 +716,9 @@ type preparedData struct {
 	wasFiltered     bool
 	filteredPub     *protocol.Publication
 	// For keyed channel lazy delta encoding (set by buildPreparedPollData).
-	keyedDeltaPatch  []byte // raw fossil delta data (patch or full data if patch >= full)
-	keyedDeltaIsReal bool   // true when the patch is a real delta (smaller than full)
+	keyedDeltaPatch       []byte // raw fossil delta data (patch or full data if patch >= full)
+	keyedDeltaIsReal      bool   // true when the patch is a real delta (smaller than full)
+	keyedDeltaPrevVersion uint64 // version corresponding to the delta's base data (entry.version BEFORE the publish)
 }
 
 func getDeltaPub(prevPub *Publication, fullPub *protocol.Publication, key preparedKey) *protocol.Publication {

--- a/internal/recovery/helpers.go
+++ b/internal/recovery/helpers.go
@@ -42,31 +42,29 @@ func MergePublications(recoveredPubs []*protocol.Publication, bufferedPubs []*pr
 		return recoveredPubs[i].Offset < recoveredPubs[j].Offset
 	})
 	if len(bufferedPubs) > 0 {
-		var (
-			skippedOffsets []uint64
-		)
+		var skippedOffsets []uint64
+		recoveredPubs, maxSeenOffset, skippedOffsets = uniqueNonFilteredPublications(recoveredPubs)
 		if len(recoveredPubs) > 1 {
-			recoveredPubs, maxSeenOffset, skippedOffsets = uniqueNonFilteredPublications(recoveredPubs)
-		}
-		prevOffset := recoveredPubs[0].Offset
-		for _, p := range recoveredPubs[1:] {
-			pubOffset := p.Offset
-			expectedOffset := prevOffset + 1
-			isWrongOffset := pubOffset != expectedOffset
-			if isWrongOffset {
-				if len(skippedOffsets) == 0 {
-					return nil, 0, false
-				}
-				// All offsets from expectedOffset till pubOffset-1 must be in skippedOffsets.
-				// Otherwise, we have a gap in recovered publications.
-				for o := expectedOffset; o < pubOffset; o++ {
-					if !slices.Contains(skippedOffsets, o) {
+			prevOffset := recoveredPubs[0].Offset
+			for _, p := range recoveredPubs[1:] {
+				pubOffset := p.Offset
+				expectedOffset := prevOffset + 1
+				isWrongOffset := pubOffset != expectedOffset
+				if isWrongOffset {
+					if len(skippedOffsets) == 0 {
 						return nil, 0, false
 					}
+					// All offsets from expectedOffset till pubOffset-1 must be in skippedOffsets.
+					// Otherwise, we have a gap in recovered publications.
+					for o := expectedOffset; o < pubOffset; o++ {
+						if !slices.Contains(skippedOffsets, o) {
+							return nil, 0, false
+						}
+					}
+					// All offsets are present in skippedOffsets, can continue.
 				}
-				// All offsets are present in skippedOffsets, can continue.
+				prevOffset = pubOffset
 			}
-			prevOffset = pubOffset
 		}
 	}
 	return recoveredPubs, maxSeenOffset, true

--- a/internal/recovery/helpers_test.go
+++ b/internal/recovery/helpers_test.go
@@ -46,3 +46,44 @@ func TestMergePublicationsBuffered(t *testing.T) {
 	require.Len(t, pubs, 3)
 	require.Equal(t, uint64(3), maxSeenOffset)
 }
+
+// TestMergePublications_AllBufferedFiltered_NoBrokerPubs asserts that
+// MergePublications does not panic when there are 2+ buffered pubs all marked
+// filtered (Time = -1) and broker history is empty.
+//
+// Bug: after `uniqueNonFilteredPublications` strips all Time=-1 entries, the
+// internal slice is empty, but the next line dereferences `recoveredPubs[0]`
+// without a length guard — index out of range panic. Reachable when a
+// recovery+tagsFilter subscription's buffered window only saw filtered pubs.
+func TestMergePublications_AllBufferedFiltered_NoBrokerPubs(t *testing.T) {
+	bufferedPubs := []*protocol.Publication{
+		{Offset: 5, Time: -1},
+		{Offset: 6, Time: -1},
+	}
+	pubs, maxSeenOffset, ok := MergePublications(nil, bufferedPubs)
+	require.True(t, ok,
+		"merge must succeed when no real pubs survive filtering; got ok=false (a downstream check would re-subscribe the client even though continuity is intact)")
+	require.Empty(t, pubs)
+	require.Equal(t, uint64(6), maxSeenOffset,
+		"maxSeenOffset should reflect the highest offset across all merged inputs (including filtered) so the caller can advance position past skipped offsets")
+}
+
+// TestMergePublications_AllBufferedFiltered_WithBrokerPubs asserts the same
+// safety property when broker has a recovered pub plus several filtered
+// buffered pubs. After dedup, the broker pub remains; the filtered ones go to
+// skippedOffsets. The result should not panic, ok must be true, and
+// maxSeenOffset must reflect the largest offset including filtered.
+func TestMergePublications_AllBufferedFiltered_WithBrokerPubs(t *testing.T) {
+	recoveredPubs := []*protocol.Publication{
+		{Offset: 5},
+	}
+	bufferedPubs := []*protocol.Publication{
+		{Offset: 6, Time: -1},
+		{Offset: 7, Time: -1},
+	}
+	pubs, maxSeenOffset, ok := MergePublications(recoveredPubs, bufferedPubs)
+	require.True(t, ok)
+	require.Len(t, pubs, 1)
+	require.Equal(t, uint64(5), pubs[0].Offset)
+	require.Equal(t, uint64(7), maxSeenOffset)
+}

--- a/keyed.go
+++ b/keyed.go
@@ -59,6 +59,46 @@ func (m *keyedManager) removeChannel(channel string) {
 	m.mu.Unlock()
 }
 
+// addSubscribers ensures a keyedChannelState exists for the channel and
+// atomically adds the given client as a subscriber to each key. The
+// "create state + add subscriber" sequence runs under m.mu so a concurrent
+// removeChannelIfEmpty cannot delete the state between creation and the
+// first addSubscriber — that race would otherwise leave the client in an
+// orphaned hub that future broadcasts (via getHub) no longer reach.
+func (m *keyedManager) addSubscribers(channel string, keys []string, c *Client, opts keyedChannelOptions) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s, ok := m.channels[channel]
+	if !ok {
+		s = &keyedChannelState{
+			hub:  newKeyedHub(),
+			opts: opts,
+		}
+		m.channels[channel] = s
+	}
+	for _, key := range keys {
+		s.hub.addSubscriber(key, c)
+	}
+}
+
+// removeChannelIfEmpty deletes the channel from the manager only when its
+// hub has no subscribers. Used by sharedPollChannelState.finalizeShutdown
+// instead of the unconditional removeChannel, so a new client whose track
+// has just added itself to the hub via addSubscribers is not orphaned by
+// an in-flight shutdown from an older sharedPollChannelState.
+func (m *keyedManager) removeChannelIfEmpty(channel string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s, ok := m.channels[channel]
+	if !ok {
+		return
+	}
+	if s.hub.numKeys() > 0 {
+		return
+	}
+	delete(m.channels, channel)
+}
+
 const defaultMaxTrackedPerConnection = 5000
 
 func (m *keyedManager) maxTrackedPerConnection(channel string) int {

--- a/map_broker_memory.go
+++ b/map_broker_memory.go
@@ -984,15 +984,44 @@ func (h *mapHub) remove(ch string, key string, chOpts MapChannelOptions, opts Ma
 
 	channel, ok := h.channels[ch]
 	if !ok {
-		// Channel doesn't exist — no position to report. All implementations
-		// (Redis, Postgres) return empty position here since no meta exists.
+		// Channel doesn't exist. When CAS is requested, the caller's
+		// ExpectedPosition cannot match (no meta yet) — mirror the Redis
+		// Lua which auto-creates meta with a fresh epoch and then returns
+		// position_mismatch against the caller's stale epoch. Without
+		// ExpectedPosition, surface KeyNotFound as before.
+		if opts.ExpectedPosition != nil {
+			return StreamPosition{}, nil, SuppressReasonPositionMismatch, nil
+		}
 		return StreamPosition{}, nil, SuppressReasonKeyNotFound, nil
 	}
 
 	var removeTags map[string]string
 	entry, keyExists := channel.state[key]
+
+	// CAS check runs BEFORE the missing-key short-circuit so we mirror the
+	// Redis broker's Lua behavior (map_broker_add.lua: is_leave=1 with
+	// expected_offset set and the key missing returns "position_mismatch").
+	// Optimistic-concurrency clients use SuppressReasonPositionMismatch as
+	// the signal to refetch state and retry; returning KeyNotFound here
+	// would break that flow across brokers.
+	if opts.ExpectedPosition != nil {
+		var pos StreamPosition
+		if channel.stream != nil {
+			pos = StreamPosition{Offset: channel.stream.Top(), Epoch: channel.stream.Epoch()}
+		}
+		if !keyExists {
+			return pos, nil, SuppressReasonPositionMismatch, nil
+		}
+		if entry.Publication.Offset != opts.ExpectedPosition.Offset ||
+			pos.Epoch != opts.ExpectedPosition.Epoch {
+			return pos, entry.Publication, SuppressReasonPositionMismatch, nil
+		}
+	}
+
 	if !keyExists {
-		// Key doesn't exist, nothing to remove
+		// Key doesn't exist, nothing to remove. No CAS was requested, so
+		// surface KeyNotFound — same as Redis's path when expected_offset
+		// is unset and the key is missing.
 		var streamPosition StreamPosition
 		if channel.stream != nil {
 			streamPosition = StreamPosition{
@@ -1001,18 +1030,6 @@ func (h *mapHub) remove(ch string, key string, chOpts MapChannelOptions, opts Ma
 			}
 		}
 		return streamPosition, nil, SuppressReasonKeyNotFound, nil
-	}
-
-	// CAS check: verify expected position (offset + epoch) before removal
-	if opts.ExpectedPosition != nil {
-		var pos StreamPosition
-		if channel.stream != nil {
-			pos = StreamPosition{Offset: channel.stream.Top(), Epoch: channel.stream.Epoch()}
-		}
-		if entry.Publication.Offset != opts.ExpectedPosition.Offset ||
-			pos.Epoch != opts.ExpectedPosition.Epoch {
-			return pos, entry.Publication, SuppressReasonPositionMismatch, nil
-		}
 	}
 
 	// Capture tags before deletion for the removal publication.

--- a/map_broker_memory_test.go
+++ b/map_broker_memory_test.go
@@ -2864,6 +2864,92 @@ func TestMemoryMapBroker_CAS_Publish(t *testing.T) {
 	require.Equal(t, []byte("v2"), stateRes.Publications[0].Data)
 }
 
+// TestMemoryMapBroker_CAS_RemoveMissingKey verifies the documented contract
+// from MapRemoveOptions.ExpectedPosition: when CAS is requested and the key
+// does not exist, the suppress reason must be PositionMismatch — matching
+// the behavior of the Redis broker (map_broker_add.lua line 280 returns
+// "position_mismatch" for is_leave=1 with expected_offset set and the key
+// missing).
+//
+// Bug: the memory broker checks key existence BEFORE the CAS branch and
+// short-circuits to KeyNotFound regardless of ExpectedPosition. That makes
+// the SuppressReason differ between Redis and Memory for the same client
+// request, breaking any SDK code that branches on PositionMismatch to
+// trigger optimistic-concurrency retry (which is exactly what
+// ExpectedPosition is for).
+func TestMemoryMapBroker_CAS_RemoveMissingKey(t *testing.T) {
+	t.Parallel()
+	node, _ := New(Config{})
+	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
+		return MapChannelOptions{
+			Mode:       MapModeRecoverable,
+			StreamSize: 100,
+			StreamTTL:  300 * time.Second,
+			KeyTTL:     300 * time.Second,
+		}
+	}
+	broker := newTestMemoryMapBroker(t, node)
+	ctx := context.Background()
+	ch := "test_cas_remove_missing"
+
+	// Establish a channel + epoch by publishing then removing a different key,
+	// so the channel state exists with a known epoch when we attempt CAS-remove
+	// of the missing key.
+	res1, err := broker.Publish(ctx, ch, "other", MapPublishOptions{Data: []byte("v1")})
+	require.NoError(t, err)
+	epoch := res1.Position.Epoch
+
+	// CAS remove on a non-existent key — caller supplies an offset they
+	// believed was current. The contract says this should report
+	// PositionMismatch (mirroring "key gone since I observed it"), not
+	// KeyNotFound.
+	res, err := broker.Remove(ctx, ch, "never_existed", MapRemoveOptions{
+		ExpectedPosition: &StreamPosition{Offset: 1, Epoch: epoch},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Suppressed)
+	require.Equal(t, SuppressReasonPositionMismatch, res.SuppressReason,
+		"Remove with ExpectedPosition on a missing key must return PositionMismatch "+
+			"(matching the Redis broker's Lua behavior), not KeyNotFound — otherwise "+
+			"applications doing optimistic-concurrency retry behave differently across brokers.")
+}
+
+// TestMemoryMapBroker_CAS_RemoveMissingChannel asserts that CAS-Remove
+// on a never-published channel returns PositionMismatch, matching the
+// Redis broker. Redis Lua (map_broker_add.lua) auto-creates the meta_key
+// with a fresh epoch on first touch, then the CAS-epoch comparison
+// against the caller's stale epoch fails — yielding position_mismatch.
+// The memory broker's remove path used to short-circuit to KeyNotFound
+// when the channel didn't exist, never inspecting ExpectedPosition.
+func TestMemoryMapBroker_CAS_RemoveMissingChannel(t *testing.T) {
+	t.Parallel()
+	node, _ := New(Config{})
+	node.config.Map.GetMapChannelOptions = func(channel string) MapChannelOptions {
+		return MapChannelOptions{
+			Mode:       MapModeRecoverable,
+			StreamSize: 100,
+			StreamTTL:  300 * time.Second,
+			KeyTTL:     300 * time.Second,
+		}
+	}
+	broker := newTestMemoryMapBroker(t, node)
+	ctx := context.Background()
+
+	// CAS-remove on a channel that has never been created. ExpectedPosition
+	// carries a fabricated offset/epoch — both fail. Contract is
+	// PositionMismatch (signal to the client to refetch + retry), not
+	// KeyNotFound.
+	res, err := broker.Remove(ctx, "test_cas_remove_missing_chan", "k", MapRemoveOptions{
+		ExpectedPosition: &StreamPosition{Offset: 5, Epoch: "stale-epoch"},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Suppressed)
+	require.Equal(t, SuppressReasonPositionMismatch, res.SuppressReason,
+		"Remove with ExpectedPosition on a missing channel must return PositionMismatch "+
+			"(Redis Lua auto-creates the meta and reports position_mismatch on the epoch diff). "+
+			"Returning KeyNotFound here makes CAS-retry logic behave differently per broker.")
+}
+
 // TestMemoryMapBroker_CAS_Remove tests Compare-And-Swap semantics for Remove.
 func TestMemoryMapBroker_CAS_Remove(t *testing.T) {
 	t.Parallel()

--- a/shared_poll.go
+++ b/shared_poll.go
@@ -904,6 +904,7 @@ func (m *SharedPollManager) handlePublishedData(channel string, key string, vers
 		m.node.metrics.getSharedPollPublishCached(channel).skipped.Inc()
 		return
 	}
+	prevVersion := entry.version
 	entry.version = version
 	entry.freshFromPublish = true
 	var prevData []byte
@@ -916,7 +917,7 @@ func (m *SharedPollManager) handlePublishedData(channel string, key string, vers
 	m.node.metrics.getSharedPollPublishCached(channel).applied.Inc()
 
 	pub := &protocol.Publication{Key: key, Data: data, Version: version, Epoch: epoch}
-	prep := buildPreparedPollData(pub, prevData)
+	prep := buildPreparedPollData(pub, prevData, prevVersion)
 	hub.broadcastToKey(channel, key, version, pub, prep)
 }
 
@@ -1022,12 +1023,19 @@ func (s *sharedPollChannelState) doShutdownLocked(m *SharedPollManager, channel 
 // keys. Must be called with s.mu released (acquires m.mu and may call back into
 // keyedManager / dissolver). Safe to call when m.channels[channel] no longer
 // points to s — that branch is a no-op.
+//
+// The keyedManager call is removeChannelIfEmpty (not removeChannel) to avoid
+// a race: a new client whose handleTrack ran concurrently with our shutdown
+// may have already added itself as a subscriber via
+// keyedManager.addSubscribers, populating the channel's hub. An
+// unconditional removeChannel would delete that state and orphan the new
+// subscriber from future broadcasts (which look up via getHub).
 func (s *sharedPollChannelState) finalizeShutdown(m *SharedPollManager, channel string) {
 	m.mu.Lock()
 	if m.channels[channel] == s {
 		delete(m.channels, channel)
 		m.mu.Unlock()
-		m.node.keyedManager.removeChannel(channel)
+		m.node.keyedManager.removeChannelIfEmpty(channel)
 	} else {
 		m.mu.Unlock()
 	}
@@ -1403,9 +1411,14 @@ type pendingBroadcast struct {
 
 // buildPreparedPollData computes delta data for a shared poll publication.
 // If prevData is available, computes a fossil delta patch; otherwise returns
-// an empty preparedData (no delta). The actual per-client encoding (JSON escaping,
-// protocol framing) is done lazily in keyedWritePublication.
-func buildPreparedPollData(pub *protocol.Publication, prevData []byte) preparedData {
+// an empty preparedData (no delta). prevVersion is the version of the bytes
+// in prevData (entry.version BEFORE this publish); keyedWritePublication
+// uses it to verify the delta's base matches the client's current data,
+// falling back to FULL when concurrent broadcasts mean the client never
+// received the version this patch is built against. The actual per-client
+// encoding (JSON escaping, protocol framing) is done lazily in
+// keyedWritePublication.
+func buildPreparedPollData(pub *protocol.Publication, prevData []byte, prevVersion uint64) preparedData {
 	if len(prevData) == 0 {
 		return preparedData{}
 	}
@@ -1416,9 +1429,10 @@ func buildPreparedPollData(pub *protocol.Publication, prevData []byte) preparedD
 		deltaData = pub.Data
 	}
 	return preparedData{
-		deltaSub:         true,
-		keyedDeltaPatch:  deltaData,
-		keyedDeltaIsReal: isReal,
+		deltaSub:              true,
+		keyedDeltaPatch:       deltaData,
+		keyedDeltaIsReal:      isReal,
+		keyedDeltaPrevVersion: prevVersion,
 	}
 }
 
@@ -1453,10 +1467,11 @@ func (s *sharedPollChannelState) applyRefreshResponse(channel string, respEpoch 
 	}
 
 	type pendingUpdate struct {
-		key      string
-		version  uint64
-		data     []byte
-		prevData []byte
+		key         string
+		version     uint64
+		data        []byte
+		prevData    []byte
+		prevVersion uint64
 	}
 
 	updates := make([]pendingUpdate, 0, len(items))
@@ -1510,6 +1525,7 @@ func (s *sharedPollChannelState) applyRefreshResponse(channel string, respEpoch 
 			changedCount++
 			s.versionCounter++
 			syntheticVersion := s.versionCounter
+			prevVersion := entry.version
 			var prevData []byte
 			if s.opts.KeepLatestData {
 				prevData = entry.data
@@ -1517,7 +1533,7 @@ func (s *sharedPollChannelState) applyRefreshResponse(channel string, respEpoch 
 			}
 			entry.version = syntheticVersion
 			updates = append(updates, pendingUpdate{
-				key: e.Key, version: syntheticVersion, data: e.Data, prevData: prevData,
+				key: e.Key, version: syntheticVersion, data: e.Data, prevData: prevData, prevVersion: prevVersion,
 			})
 			continue
 		}
@@ -1535,6 +1551,7 @@ func (s *sharedPollChannelState) applyRefreshResponse(channel string, respEpoch 
 
 		entry.needsBroadcast = false
 		changedCount++
+		prevVersion := entry.version
 		// Capture prevData before updating — this is the delta base.
 		var prevData []byte
 		if s.opts.KeepLatestData {
@@ -1547,7 +1564,7 @@ func (s *sharedPollChannelState) applyRefreshResponse(channel string, respEpoch 
 		entry.version = e.Version
 
 		updates = append(updates, pendingUpdate{
-			key: e.Key, version: e.Version, data: e.Data, prevData: prevData,
+			key: e.Key, version: e.Version, data: e.Data, prevData: prevData, prevVersion: prevVersion,
 		})
 	}
 
@@ -1564,7 +1581,7 @@ func (s *sharedPollChannelState) applyRefreshResponse(channel string, respEpoch 
 	pubs := make([]protocol.Publication, len(updates))
 	for i, u := range updates {
 		pubs[i] = protocol.Publication{Key: u.key, Data: u.data, Version: u.version}
-		prep := buildPreparedPollData(&pubs[i], u.prevData)
+		prep := buildPreparedPollData(&pubs[i], u.prevData, u.prevVersion)
 		broadcasts = append(broadcasts, pendingBroadcast{key: u.key, version: u.version, pub: &pubs[i], prep: prep})
 	}
 	for _, key := range removals {

--- a/shared_poll.go
+++ b/shared_poll.go
@@ -88,6 +88,19 @@ type sharedPollTrackedEntry struct {
 	dataHash         uint64 // xxhash64 hash of data, only used in versionless mode
 	freshFromPublish bool   // set by SharedPollPublish, cleared each timer poll cycle
 	needsBroadcast   bool   // set when a version=0 subscriber joins an existing key; cleared after broadcast
+
+	// subscribeReady is non-nil if the broker.Subscribe for this key is
+	// currently in flight (called by an earlier track*() that already
+	// installed the entry but released s.mu before calling the broker).
+	// Concurrent track*() callers for the same key must wait on this chan
+	// before reporting success — otherwise a subsequent subscribe failure
+	// + rollback would orphan their caller's client in the keyed hub with
+	// no broker subscription. The chan is closed (and nilled under s.mu)
+	// once subscribe completes; the result is recorded in subscribeErr
+	// just before close, so the chan-close memory barrier makes it visible
+	// to waiters.
+	subscribeReady chan struct{}
+	subscribeErr   error
 }
 
 func xxHash64(data []byte) uint64 {
@@ -236,22 +249,70 @@ func (m *SharedPollManager) track(channel string, opts SharedPollChannelOptions,
 		m.wg.Add(1)
 		go s.runRefreshWorker(ctx, m.node, channel, gen, m)
 	}
+
+	// Identify ownership: either we OWN the in-flight subscribe for this
+	// key (isNewKey + PublishEnabled), or another track*() owns it and we
+	// must wait. ownEntry / waitCh capture pointers, not keys — between
+	// here and the broker.Subscribe result a concurrent untrack+retrack
+	// can replace s.itemIndex[key] with a different entry, and we must
+	// only close/delete the entry WE created.
+	var ownEntry *sharedPollTrackedEntry
+	var waitEntry *sharedPollTrackedEntry
+	var waitCh chan struct{}
+	if isNewKey {
+		if opts.PublishEnabled {
+			ownEntry = s.itemIndex[key]
+			ownEntry.subscribeReady = make(chan struct{})
+		}
+	} else {
+		e := s.itemIndex[key]
+		if e != nil && e.subscribeReady != nil {
+			waitEntry = e
+			waitCh = e.subscribeReady
+		}
+	}
 	s.mu.Unlock()
 
-	if isNewKey && opts.PublishEnabled {
-		if err := m.subscribeToBrokerKeys(channel, []string{key}); err != nil {
-			// Broker subscribe failed — clean up our key. Only tear down the channel
-			// if no other goroutine added keys in the meantime.
-			s.mu.Lock()
-			delete(s.itemIndex, key)
-			empty := len(s.itemIndex) == 0
+	// Wait for the concurrent in-flight subscribe (if any). The chan close
+	// is a memory barrier for waitEntry.subscribeErr.
+	if waitCh != nil {
+		<-waitCh
+		if waitEntry.subscribeErr != nil {
+			// The owner of the in-flight subscribe failed and rolled back
+			// its entry. We must fail too — surfacing success would orphan
+			// our caller in the keyed hub with no broker subscription.
+			return false, 0, waitEntry.subscribeErr
+		}
+	}
+
+	if ownEntry != nil {
+		err := m.subscribeToBrokerKeys(channel, []string{key})
+		s.mu.Lock()
+		// Always notify waiters BEFORE touching itemIndex — the waiters
+		// are waiting on ownEntry.subscribeReady, not on whatever is
+		// currently in s.itemIndex[key] (a concurrent untrack+retrack may
+		// have installed a different entry by now).
+		ownEntry.subscribeErr = err
+		close(ownEntry.subscribeReady)
+		ownEntry.subscribeReady = nil
+		if err != nil {
+			// Only delete from itemIndex if it still points to OUR entry —
+			// otherwise we'd erase a different goroutine's freshly
+			// installed entry. This is the same "pointer identity"
+			// invariant we use to avoid double-closing the chan.
+			cleanedUp := false
+			if s.itemIndex[key] == ownEntry {
+				delete(s.itemIndex, key)
+				cleanedUp = true
+			}
+			empty := cleanedUp && len(s.itemIndex) == 0
 			if empty && s.workerCancel != nil {
 				s.workerCancel()
+				s.removed = true
 			}
 			s.mu.Unlock()
 			if empty {
 				m.mu.Lock()
-				// Verify the channel wasn't replaced by another goroutine.
 				if m.channels[channel] == s {
 					delete(m.channels, channel)
 				}
@@ -259,6 +320,7 @@ func (m *SharedPollManager) track(channel string, opts SharedPollChannelOptions,
 			}
 			return false, 0, err
 		}
+		s.mu.Unlock()
 	}
 
 	return isNewKey, entryVersion, nil
@@ -268,6 +330,17 @@ func (m *SharedPollManager) track(channel string, opts SharedPollChannelOptions,
 type trackKeyResult struct {
 	isNew        bool
 	entryVersion uint64
+}
+
+// ownedKey pairs a key with the entry pointer this trackKeys call
+// installed for it. Pointer identity matters: a concurrent untrack +
+// retrack can replace s.itemIndex[key] with a different entry while our
+// broker.Subscribe is in flight, and we must only close/delete the entry
+// WE own — touching another goroutine's entry would either double-close
+// its subscribeReady chan (panic) or erase its registration.
+type ownedKey struct {
+	key   string
+	entry *sharedPollTrackedEntry
 }
 
 // trackKeys registers multiple items in the shared poll channel state in one batch.
@@ -339,18 +412,46 @@ func (m *SharedPollManager) trackKeys(channel string, opts SharedPollChannelOpti
 	// Cancel any pending shutdown timer.
 	s.cancelShutdown()
 
-	// Register all keys and collect results + new keys list.
+	// Register all keys and collect results, owned-new-entry pointers, and
+	// any in-flight subscribe chans we must wait on. We capture entry
+	// pointers (not key strings) because a concurrent untrack+retrack can
+	// replace s.itemIndex[key] with a different entry between here and
+	// when our broker.Subscribe completes — close/delete must only touch
+	// the entries WE installed.
 	results := make([]trackKeyResult, len(keys))
-	var newKeys []string
+	var owned []ownedKey
+	// ownedSet identifies entries this call installed so a duplicate key
+	// later in the same `keys` slice does not get classified as someone
+	// else's in-flight subscribe — which would have us wait on our own
+	// subscribeReady chan and deadlock.
+	var ownedSet map[*sharedPollTrackedEntry]struct{}
+	type waitInfo struct {
+		entry *sharedPollTrackedEntry
+		ch    chan struct{}
+	}
+	var waits []waitInfo
 	for i, key := range keys {
-		isNewKey := s.itemIndex[key] == nil
+		entry := s.itemIndex[key]
+		isNewKey := entry == nil
 		if isNewKey {
-			s.itemIndex[key] = &sharedPollTrackedEntry{}
-			newKeys = append(newKeys, key)
+			entry = &sharedPollTrackedEntry{}
+			if opts.PublishEnabled {
+				entry.subscribeReady = make(chan struct{})
+			}
+			s.itemIndex[key] = entry
+			owned = append(owned, ownedKey{key: key, entry: entry})
+			if ownedSet == nil {
+				ownedSet = make(map[*sharedPollTrackedEntry]struct{}, len(keys))
+			}
+			ownedSet[entry] = struct{}{}
+		} else if entry.subscribeReady != nil {
+			if _, mine := ownedSet[entry]; !mine {
+				waits = append(waits, waitInfo{entry: entry, ch: entry.subscribeReady})
+			}
 		}
 		results[i] = trackKeyResult{
 			isNew:        isNewKey,
-			entryVersion: s.itemIndex[key].version,
+			entryVersion: entry.version,
 		}
 	}
 
@@ -375,18 +476,52 @@ func (m *SharedPollManager) trackKeys(channel string, opts SharedPollChannelOpti
 		m.wg.Add(1)
 		go s.runRefreshWorker(ctx, m.node, channel, gen, m)
 	}
+
 	s.mu.Unlock()
 
-	if len(newKeys) > 0 && opts.PublishEnabled {
-		if err := m.subscribeToBrokerKeys(channel, newKeys); err != nil {
-			// Broker subscribe failed — clean up new keys.
-			s.mu.Lock()
-			for _, key := range newKeys {
-				delete(s.itemIndex, key)
+	// Wait for any concurrent in-flight broker subscribes for keys we did
+	// not create. The chan close acts as a memory barrier for subscribeErr.
+	// If any in-flight subscribe failed, our track fails too — surfacing
+	// success while a key's broker subscription is missing would orphan
+	// the caller's client in the keyed hub.
+	for _, w := range waits {
+		<-w.ch
+		if w.entry.subscribeErr != nil {
+			// Roll back the entries WE created so subsequent callers can
+			// retry from scratch.
+			m.rollbackOwnedKeys(channel, s, owned, w.entry.subscribeErr)
+			return nil, w.entry.subscribeErr
+		}
+	}
+
+	if len(owned) > 0 && opts.PublishEnabled {
+		ownedKeyStrs := make([]string, len(owned))
+		for i, o := range owned {
+			ownedKeyStrs[i] = o.key
+		}
+		err := m.subscribeToBrokerKeys(channel, ownedKeyStrs)
+		s.mu.Lock()
+		// Always notify waiters BEFORE touching itemIndex — they're
+		// waiting on our captured ownEntry pointers, not on whatever the
+		// map currently holds (a concurrent untrack+retrack may have
+		// installed a different entry).
+		for _, o := range owned {
+			o.entry.subscribeErr = err
+			close(o.entry.subscribeReady)
+			o.entry.subscribeReady = nil
+		}
+		if err != nil {
+			// Only delete entries we still own — itemIndex[key] must
+			// point to OUR entry for the delete to be safe.
+			for _, o := range owned {
+				if s.itemIndex[o.key] == o.entry {
+					delete(s.itemIndex, o.key)
+				}
 			}
 			empty := len(s.itemIndex) == 0
 			if empty && s.workerCancel != nil {
 				s.workerCancel()
+				s.removed = true
 			}
 			s.mu.Unlock()
 			if empty {
@@ -398,9 +533,45 @@ func (m *SharedPollManager) trackKeys(channel string, opts SharedPollChannelOpti
 			}
 			return nil, err
 		}
+		s.mu.Unlock()
 	}
 
 	return results, nil
+}
+
+// rollbackOwnedKeys signals failure on each owned entry's subscribeReady
+// chan and deletes the entry from itemIndex when it is still the installed
+// one. Used when a concurrent in-flight subscribe (for a key we did NOT
+// own) failed — we must abandon any entries we ourselves installed in this
+// same trackKeys call so subsequent track*() callers retry from scratch.
+func (m *SharedPollManager) rollbackOwnedKeys(channel string, s *sharedPollChannelState, owned []ownedKey, err error) {
+	if len(owned) == 0 {
+		return
+	}
+	s.mu.Lock()
+	for _, o := range owned {
+		if o.entry.subscribeReady != nil {
+			o.entry.subscribeErr = err
+			close(o.entry.subscribeReady)
+			o.entry.subscribeReady = nil
+		}
+		if s.itemIndex[o.key] == o.entry {
+			delete(s.itemIndex, o.key)
+		}
+	}
+	empty := len(s.itemIndex) == 0
+	if empty && s.workerCancel != nil {
+		s.workerCancel()
+		s.removed = true
+	}
+	s.mu.Unlock()
+	if empty {
+		m.mu.Lock()
+		if m.channels[channel] == s {
+			delete(m.channels, channel)
+		}
+		m.mu.Unlock()
+	}
 }
 
 // untrack removes an item from shared poll tracking when no connections remain.
@@ -1541,10 +1712,39 @@ func (s *sharedPollChannelState) applyRefreshResponse(channel string, respEpoch 
 		if e.Version <= entry.version {
 			unchangedCount++
 			if entry.needsBroadcast && entry.version > 0 {
-				entry.needsBroadcast = false
-				updates = append(updates, pendingUpdate{
-					key: e.Key, version: entry.version, data: e.Data,
-				})
+				// Choose (version, data) so the pair always matches. Without
+				// this, a concurrent SharedPollPublish that bumped
+				// entry.version while the backend response was in flight
+				// would have us emit (entry.version, e.Data) — the new
+				// (higher) version paired with the old bytes. The receiving
+				// client advances keyState.version to entry.version, then
+				// suppresses any later legitimate broadcast at the same
+				// version, pinning the client to wrong data until the next
+				// entry update.
+				//
+				// KeepLatestData: entry.data is the live publish payload at
+				// entry.version. Safe to broadcast both; clear needsBroadcast.
+				//
+				// !KeepLatestData: entry.data is empty. The only valid pair
+				// we can emit is the backend's (e.Version, e.Data). Emitting
+				// that pins the client to the backend's older version, which
+				// is fine — a future publish at any higher version will
+				// pass the keyState.version filter. But only do so when the
+				// versions match (no concurrent publish raced ahead); if
+				// they don't, leave needsBroadcast set so the next poll
+				// retries once the backend catches up.
+				if s.opts.KeepLatestData {
+					entry.needsBroadcast = false
+					updates = append(updates, pendingUpdate{
+						key: e.Key, version: entry.version, data: entry.data,
+					})
+				} else if e.Version == entry.version {
+					entry.needsBroadcast = false
+					updates = append(updates, pendingUpdate{
+						key: e.Key, version: e.Version, data: e.Data,
+					})
+				}
+				// else: backend behind a concurrent publish; retry next poll.
 			}
 			continue
 		}

--- a/shared_poll.go
+++ b/shared_poll.go
@@ -1037,6 +1037,18 @@ func (m *SharedPollManager) subscribeToBrokerKeys(channel string, keys []string)
 		keyChannels[i] = sharedPollKeyChannel(channel, key)
 	}
 	m.node.metrics.incActionCount("broker_subscribe", channel)
+	// Per-channel sharded lock — mirrors Node.addSubscription so that a
+	// concurrent shared-poll unsubscribe (queued via subDissolver) cannot
+	// race between our broker.Subscribe and brokerSubChans update and
+	// silently unsubscribe the key at the broker after we've recorded it
+	// as subscribed. Without this, the queued unsub's filter check sees
+	// the key absent (because we hadn't installed our entry yet when it
+	// ran), proceeds to broker.Unsubscribe(kc) after we have already
+	// re-subscribed, and then deletes brokerSubChans[kc] — leaving the
+	// new tracker in the hub with no broker subscription.
+	mu := m.node.subLock(channel)
+	mu.Lock()
+	defer mu.Unlock()
 	if err := broker.Subscribe(keyChannels...); err != nil {
 		return err
 	}
@@ -1062,6 +1074,15 @@ func (m *SharedPollManager) unsubscribeFromBrokerKeys(channel string, keys []str
 	}
 	_ = m.node.subDissolver.Submit(func() error {
 		m.node.metrics.incActionCount("broker_unsubscribe", channel)
+		// Hold the per-channel sharded lock across the filter recheck, the
+		// broker.Unsubscribe call, and the brokerSubChans update — so a
+		// concurrent retrack (which also takes the lock in
+		// subscribeToBrokerKeys) cannot squeeze a fresh broker.Subscribe
+		// between our filter check and our Unsubscribe. Mirrors the
+		// Node.removeSubscription pattern.
+		mu := m.node.subLock(channel)
+		mu.Lock()
+		defer mu.Unlock()
 		// Filter out keys that were re-tracked between queueing and execution.
 		m.mu.RLock()
 		s, chExists := m.channels[channel]
@@ -1113,6 +1134,13 @@ func (m *SharedPollManager) unsubscribeFromBrokerKeys(channel string, keys []str
 func (m *SharedPollManager) unsubscribeAllBrokerKeys(channel string) {
 	_ = m.node.subDissolver.Submit(func() error {
 		m.node.metrics.incActionCount("broker_unsubscribe", channel)
+		// Per-channel sharded lock — same rationale as unsubscribeFromBrokerKeys.
+		// A concurrent track() that re-creates the channel state and issues a
+		// fresh broker.Subscribe could otherwise race the shutdown-time
+		// Unsubscribe and end up with a tracked key but no broker subscription.
+		mu := m.node.subLock(channel)
+		mu.Lock()
+		defer mu.Unlock()
 		// Check if channel was re-created while shutting down.
 		m.mu.RLock()
 		_, stillActive := m.channels[channel]

--- a/shared_poll.go
+++ b/shared_poll.go
@@ -101,6 +101,18 @@ type sharedPollTrackedEntry struct {
 	// to waiters.
 	subscribeReady chan struct{}
 	subscribeErr   error
+
+	// pendingHubJoin counts trackKeys callers that have successfully
+	// reserved this entry but have NOT yet finalized — either by joining
+	// the hub via keyedManager.addSubscribers or by rolling back. While
+	// pendingHubJoin > 0, untrack must NOT delete the entry: a concurrent
+	// trackKeys caller may have returned success and be about to join the
+	// hub, and deleting now would silently orphan that caller (in hub,
+	// no itemIndex, no broker subscription). Each trackKeys call
+	// increments under s.mu and returns a release closure that decrements
+	// under s.mu and runs untrack-style cleanup if the counter and hub
+	// subscriber count are both zero.
+	pendingHubJoin int
 }
 
 func xxHash64(data []byte) uint64 {
@@ -144,14 +156,27 @@ func newSharedPollManager(node *Node) *SharedPollManager {
 	}
 }
 
+// noopReleaseTrack is returned from track/trackKeys on early-exit paths
+// (shutdown, etc.) where no reservation was acquired. Lets callers
+// unconditionally invoke release() without nil-checking.
+func noopReleaseTrack() {}
+
 // track registers an item in the shared poll channel state and ensures
 // a refresh worker is running. Hub registration (addSubscriber) is handled
 // by the generic keyed layer in handleTrack — NOT here.
-func (m *SharedPollManager) track(channel string, opts SharedPollChannelOptions, key string) (bool, uint64, error) {
+//
+// On success returns a release closure that the caller MUST invoke after
+// either joining the hub via keyedManager.addSubscribers or definitively
+// abandoning the track (rollback path). The closure decrements the
+// pendingHubJoin reservation and cleans up the entry if it has no
+// remaining holders. Without this contract a concurrent rollback in
+// another goroutine could orphan an in-flight hub join — see
+// pendingHubJoin doc.
+func (m *SharedPollManager) track(channel string, opts SharedPollChannelOptions, key string) (bool, uint64, func(), error) {
 	// Check global shutdown.
 	select {
 	case <-m.shutdownCh:
-		return false, 0, nil
+		return false, 0, noopReleaseTrack, nil
 	default:
 	}
 
@@ -174,7 +199,7 @@ func (m *SharedPollManager) track(channel string, opts SharedPollChannelOptions,
 	select {
 	case <-m.shutdownCh:
 		s.mu.Unlock()
-		return false, 0, nil
+		return false, 0, noopReleaseTrack, nil
 	default:
 	}
 
@@ -212,7 +237,7 @@ func (m *SharedPollManager) track(channel string, opts SharedPollChannelOptions,
 		select {
 		case <-m.shutdownCh:
 			s.mu.Unlock()
-			return false, 0, nil
+			return false, 0, noopReleaseTrack, nil
 		default:
 		}
 	}
@@ -226,7 +251,11 @@ func (m *SharedPollManager) track(channel string, opts SharedPollChannelOptions,
 	if isNewKey {
 		s.itemIndex[key] = &sharedPollTrackedEntry{}
 	}
-	entryVersion := s.itemIndex[key].version
+	entry := s.itemIndex[key]
+	entryVersion := entry.version
+	// Reserve a hub-join slot. Decremented by the returned release closure
+	// or by the internal failure paths below.
+	entry.pendingHubJoin++
 
 	// Ensure refresh worker is running.
 	startWorker := false
@@ -256,22 +285,30 @@ func (m *SharedPollManager) track(channel string, opts SharedPollChannelOptions,
 	// here and the broker.Subscribe result a concurrent untrack+retrack
 	// can replace s.itemIndex[key] with a different entry, and we must
 	// only close/delete the entry WE created.
+	//
+	// Use s.opts.PublishEnabled (frozen at channel-state creation) rather
+	// than the caller's opts.PublishEnabled. If the caller-passed opts
+	// drift from the channel's first-tracker opts, gating on the caller's
+	// flag would skip broker.Subscribe for a key on a PublishEnabled
+	// channel — publish() then routes through the broker per s.opts but
+	// this node is not subscribed for the key, so cross-node publications
+	// silently miss local subscribers.
+	publishEnabled := s.opts.PublishEnabled
 	var ownEntry *sharedPollTrackedEntry
 	var waitEntry *sharedPollTrackedEntry
 	var waitCh chan struct{}
 	if isNewKey {
-		if opts.PublishEnabled {
-			ownEntry = s.itemIndex[key]
+		if publishEnabled {
+			ownEntry = entry
 			ownEntry.subscribeReady = make(chan struct{})
 		}
-	} else {
-		e := s.itemIndex[key]
-		if e != nil && e.subscribeReady != nil {
-			waitEntry = e
-			waitCh = e.subscribeReady
-		}
+	} else if entry.subscribeReady != nil {
+		waitEntry = entry
+		waitCh = entry.subscribeReady
 	}
 	s.mu.Unlock()
+
+	reservations := []reservation{{key: key, entry: entry}}
 
 	// Wait for the concurrent in-flight subscribe (if any). The chan close
 	// is a memory barrier for waitEntry.subscribeErr.
@@ -281,7 +318,11 @@ func (m *SharedPollManager) track(channel string, opts SharedPollChannelOptions,
 			// The owner of the in-flight subscribe failed and rolled back
 			// its entry. We must fail too — surfacing success would orphan
 			// our caller in the keyed hub with no broker subscription.
-			return false, 0, waitEntry.subscribeErr
+			// Decrement our reservation (the wait entry; ownEntry is nil
+			// in the wait branch). No synchronous channel cleanup needed
+			// — the owner's failure path already handled that.
+			m.releasePendingHubJoin(s, reservations)
+			return false, 0, noopReleaseTrack, waitEntry.subscribeErr
 		}
 	}
 
@@ -296,10 +337,10 @@ func (m *SharedPollManager) track(channel string, opts SharedPollChannelOptions,
 		close(ownEntry.subscribeReady)
 		ownEntry.subscribeReady = nil
 		if err != nil {
-			// Only delete from itemIndex if it still points to OUR entry —
-			// otherwise we'd erase a different goroutine's freshly
-			// installed entry. This is the same "pointer identity"
-			// invariant we use to avoid double-closing the chan.
+			// Synchronous cleanup of our owned entry (broker.Subscribe
+			// failed so brokerSubChans has no record). Pointer identity
+			// check protects against a concurrent untrack+retrack that
+			// replaced s.itemIndex[key] with a different entry.
 			cleanedUp := false
 			if s.itemIndex[key] == ownEntry {
 				delete(s.itemIndex, key)
@@ -318,12 +359,18 @@ func (m *SharedPollManager) track(channel string, opts SharedPollChannelOptions,
 				}
 				m.mu.Unlock()
 			}
-			return false, 0, err
+			// Decrement reservations. ownEntry's counter is moot (entry
+			// deleted) but the call is symmetric and harmless.
+			m.releasePendingHubJoin(s, reservations)
+			return false, 0, noopReleaseTrack, err
 		}
 		s.mu.Unlock()
 	}
 
-	return isNewKey, entryVersion, nil
+	release := func() {
+		m.releaseTrackReservations(channel, s, reservations)
+	}
+	return isNewKey, entryVersion, release, nil
 }
 
 // trackKeyResult holds the outcome for a single key tracked via trackKeys.
@@ -343,17 +390,105 @@ type ownedKey struct {
 	entry *sharedPollTrackedEntry
 }
 
-// trackKeys registers multiple items in the shared poll channel state in one batch.
-// It subscribes to all new keys with a single broker.Subscribe call.
-func (m *SharedPollManager) trackKeys(channel string, opts SharedPollChannelOptions, keys []string) ([]trackKeyResult, error) {
+// reservation pairs a key with the entry pointer whose pendingHubJoin
+// this trackKeys call incremented. Used to undo the increment (and
+// possibly clean up the entry) on rollback or release. Pointer identity
+// matters: a concurrent untrack+retrack may have installed a different
+// entry by the time we run cleanup, and decrementing the wrong entry
+// would underflow it or interfere with another caller's bookkeeping.
+type reservation struct {
+	key   string
+	entry *sharedPollTrackedEntry
+}
+
+// releaseTrackReservations decrements pendingHubJoin on each reserved
+// entry and performs untrack-style cleanup for any entry whose counter
+// reaches zero AND has no remaining hub subscribers. The hub-count check
+// closes the inter-client orphan race: another in-flight trackKeys
+// caller (waiter who returned success and is about to call
+// addSubscribers) keeps the entry alive via its own reservation until
+// it has joined the hub.
+//
+// Pointer identity (s.itemIndex[key] == r.entry) is required before
+// deleting — a concurrent untrack+retrack may have installed a different
+// entry, and deleting now would erase that caller's freshly installed
+// entry.
+//
+// Used by the release closure returned to successful trackKeys callers,
+// invoked after either addSubscribers (entry stays via hub.count>0) or
+// rollback (entry deletes if no other holders).
+func (m *SharedPollManager) releaseTrackReservations(channel string, s *sharedPollChannelState, reservations []reservation) {
+	if len(reservations) == 0 {
+		return
+	}
+	hub := m.node.keyedManager.getHub(channel)
+
+	var cleanupKeys []string
+	s.mu.Lock()
+	for _, r := range reservations {
+		if r.entry.pendingHubJoin > 0 {
+			r.entry.pendingHubJoin--
+		}
+		if r.entry.pendingHubJoin > 0 {
+			continue
+		}
+		if s.itemIndex[r.key] != r.entry {
+			continue
+		}
+		if hub != nil && hub.subscriberCount(r.key) > 0 {
+			continue
+		}
+		delete(s.itemIndex, r.key)
+		cleanupKeys = append(cleanupKeys, r.key)
+	}
+	empty := len(s.itemIndex) == 0
+	publishEnabled := s.opts.PublishEnabled
+	s.mu.Unlock()
+
+	if publishEnabled && len(cleanupKeys) > 0 {
+		m.unsubscribeFromBrokerKeys(channel, cleanupKeys)
+	}
+	if empty {
+		s.scheduleShutdown(m, channel, s.opts.ChannelShutdownDelay)
+	}
+}
+
+// releasePendingHubJoin decrements pendingHubJoin on each reservation
+// without performing any entry or channel-state cleanup. Used by
+// trackKeys / track internal failure paths (broker.Subscribe failure or
+// wait-failure) where the failing path already runs its own synchronous
+// cleanup — we just need to drop the reservations we held on wait
+// entries so other concurrent trackKeys callers see a correct count.
+// Owned entries are deleted synchronously by the failing path; their
+// counter goes away with the entry, so the decrement is harmless.
+func (m *SharedPollManager) releasePendingHubJoin(s *sharedPollChannelState, reservations []reservation) {
+	if len(reservations) == 0 {
+		return
+	}
+	s.mu.Lock()
+	for _, r := range reservations {
+		if r.entry.pendingHubJoin > 0 {
+			r.entry.pendingHubJoin--
+		}
+	}
+	s.mu.Unlock()
+}
+
+// trackKeys registers multiple items in the shared poll channel state in
+// one batch. It subscribes to all new keys with a single broker.Subscribe
+// call. On success returns a release closure the caller MUST invoke
+// after either joining the hub via keyedManager.addSubscribers or
+// definitively abandoning the track (rollback path). See track() and
+// pendingHubJoin doc for the orphan race this guards against.
+func (m *SharedPollManager) trackKeys(channel string, opts SharedPollChannelOptions, keys []string) ([]trackKeyResult, func(), error) {
 	if len(keys) == 0 {
-		return nil, nil
+		return nil, noopReleaseTrack, nil
 	}
 
 	// Check global shutdown.
 	select {
 	case <-m.shutdownCh:
-		return make([]trackKeyResult, len(keys)), nil
+		return make([]trackKeyResult, len(keys)), noopReleaseTrack, nil
 	default:
 	}
 
@@ -376,7 +511,7 @@ func (m *SharedPollManager) trackKeys(channel string, opts SharedPollChannelOpti
 	select {
 	case <-m.shutdownCh:
 		s.mu.Unlock()
-		return make([]trackKeyResult, len(keys)), nil
+		return make([]trackKeyResult, len(keys)), noopReleaseTrack, nil
 	default:
 	}
 
@@ -404,7 +539,7 @@ func (m *SharedPollManager) trackKeys(channel string, opts SharedPollChannelOpti
 		select {
 		case <-m.shutdownCh:
 			s.mu.Unlock()
-			return make([]trackKeyResult, len(keys)), nil
+			return make([]trackKeyResult, len(keys)), noopReleaseTrack, nil
 		default:
 		}
 	}
@@ -412,14 +547,29 @@ func (m *SharedPollManager) trackKeys(channel string, opts SharedPollChannelOpti
 	// Cancel any pending shutdown timer.
 	s.cancelShutdown()
 
-	// Register all keys and collect results, owned-new-entry pointers, and
-	// any in-flight subscribe chans we must wait on. We capture entry
-	// pointers (not key strings) because a concurrent untrack+retrack can
-	// replace s.itemIndex[key] with a different entry between here and
-	// when our broker.Subscribe completes — close/delete must only touch
-	// the entries WE installed.
+	// Register all keys and collect results, owned-new-entry pointers,
+	// reservation list (for pendingHubJoin bookkeeping), and any in-flight
+	// subscribe chans we must wait on. We capture entry pointers (not key
+	// strings) because a concurrent untrack+retrack can replace
+	// s.itemIndex[key] with a different entry between here and when our
+	// broker.Subscribe completes — close/delete must only touch the
+	// entries WE installed, and pending-counter decrement must only touch
+	// the entry we incremented.
+	//
+	// Use s.opts.PublishEnabled (frozen at channel-state creation) rather
+	// than the caller's opts.PublishEnabled. See track() for the drift
+	// rationale — gating broker.Subscribe on the caller's flag would
+	// silently skip subscriptions on a PublishEnabled channel and miss
+	// cross-node publications for that key.
+	publishEnabled := s.opts.PublishEnabled
 	results := make([]trackKeyResult, len(keys))
 	var owned []ownedKey
+	reservations := make([]reservation, 0, len(keys))
+	// reservedSet dedups: if the same key appears multiple times in the
+	// keys slice, we reserve once per unique entry. Otherwise duplicate
+	// keys would over-increment pendingHubJoin and the matching release
+	// would underflow (or worse, decrement another caller's count).
+	reservedSet := make(map[*sharedPollTrackedEntry]struct{}, len(keys))
 	// ownedSet identifies entries this call installed so a duplicate key
 	// later in the same `keys` slice does not get classified as someone
 	// else's in-flight subscribe — which would have us wait on our own
@@ -435,7 +585,7 @@ func (m *SharedPollManager) trackKeys(channel string, opts SharedPollChannelOpti
 		isNewKey := entry == nil
 		if isNewKey {
 			entry = &sharedPollTrackedEntry{}
-			if opts.PublishEnabled {
+			if publishEnabled {
 				entry.subscribeReady = make(chan struct{})
 			}
 			s.itemIndex[key] = entry
@@ -448,6 +598,11 @@ func (m *SharedPollManager) trackKeys(channel string, opts SharedPollChannelOpti
 			if _, mine := ownedSet[entry]; !mine {
 				waits = append(waits, waitInfo{entry: entry, ch: entry.subscribeReady})
 			}
+		}
+		if _, dup := reservedSet[entry]; !dup {
+			entry.pendingHubJoin++
+			reservations = append(reservations, reservation{key: key, entry: entry})
+			reservedSet[entry] = struct{}{}
 		}
 		results[i] = trackKeyResult{
 			isNew:        isNewKey,
@@ -488,13 +643,15 @@ func (m *SharedPollManager) trackKeys(channel string, opts SharedPollChannelOpti
 		<-w.ch
 		if w.entry.subscribeErr != nil {
 			// Roll back the entries WE created so subsequent callers can
-			// retry from scratch.
+			// retry from scratch (synchronous channel-state cleanup), and
+			// decrement our pending counter on wait entries.
 			m.rollbackOwnedKeys(channel, s, owned, w.entry.subscribeErr)
-			return nil, w.entry.subscribeErr
+			m.releasePendingHubJoin(s, reservations)
+			return nil, noopReleaseTrack, w.entry.subscribeErr
 		}
 	}
 
-	if len(owned) > 0 && opts.PublishEnabled {
+	if len(owned) > 0 && publishEnabled {
 		ownedKeyStrs := make([]string, len(owned))
 		for i, o := range owned {
 			ownedKeyStrs[i] = o.key
@@ -511,8 +668,9 @@ func (m *SharedPollManager) trackKeys(channel string, opts SharedPollChannelOpti
 			o.entry.subscribeReady = nil
 		}
 		if err != nil {
-			// Only delete entries we still own — itemIndex[key] must
-			// point to OUR entry for the delete to be safe.
+			// Synchronous cleanup of our owned entries (broker.Subscribe
+			// failed; brokerSubChans has no record). Pointer identity
+			// check guards against concurrent untrack+retrack.
 			for _, o := range owned {
 				if s.itemIndex[o.key] == o.entry {
 					delete(s.itemIndex, o.key)
@@ -531,12 +689,16 @@ func (m *SharedPollManager) trackKeys(channel string, opts SharedPollChannelOpti
 				}
 				m.mu.Unlock()
 			}
-			return nil, err
+			m.releasePendingHubJoin(s, reservations)
+			return nil, noopReleaseTrack, err
 		}
 		s.mu.Unlock()
 	}
 
-	return results, nil
+	release := func() {
+		m.releaseTrackReservations(channel, s, reservations)
+	}
+	return results, release, nil
 }
 
 // rollbackOwnedKeys signals failure on each owned entry's subscribeReady
@@ -574,7 +736,15 @@ func (m *SharedPollManager) rollbackOwnedKeys(channel string, s *sharedPollChann
 	}
 }
 
-// untrack removes an item from shared poll tracking when no connections remain.
+// untrack removes an item from shared poll tracking when no connections
+// remain. Called after the client has been removed from the hub via
+// keyedHub.removeSubscriber.
+//
+// The pendingHubJoin guard prevents deleting an entry while a concurrent
+// trackKeys caller still holds a reservation — that caller may have
+// returned success and be about to join the hub, and deleting now would
+// silently orphan it (in hub, no itemIndex, no broker subscription). See
+// pendingHubJoin doc on sharedPollTrackedEntry.
 func (m *SharedPollManager) untrack(channel string, key string) {
 	m.mu.RLock()
 	s, ok := m.channels[channel]
@@ -586,8 +756,11 @@ func (m *SharedPollManager) untrack(channel string, key string) {
 	hub := m.node.keyedManager.getHub(channel)
 
 	s.mu.Lock()
-	// Check if any connections remain for this key.
 	if hub != nil && hub.subscriberCount(key) > 0 {
+		s.mu.Unlock()
+		return
+	}
+	if entry := s.itemIndex[key]; entry != nil && entry.pendingHubJoin > 0 {
 		s.mu.Unlock()
 		return
 	}
@@ -990,33 +1163,46 @@ func (m *SharedPollManager) unsubscribeAllBrokerKeys(channel string) {
 }
 
 func (m *SharedPollManager) publish(ctx context.Context, channel string, key string, version uint64, epoch string, data []byte) error {
+	// Resolve channel options. Prefer the running channel state's opts
+	// (immutable for its lifetime). Fall back to the config callback so a
+	// publisher node that has never tracked the channel still gets the
+	// correct routing decision.
+	var opts SharedPollChannelOptions
+	var hasOpts bool
+
 	m.mu.RLock()
 	s, ok := m.channels[channel]
 	m.mu.RUnlock()
 	if ok {
 		s.mu.Lock()
-		versionless := s.opts.isVersionless()
+		opts = s.opts
 		s.mu.Unlock()
-		if versionless {
-			return errors.New("SharedPollPublish not supported in versionless refresh mode")
-		}
+		hasOpts = true
+	} else if m.node.config.SharedPoll.GetSharedPollChannelOptions != nil {
+		opts, hasOpts = m.node.config.SharedPoll.GetSharedPollChannelOptions(channel)
+	}
+	if !hasOpts {
+		return errors.New("SharedPollPublish: channel not configured for shared poll")
+	}
+	if opts.isVersionless() {
+		return errors.New("SharedPollPublish not supported in versionless refresh mode")
 	}
 
-	// Check if publish is enabled for this channel (broker subscribed).
-	keyCh := sharedPollKeyChannel(channel, key)
-	m.brokerSubMu.RLock()
-	broker := m.brokerSubChans[keyCh]
-	m.brokerSubMu.RUnlock()
-
-	if broker != nil {
-		// For shared-poll keyed channels, the broker's Publication.Epoch
-		// carries the publisher's per-channel epoch (the wire field is
-		// shared with stream channels' stream-position epoch — semantics
-		// differ per channel type, but the wire is the same).
+	// Routing is purely a function of PublishEnabled — not of local
+	// subscriber state. When PublishEnabled is true we always go through
+	// the broker so cross-node subscribers receive the publication,
+	// regardless of whether this node has tracked the key (and regardless
+	// of any in-flight broker.Subscribe). For shared-poll keyed channels
+	// the broker's Publication.Epoch carries the publisher's per-channel
+	// epoch (the wire field is shared with stream channels' stream-position
+	// epoch — semantics differ per channel type, but the wire is the same).
+	if opts.PublishEnabled {
+		broker := m.node.getBroker(channel)
+		keyCh := sharedPollKeyChannel(channel, key)
 		_, err := broker.Publish(keyCh, data, PublishOptions{Key: key, Version: version, Epoch: epoch})
 		return err
 	}
-	// Local-only (PublishEnabled=false or channel not active): apply directly.
+	// Local-only mode: apply directly. Only this node's subscribers see it.
 	m.handlePublishedData(channel, key, version, epoch, data)
 	return nil
 }
@@ -1116,22 +1302,39 @@ func (m *SharedPollManager) SharedPollRevokeKeys(channel string, keys []string, 
 		}
 	}
 
-	// Clean up hub and itemIndex.
+	// Clean up hub and itemIndex. Track keys we actually delete from
+	// itemIndex so we can drop their broker subscriptions too — otherwise
+	// the broker keeps pushing cross-node publications that handlePublishedData
+	// silently no-ops (entry == nil), wasting traffic until full channel
+	// shutdown.
+	var brokerCleanupKeys []string
 	s.mu.Lock()
+	publishEnabled := s.opts.PublishEnabled
 	for _, key := range keys {
 		if len(users) == 0 && len(excludeUsers) == 0 {
 			hub.removeAllSubscribers(key)
 		} else {
 			hub.removeSubscribersForUsers(key, users, excludeUsers)
 		}
-		// Remove from itemIndex if no subscribers remain.
+		// Remove from itemIndex if no subscribers remain AND no in-flight
+		// trackKeys reservation is holding the key alive. Mirrors the
+		// untrack guard so a concurrent track caller about to addSubscribers
+		// is not orphaned.
 		if hub.subscriberCount(key) == 0 {
-			delete(s.itemIndex, key)
+			if entry := s.itemIndex[key]; entry != nil && entry.pendingHubJoin == 0 {
+				delete(s.itemIndex, key)
+				if publishEnabled {
+					brokerCleanupKeys = append(brokerCleanupKeys, key)
+				}
+			}
 		}
 	}
 	empty := len(s.itemIndex) == 0
 	s.mu.Unlock()
 
+	if len(brokerCleanupKeys) > 0 {
+		m.unsubscribeFromBrokerKeys(channel, brokerCleanupKeys)
+	}
 	if empty {
 		s.scheduleShutdown(m, channel, s.opts.ChannelShutdownDelay)
 	}

--- a/shared_poll_bench_test.go
+++ b/shared_poll_bench_test.go
@@ -71,7 +71,7 @@ func benchRefreshCycle(b *testing.B, numKeys int, latency time.Duration) {
 	mgr := node.sharedPollManager
 	opts, _ := node.config.SharedPoll.GetSharedPollChannelOptions("bench:ch")
 	for i := 0; i < numKeys; i++ {
-		_, _, _ = mgr.track("bench:ch", opts, fmt.Sprintf("item_%d", i))
+		_, _, _, _ = mgr.track("bench:ch", opts, fmt.Sprintf("item_%d", i))
 	}
 
 	// Ensure keyed hub exists.
@@ -174,7 +174,7 @@ func benchLargeChannel(b *testing.B, totalKeys, batchSize int, latency time.Dura
 	mgr := node.sharedPollManager
 	opts, _ := node.config.SharedPoll.GetSharedPollChannelOptions("bench:ch")
 	for i := 0; i < totalKeys; i++ {
-		_, _, _ = mgr.track("bench:ch", opts, fmt.Sprintf("item_%d", i))
+		_, _, _, _ = mgr.track("bench:ch", opts, fmt.Sprintf("item_%d", i))
 	}
 
 	node.keyedManager.getOrCreateChannel("bench:ch", keyedChannelOptions{})

--- a/shared_poll_test.go
+++ b/shared_poll_test.go
@@ -831,7 +831,16 @@ func TestSharedPollPublish_FreshFromPublish_NotSkippedByNotify(t *testing.T) {
 
 func TestSharedPollPublish_UnknownChannel(t *testing.T) {
 	t.Parallel()
-	node := newTestNodeWithSharedPoll(t)
+	// Versioned + !PublishEnabled means publish() goes through the local
+	// path, which no-ops without channel state. This exercises the "no
+	// track yet" case while staying on a non-versionless mode (publish in
+	// versionless mode is explicitly rejected).
+	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
+		Mode:                 SharedPollModeVersioned,
+		RefreshInterval:      30 * time.Second,
+		RefreshBatchSize:     100,
+		MaxKeysPerConnection: 100,
+	})
 	setupSharedPollHandlers(node)
 
 	// Publish to untracked channel — should be a no-op.
@@ -1823,7 +1832,7 @@ func TestSharedPollManager_ConcurrentTrackSingleBrokerSubscribe(t *testing.T) {
 	for i := 0; i < numGoroutines; i++ {
 		go func(i int) {
 			defer wg.Done()
-			_, _, _ = m.track("test:channel", opts, "key"+string(rune('A'+i)))
+			_, _, _, _ = m.track("test:channel", opts, "key"+string(rune('A'+i)))
 		}(i)
 	}
 	wg.Wait()
@@ -1855,7 +1864,7 @@ func TestSharedPollManager_BrokerSubscribeFailureCleanup(t *testing.T) {
 	node := newTestNodeWithControllableBroker(t, broker, opts)
 	m := node.sharedPollManager
 
-	isNew, _, err := m.track("test:channel", opts, "key1")
+	isNew, _, _, err := m.track("test:channel", opts, "key1")
 	require.Error(t, err)
 	require.False(t, isNew)
 
@@ -1904,7 +1913,7 @@ func TestSharedPollManager_BrokerSubscribeFailureNoOrphanConcurrent(t *testing.T
 	aDone.Add(1)
 	go func() {
 		defer aDone.Done()
-		_, _, aErr = m.track("test:channel", opts, "key1")
+		_, _, _, aErr = m.track("test:channel", opts, "key1")
 	}()
 
 	// Wait for A to reach broker.Subscribe.
@@ -1914,7 +1923,7 @@ func TestSharedPollManager_BrokerSubscribeFailureNoOrphanConcurrent(t *testing.T
 
 	// Goroutine B: track key2 on same channel (won't call broker.Subscribe because
 	// isNewChannel is false for B).
-	isNew2, _, err2 := m.track("test:channel", opts, "key2")
+	isNew2, _, _, err2 := m.track("test:channel", opts, "key2")
 	require.NoError(t, err2)
 	require.True(t, isNew2)
 
@@ -1949,7 +1958,7 @@ func TestSharedPollManager_BrokerUnsubscribeViaDissolver(t *testing.T) {
 	node := newTestNodeWithControllableBroker(t, broker, opts)
 	m := node.sharedPollManager
 
-	isNew, _, err := m.track("test:channel", opts, "key1")
+	isNew, _, release, err := m.track("test:channel", opts, "key1")
 	require.NoError(t, err)
 	require.True(t, isNew)
 
@@ -1960,8 +1969,11 @@ func TestSharedPollManager_BrokerUnsubscribeViaDissolver(t *testing.T) {
 	m.brokerSubMu.Unlock()
 	require.True(t, hasSub)
 
-	// Remove the key directly (simulating untrack with no hub).
+	// Remove the key directly. The test does not simulate a hub join, so
+	// untrack is a no-op while the pendingHubJoin reservation is held —
+	// release drops it and triggers cleanup (delete + broker unsubscribe).
 	m.untrack("test:channel", "key1")
+	release()
 
 	// Wait for dissolver to process the unsubscribe.
 	require.Eventually(t, func() bool {
@@ -1995,12 +2007,15 @@ func TestSharedPollManager_BrokerUnsubscribeRetryOnFailure(t *testing.T) {
 	node := newTestNodeWithControllableBroker(t, broker, opts)
 	m := node.sharedPollManager
 
-	isNew, _, err := m.track("test:channel", opts, "key1")
+	isNew, _, release, err := m.track("test:channel", opts, "key1")
 	require.NoError(t, err)
 	require.True(t, isNew)
 
-	// Remove key to trigger unsubscribe.
+	// Remove key to trigger unsubscribe. Test does not simulate hub join,
+	// so untrack is a no-op while the pendingHubJoin reservation is held
+	// — release drops it and triggers the actual cleanup.
 	m.untrack("test:channel", "key1")
+	release()
 
 	// Wait for dissolver to eventually succeed (after 2 failures).
 	keyCh := sharedPollKeyChannel("test:channel", "key1")
@@ -2037,14 +2052,14 @@ func TestSharedPollManager_BrokerUnsubscribeSkipsIfResubscribed(t *testing.T) {
 	m := node.sharedPollManager
 
 	// Track key1 → broker.Subscribe called.
-	_, _, err := m.track("test:channel", opts, "key1")
+	_, _, _, err := m.track("test:channel", opts, "key1")
 	require.NoError(t, err)
 
 	// Untrack key1 → triggers dissolver unsubscribe job.
 	m.untrack("test:channel", "key1")
 
 	// Immediately re-track with key2 → new channel state, new broker.Subscribe.
-	_, _, err = m.track("test:channel", opts, "key2")
+	_, _, _, err = m.track("test:channel", opts, "key2")
 	require.NoError(t, err)
 
 	// Wait for dissolver to finish any pending work.
@@ -2091,7 +2106,7 @@ func TestSharedPollManager_ConcurrentTrackNoPanic(t *testing.T) {
 			defer wg.Done()
 			ch := "test:channel"
 			key := "key" + string(rune('A'+i))
-			_, _, _ = m.track(ch, opts, key)
+			_, _, _, _ = m.track(ch, opts, key)
 		}(i)
 	}
 	wg.Wait()
@@ -2122,14 +2137,17 @@ func TestSharedPollManager_ScheduleShutdownImmediate(t *testing.T) {
 	m := node.sharedPollManager
 
 	// Track a key so channel gets created.
-	_, _, _ = m.track("test:shutdown_imm", opts, "k1")
+	_, _, release, _ := m.track("test:shutdown_imm", opts, "k1")
 	m.mu.RLock()
 	_, exists := m.channels["test:shutdown_imm"]
 	m.mu.RUnlock()
 	require.True(t, exists)
 
-	// Untrack the key — should trigger immediate shutdown.
+	// Untrack the key, then drop the pendingHubJoin reservation so the
+	// entry is actually deleted (test does not simulate hub join). The
+	// release closure triggers immediate shutdown via the negative delay.
 	m.untrack("test:shutdown_imm", "k1")
+	release()
 
 	// Channel should be removed.
 	require.Eventually(t, func() bool {
@@ -2153,9 +2171,12 @@ func TestSharedPollManager_ScheduleShutdownDelayed(t *testing.T) {
 	node := newTestNodeWithControllableBroker(t, broker, opts)
 	m := node.sharedPollManager
 
-	// Track and untrack.
-	_, _, _ = m.track("test:shutdown_delay", opts, "k1")
+	// Track and untrack. Drop the pendingHubJoin reservation via release
+	// so the deferred shutdown fires (untrack alone is a no-op while
+	// pending>0).
+	_, _, release, _ := m.track("test:shutdown_delay", opts, "k1")
 	m.untrack("test:shutdown_delay", "k1")
+	release()
 
 	// Channel should still exist immediately after untrack (delay pending).
 	m.mu.RLock()
@@ -2184,11 +2205,11 @@ func TestSharedPollManager_ShutdownCancelledByRetrack(t *testing.T) {
 	node := newTestNodeWithControllableBroker(t, broker, opts)
 	m := node.sharedPollManager
 
-	_, _, _ = m.track("test:retrack", opts, "k1")
+	_, _, _, _ = m.track("test:retrack", opts, "k1")
 	m.untrack("test:retrack", "k1")
 
 	// Re-track before delay fires.
-	_, _, _ = m.track("test:retrack", opts, "k2")
+	_, _, _, _ = m.track("test:retrack", opts, "k2")
 
 	// Channel should still exist after the shutdown delay would have fired.
 	// Use Eventually with inverted check: keep asserting existence over a window
@@ -2262,7 +2283,7 @@ func TestSharedPollManager_TrackKeys_Basic(t *testing.T) {
 	node := newTestNodeWithControllableBroker(t, broker, opts)
 	m := node.sharedPollManager
 
-	results, err := m.trackKeys("test:channel", opts, []string{"key1", "key2", "key3"})
+	results, _, err := m.trackKeys("test:channel", opts, []string{"key1", "key2", "key3"})
 	require.NoError(t, err)
 	require.Len(t, results, 3)
 
@@ -2307,12 +2328,12 @@ func TestSharedPollManager_TrackKeys_MixedNewAndExisting(t *testing.T) {
 	m := node.sharedPollManager
 
 	// Pre-track key1.
-	_, _, err := m.track("test:channel", opts, "key1")
+	_, _, _, err := m.track("test:channel", opts, "key1")
 	require.NoError(t, err)
 	require.Equal(t, int32(1), broker.subscribeCount.Load())
 
 	// Batch track: key1 (existing) + key2, key3 (new).
-	results, err := m.trackKeys("test:channel", opts, []string{"key1", "key2", "key3"})
+	results, _, err := m.trackKeys("test:channel", opts, []string{"key1", "key2", "key3"})
 	require.NoError(t, err)
 	require.Len(t, results, 3)
 
@@ -2336,7 +2357,7 @@ func TestSharedPollManager_TrackKeys_NoPublishEnabled(t *testing.T) {
 	node := newTestNodeWithControllableBroker(t, broker, opts)
 	m := node.sharedPollManager
 
-	results, err := m.trackKeys("test:channel", opts, []string{"key1", "key2"})
+	results, _, err := m.trackKeys("test:channel", opts, []string{"key1", "key2"})
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 	require.True(t, results[0].isNew)
@@ -2357,7 +2378,7 @@ func TestSharedPollManager_TrackKeys_SubscribeFailureCleanup(t *testing.T) {
 	node := newTestNodeWithControllableBroker(t, broker, opts)
 	m := node.sharedPollManager
 
-	results, err := m.trackKeys("test:channel", opts, []string{"key1", "key2"})
+	results, _, err := m.trackKeys("test:channel", opts, []string{"key1", "key2"})
 	require.Error(t, err)
 	require.Nil(t, results)
 
@@ -2392,11 +2413,11 @@ func TestSharedPollManager_TrackKeys_SubscribeFailurePartialCleanup(t *testing.T
 	m := node.sharedPollManager
 
 	// Pre-track key0 — succeeds.
-	_, _, err := m.track("test:channel", opts, "key0")
+	_, _, _, err := m.track("test:channel", opts, "key0")
 	require.NoError(t, err)
 
 	// Batch track key1+key2 — broker fails.
-	results, err := m.trackKeys("test:channel", opts, []string{"key1", "key2"})
+	results, _, err := m.trackKeys("test:channel", opts, []string{"key1", "key2"})
 	require.Error(t, err)
 	require.Nil(t, results)
 
@@ -2428,7 +2449,7 @@ func TestSharedPollManager_TrackKeys_DuplicateKeys(t *testing.T) {
 	m := node.sharedPollManager
 
 	// Track with duplicates.
-	results, err := m.trackKeys("test:channel", opts, []string{"key1", "key1", "key2"})
+	results, _, err := m.trackKeys("test:channel", opts, []string{"key1", "key1", "key2"})
 	require.NoError(t, err)
 	require.Len(t, results, 3)
 
@@ -2459,11 +2480,11 @@ func TestSharedPollManager_TrackKeys_Empty(t *testing.T) {
 	node := newTestNodeWithControllableBroker(t, broker, opts)
 	m := node.sharedPollManager
 
-	results, err := m.trackKeys("test:channel", opts, nil)
+	results, _, err := m.trackKeys("test:channel", opts, nil)
 	require.NoError(t, err)
 	require.Nil(t, results)
 
-	results, err = m.trackKeys("test:channel", opts, []string{})
+	results, _, err = m.trackKeys("test:channel", opts, []string{})
 	require.NoError(t, err)
 	require.Nil(t, results)
 
@@ -2492,11 +2513,11 @@ func TestSharedPollManager_TrackKeys_ConcurrentBatch(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		_, _ = m.trackKeys("test:channel", opts, []string{"a1", "a2", "a3"})
+		_, _, _ = m.trackKeys("test:channel", opts, []string{"a1", "a2", "a3"})
 	}()
 	go func() {
 		defer wg.Done()
-		_, _ = m.trackKeys("test:channel", opts, []string{"b1", "b2", "b3"})
+		_, _, _ = m.trackKeys("test:channel", opts, []string{"b1", "b2", "b3"})
 	}()
 	wg.Wait()
 
@@ -2620,12 +2641,18 @@ func TestSharedPoll_Publish_VersionlessRejected(t *testing.T) {
 	require.Contains(t, err.Error(), "versionless")
 }
 
-// TestSharedPoll_Publish_LocalOnly covers the "channel not active, no broker"
-// path of publish — falls through to handlePublishedData (which then early-returns
-// since the channel isn't tracked).
+// TestSharedPoll_Publish_LocalOnly covers the "channel configured for local
+// delivery, no track yet" path of publish — versioned + !PublishEnabled
+// routes to handlePublishedData, which early-returns when no channel state
+// exists.
 func TestSharedPoll_Publish_LocalOnly(t *testing.T) {
 	t.Parallel()
-	node := newTestNodeWithSharedPoll(t)
+	node := newTestNodeWithSharedPoll(t, SharedPollChannelOptions{
+		Mode:                 SharedPollModeVersioned,
+		RefreshInterval:      30 * time.Second,
+		RefreshBatchSize:     100,
+		MaxKeysPerConnection: 100,
+	})
 	require.NoError(t, node.sharedPollManager.publish(
 		context.Background(), "never-seen", "k", 1, "ep", []byte(`{}`),
 	))
@@ -2697,12 +2724,12 @@ func TestSharedPoll_Track_AfterShutdown(t *testing.T) {
 	node.sharedPollManager.close()
 
 	// Subsequent track / trackKeys calls must hit the shutdown-guard early return.
-	isNew, ver, err := node.sharedPollManager.track("test:channel", opts, "k")
+	isNew, ver, _, err := node.sharedPollManager.track("test:channel", opts, "k")
 	require.NoError(t, err)
 	require.False(t, isNew)
 	require.Equal(t, uint64(0), ver)
 
-	results, err := node.sharedPollManager.trackKeys("test:channel", opts, []string{"k1", "k2"})
+	results, _, err := node.sharedPollManager.trackKeys("test:channel", opts, []string{"k1", "k2"})
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 	for _, r := range results {
@@ -2756,11 +2783,14 @@ func TestSharedPollManager_ShutdownRetrackChaos(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			key := "k" + string(rune('0'+i%8)) // small key set => high reuse rate
-			_, _, _ = m.track(channel, opts, key)
+			_, _, release, _ := m.track(channel, opts, key)
 			// Notify can race with shutdown; the lock ordering in notify()
 			// must prevent sending on a dead notifCh.
 			m.notify(channel, key)
 			m.untrack(channel, key)
+			release() // drop pendingHubJoin reservation; untrack above is
+			// a no-op while pending>0, so release is what actually
+			// triggers entry cleanup in this test (no hub join).
 		}(i)
 	}
 	wg.Wait()

--- a/shared_poll_test.go
+++ b/shared_poll_test.go
@@ -1884,9 +1884,15 @@ func TestSharedPollManager_BrokerSubscribeFailureCleanup(t *testing.T) {
 func TestSharedPollManager_BrokerSubscribeFailureNoOrphanConcurrent(t *testing.T) {
 	t.Parallel()
 	// Scenario: goroutine A creates channel, starts broker.Subscribe (which blocks).
-	// Goroutine B arrives, sees existing channel, adds its own key.
-	// A's broker.Subscribe fails. A should NOT tear down the channel because B's
-	// key is still there.
+	// Goroutine B arrives concurrently and tracks a different key on the same
+	// channel. A's broker.Subscribe fails. A should NOT tear down the channel
+	// because B's key is still there.
+	//
+	// Note: broker.Subscribe and broker.Unsubscribe for the same base channel are
+	// serialized via the per-channel sharded sub-lock (matches the normal
+	// subscription pattern). B's track therefore waits until A's broker.Subscribe
+	// returns; both goroutines are launched before unblocking A so the
+	// concurrent-track race condition is still exercised.
 	blockCh := make(chan struct{})
 	var callCount atomic.Int32
 	broker := &controllableBroker{
@@ -1921,16 +1927,25 @@ func TestSharedPollManager_BrokerSubscribeFailureNoOrphanConcurrent(t *testing.T
 		return broker.subscribeCount.Load() >= 1
 	}, time.Second, time.Millisecond)
 
-	// Goroutine B: track key2 on same channel (won't call broker.Subscribe because
-	// isNewChannel is false for B).
-	isNew2, _, _, err2 := m.track("test:channel", opts, "key2")
-	require.NoError(t, err2)
-	require.True(t, isNew2)
+	// Goroutine B: track key2 on the same channel. With the per-channel
+	// sharded lock, B parks on subLock until A's subscribe returns. Run B in
+	// its own goroutine so we can close(blockCh) below.
+	var isNew2 bool
+	var err2 error
+	var bDone sync.WaitGroup
+	bDone.Add(1)
+	go func() {
+		defer bDone.Done()
+		isNew2, _, _, err2 = m.track("test:channel", opts, "key2")
+	}()
 
-	// Unblock A (will fail).
+	// Unblock A (will fail) — B then proceeds and succeeds.
 	close(blockCh)
 	aDone.Wait()
 	require.Error(t, aErr)
+	bDone.Wait()
+	require.NoError(t, err2)
+	require.True(t, isNew2)
 
 	// Channel should still exist because key2 is there.
 	m.mu.RLock()
@@ -2817,6 +2832,132 @@ func TestSharedPollManager_ShutdownRetrackChaos(t *testing.T) {
 	// m.channels, close() can't reach it and m.wg.Wait blocks forever.
 	// The t.Cleanup-driven Shutdown thus serves as the leak detector;
 	// the test framework's overall timeout will catch the regression.
+}
+
+// TestSharedPollManager_DeferredUnsubRaceWithRetrack reproduces the race
+// where a deferred broker.Unsubscribe (queued when the last tracker for a key
+// went away) clobbers a concurrent broker.Subscribe issued by a fresh retrack
+// of the same key.
+//
+// The deferred unsubscribe runs inside subDissolver. Without serialization,
+// the body
+//
+//	(1) filters keys under s.mu (finds key absent, marks it for unsub),
+//	(2) releases s.mu,
+//	(3) calls broker.Unsubscribe(kc),
+//	(4) deletes brokerSubChans[kc].
+//
+// A concurrent track of the same key can land between (2) and (3): it
+// installs a fresh entry in s.itemIndex, calls broker.Subscribe(kc), and
+// writes brokerSubChans[kc] = broker. Then step (3) reaches the broker —
+// unsubscribing the freshly subscribed client — and step (4) wipes the local
+// tracking. Result: itemIndex has the key and the client is in the hub, but
+// the broker no longer pushes cross-node publications for it. Silent miss.
+//
+// Test setup: broker.Unsubscribe is blocked via a hook. We track + release a
+// key (which enqueues the deferred unsub), wait for the dissolver worker to
+// enter Unsubscribe, then retrack the same key from another goroutine. After
+// unblocking the unsubscribe, the broker must still be subscribed for the
+// key — otherwise cross-node delivery is broken.
+//
+// Expected: after the fix, brokerSubChans[kc] is populated when activity
+// settles. Pre-fix, the deferred Unsubscribe's brokerSubChans delete wins
+// and the entry is missing.
+func TestSharedPollManager_DeferredUnsubRaceWithRetrack(t *testing.T) {
+	t.Parallel()
+
+	unsubBlock := make(chan struct{})
+	unsubStarted := make(chan struct{})
+	var startedOnce sync.Once
+
+	broker := &controllableBroker{
+		unsubscribeFunc: func(ch string) error {
+			startedOnce.Do(func() { close(unsubStarted) })
+			<-unsubBlock
+			return nil
+		},
+	}
+
+	opts := SharedPollChannelOptions{
+		RefreshInterval:      time.Hour,
+		MaxKeysPerConnection: 100,
+		PublishEnabled:       true,
+		// Push channel shutdown well outside the test window so the
+		// finalize-shutdown path doesn't queue extra broker work.
+		ChannelShutdownDelay: 30 * time.Second,
+	}
+	node := newTestNodeWithControllableBroker(t, broker, opts)
+	m := node.sharedPollManager
+
+	channel := "test:b1race"
+	key := "k1"
+	keyCh := sharedPollKeyChannel(channel, key)
+
+	// Initial track. release() drops the pendingHubJoin reservation; since
+	// no hub-join happens in this test, release also tears down the entry
+	// and enqueues the deferred broker.Unsubscribe.
+	_, _, release1, err := m.track(channel, opts, key)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), broker.subscribeCount.Load())
+	m.untrack(channel, key) // no-op while pending>0
+	release1()
+
+	// Wait until the dissolver worker has entered broker.Unsubscribe and
+	// is blocked on unsubBlock — the race window we want to exercise.
+	select {
+	case <-unsubStarted:
+	case <-time.After(2 * time.Second):
+		close(unsubBlock) // avoid hanging the worker
+		t.Fatal("dissolver never entered broker.Unsubscribe")
+	}
+
+	// Retrack the same key from another goroutine. With the fix, this
+	// blocks on the per-channel sub-lock until the deferred unsubscribe
+	// completes. Without the fix, it races ahead and registers the broker
+	// subscription that the pending unsubscribe will then clobber.
+	retrackDone := make(chan struct{})
+	var retrackErr error
+	var release2 func()
+	go func() {
+		defer close(retrackDone)
+		_, _, rel, e := m.track(channel, opts, key)
+		retrackErr = e
+		release2 = rel
+	}()
+
+	// Give the retrack a moment to run (no fix path) or to park on the
+	// sub-lock (fix path). Either way, we then unblock the deferred unsub
+	// so all in-flight broker calls drain.
+	time.Sleep(50 * time.Millisecond)
+	close(unsubBlock)
+
+	select {
+	case <-retrackDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("retrack did not complete after unblocking broker.Unsubscribe")
+	}
+	require.NoError(t, retrackErr)
+
+	// After all activity settles, the broker MUST be subscribed for kc:
+	// the most recent operation on this key was a successful track, and no
+	// untrack has occurred since. With the bug, the deferred Unsubscribe's
+	// brokerSubChans delete wins and the entry is missing — cross-node
+	// publications silently bypass this node's subscribers.
+	require.Eventually(t, func() bool {
+		m.brokerSubMu.RLock()
+		_, has := m.brokerSubChans[keyCh]
+		m.brokerSubMu.RUnlock()
+		return has
+	}, 1*time.Second, 5*time.Millisecond,
+		"deferred broker.Unsubscribe clobbered the re-tracked client's "+
+			"broker subscription; brokerSubChans has no entry for the "+
+			"re-tracked key, breaking cross-node publication delivery")
+
+	// Cleanup: drop the retrack reservation.
+	if release2 != nil {
+		m.untrack(channel, key)
+		release2()
+	}
 }
 
 // TestSharedPoll_Stats covers the stats() helper.


### PR DESCRIPTION
A bundle of correctness fixes surfaced by a closer audit of the keyed / shared-poll / map-broker stack, plus two unrelated bugs in `channel_medium` and `recovery.MergePublications`. Each fix ships with a regression test.

## Changes

### 1. Recovery: index-out-of-range in `MergePublications` (`internal/recovery/helpers.go`)

`MergePublications` dereferenced `recoveredPubs[0]` after `uniqueNonFilteredPublications` could strip the slice empty (all buffered pubs marked filtered, `Time == -1`, no broker pubs). Fix: run `uniqueNonFilteredPublications` unconditionally and guard the gap check with `len(recoveredPubs) > 1`.

Reachable when a recovery + tagsFilter subscription's buffered window only saw filtered pubs.

Covered by `TestMergePublications_AllBufferedFiltered_NoBrokerPubs` and `TestMergePublications_AllBufferedFiltered_WithBrokerPubs`.

### 2. `channelMedium.close()` writer-goroutine leak (`channel_medium.go`)

`close()` signalled `closeCh` but never closed `c.messages`. The writer goroutine sits in `publicationQueue.Wait` (sync.Cond) on an empty queue and only wakes on an Add or queue Close — `closeCh` is only checked inside the unreachable timer branch. Result: one leaked goroutine per channelMedium lifecycle on any server using queued/delayed medium options.

Fix: call `c.messages.Close()` in `close()` so Wait returns and the goroutine exits.

Covered by `TestChannelMediumCloseStopsWriterGoroutine`.

### 3. Join/Leave wire ordering (`client.go`, `client_map.go`)

`publishJoinAndPresence` was spawned in a goroutine from `handleSubscribe`, `connectCmd`, and the map subscribe path. A quick client disconnect's synchronous `publishLeave` (from close → unsubscribe) could win the race to the broker, leaving observers with `[leave, join]` on the wire and corrupting any membership state derived from join/leave events.

Fix: call `publishJoinAndPresence` / `publishJoin` synchronously so it reaches the broker before the subscribe path returns.

### 4. Keyed-channel hub orphan race (`keyed.go`, `shared_poll.go`, `client_keyed.go`)

A new client's `handleTrack` could run concurrently with `finalizeShutdown` of an older `sharedPollChannelState` for the same channel:

- old non-atomic flow: `getOrCreateChannel` → `hub.addSubscriber` → (shutdown runs in between) → `removeChannel` deletes the freshly created state → broadcasts via `getHub` no longer reach the new subscriber.

Fix:
- `keyedManager.addSubscribers(channel, keys, c, opts)` performs ensure-state-then-add atomically under `m.mu`.
- `keyedManager.removeChannelIfEmpty(channel)` replaces the unconditional `removeChannel` call inside `finalizeShutdown`, so a state populated by a racing `addSubscribers` is not torn down.
- `handleTrack` switches to `addSubscribers` and snapshots `warmCachedData` **after** the subscribe (so a publish landing in the gap reaches the client via the hub instead of being silently shadowed by a stale snapshot + version filter).

### 5. Keyed delta version safety + race-free wire ordering (`hub.go`, `shared_poll.go`, `client_keyed.go`)

`preparedData` gains `keyedDeltaPrevVersion` (the entry's version *before* the publish, i.e., the version of the bytes the patch is built against). `buildPreparedPollData`, `handlePublishedData`, and `applyRefreshResponse` all thread it through.

`keyedWritePublication` was restructured into three phases:

1. Lock → snapshot tentative state, unlock.
2. Encode FULL and (if applicable) DELTA outside the lock — encoding can JSON-escape large payloads or build delta frames; keeping it lock-free avoids stalling other client operations.
3. Lock → re-check version, decide delta-vs-full, enqueue, advance state, unlock.

Two correctness properties this restores:

- **Delta safety**: delta is only sent when `keyState.version == prep.keyedDeltaPrevVersion`. Otherwise the client's base bytes don't match the patch's base and applying it would yield garbage — fall back to the pre-encoded FULL.
- **Causal wire order**: the version re-check + enqueue + state update share a single critical section, so a slow-encoding older broadcast cannot land on the wire ahead of a fast-encoding newer one for the same key.

State (`keyState.version`, `keyState.deltaReady`) is updated only after a successful enqueue — if encode fails or the queue rejects the write, state stays unchanged, so subsequent broadcasts aren't silently filtered out.

### 6. Inline-untrack slot accounting (`client_keyed.go`)

The optimistic and re-checked `maxTrackedPerConnection` limit counted incoming new keys but didn't credit back already-tracked keys that the same request would remove via `inlineUntrackSet`. Result: a request that simultaneously removed N keys and added N new ones could falsely return `ErrorLimitExceeded`. Both check sites now subtract `inlineRemovedExisting`.

### 7. Memory map broker CAS parity with Redis (`map_broker_memory.go`)

`mapHub.remove` short-circuited on missing channel/key to `SuppressReasonKeyNotFound`, ignoring `ExpectedPosition`. The Redis Lua (`map_broker_add.lua`) returns `position_mismatch` for the same input (`is_leave=1` with `expected_offset` set, key missing). SDKs that branch on `PositionMismatch` to drive optimistic-concurrency retry would behave differently across brokers.

Fix: when `ExpectedPosition != nil` and the channel/key is absent, return `SuppressReasonPositionMismatch`. The `KeyNotFound` path stays for the no-CAS case.

Covered by `TestMemoryMapBroker_CAS_RemoveMissingKey`