### PR TITLE
Flag to force recovery during subscribe

### DIFF
--- a/client.go
+++ b/client.go
@@ -3476,13 +3476,17 @@ func (c *Client) subscribeCmd(req *protocol.SubscribeRequest, reply SubscribeRep
 			res.Recoverable = true
 		}
 
-		if reply.Options.EnableRecovery && req.Recover {
+		// Recovery is attempted either when the client itself asked for it (req.Recover)
+		// or when the server forces it via SubscribeOptions.Recover (e.g. for server-side
+		// subscriptions of unidirectional clients, or to always deliver the latest
+		// publication in cache recovery mode without a client-provided position).
+		if reply.Options.EnableRecovery && (req.Recover || reply.Options.Recover) {
 			cmdOffset := req.Offset
 			cmdEpoch := req.Epoch
 			recoveryMode := reply.Options.RecoveryMode
 
-			// Client provided subscribe request with recover flag on. Try to recover missed
-			// publications automatically from history (we assume here that the history configured wisely).
+			// Try to recover missed publications automatically from history (we assume here
+			// that the history configured wisely).
 
 			if recoveryMode == RecoveryModeCache {
 				var latestPub *Publication
@@ -3628,7 +3632,12 @@ func (c *Client) subscribeCmd(req *protocol.SubscribeRequest, reply SubscribeRep
 		// Valid stream position will be then caught up upon processing publications.
 		res.Offset = req.Offset
 	}
-	res.WasRecovering = req.Recover
+	// WasRecovering reflects whether a recovery attempt was made for this subscription –
+	// either requested by the client (req.Recover) or forced by the server via
+	// SubscribeOptions.Recover. This keeps the documented invariant that Recovered can only
+	// be true when WasRecovering is true, and makes a server-forced recovery look the same to
+	// the client as a client-initiated one.
+	res.WasRecovering = req.Recover || (reply.Options.EnableRecovery && reply.Options.Recover)
 
 	// Append publications from subscribe reply (e.g., initial full state).
 	if len(reply.Publications) > 0 && len(res.Publications) == 0 {

--- a/client_test.go
+++ b/client_test.go
@@ -1249,6 +1249,183 @@ func TestServerSideSubscriptions(t *testing.T) {
 	}
 }
 
+func TestServerSideSubscriptionServerInitiatedCacheRecovery(t *testing.T) {
+	// A server-side subscription with EnableRecovery + RecoveryModeCache + Recover
+	// must deliver the latest publication on connect even though the client does not
+	// send any recover flag/position itself (e.g. a unidirectional client which does
+	// not know channels at all). See https://github.com/centrifugal/centrifugo/issues/1156.
+	t.Parallel()
+	node := defaultTestNode()
+	defer func() { _ = node.Shutdown(context.Background()) }()
+
+	const channel = "server-side-cache"
+
+	node.OnConnecting(func(context.Context, ConnectEvent) (ConnectReply, error) {
+		return ConnectReply{
+			Subscriptions: map[string]SubscribeOptions{
+				channel: {
+					EnableRecovery: true,
+					RecoveryMode:   RecoveryModeCache,
+					Recover:        true,
+				},
+			},
+		}, nil
+	})
+
+	// Populate channel history with the latest publication before client connects.
+	_, err := node.Publish(channel, []byte(`{"input": "latest"}`), WithHistory(1, time.Minute))
+	require.NoError(t, err)
+
+	transport := newTestTransport(func() {})
+	ctx := SetCredentials(context.Background(), &Credentials{UserID: "42"})
+	client, _ := newClient(ctx, node, transport)
+
+	rwWrapper := testReplyWriterWrapper()
+	// Note: no Subs in the connect request - the client does not request recovery.
+	err = client.connectCmd(&protocol.ConnectRequest{}, &protocol.Command{}, time.Now(), rwWrapper.rw)
+	require.NoError(t, err)
+
+	result := extractConnectReply(rwWrapper.replies)
+	require.Contains(t, result.Subs, channel)
+	subResult := result.Subs[channel]
+	require.True(t, subResult.Recoverable)
+	require.True(t, subResult.Recovered, "server-side subscription must be recovered without client recover request")
+	require.True(t, subResult.WasRecovering, "forced recovery must report was_recovering so the recovered=>was_recovering invariant holds")
+	require.Len(t, subResult.Publications, 1)
+	require.Equal(t, `{"input": "latest"}`, string(subResult.Publications[0].Data))
+}
+
+func TestServerSideSubscriptionForcedCacheRecoveryEmpty(t *testing.T) {
+	// Forced recovery on an empty cache must not deliver publications and must report
+	// recovered=false (but still was_recovering=true).
+	t.Parallel()
+	node := defaultTestNode()
+	defer func() { _ = node.Shutdown(context.Background()) }()
+
+	const channel = "server-side-cache-empty"
+
+	node.OnConnecting(func(context.Context, ConnectEvent) (ConnectReply, error) {
+		return ConnectReply{
+			Subscriptions: map[string]SubscribeOptions{
+				channel: {
+					EnableRecovery: true,
+					RecoveryMode:   RecoveryModeCache,
+					Recover:        true,
+				},
+			},
+		}, nil
+	})
+
+	transport := newTestTransport(func() {})
+	ctx := SetCredentials(context.Background(), &Credentials{UserID: "42"})
+	client, _ := newClient(ctx, node, transport)
+
+	rwWrapper := testReplyWriterWrapper()
+	err := client.connectCmd(&protocol.ConnectRequest{}, &protocol.Command{}, time.Now(), rwWrapper.rw)
+	require.NoError(t, err)
+
+	result := extractConnectReply(rwWrapper.replies)
+	require.Contains(t, result.Subs, channel)
+	subResult := result.Subs[channel]
+	require.True(t, subResult.Recoverable)
+	require.False(t, subResult.Recovered)
+	require.True(t, subResult.WasRecovering)
+	require.Empty(t, subResult.Publications)
+}
+
+func TestClientSubscribeForcedStreamRecovery(t *testing.T) {
+	// Forced recovery (Recover option) also works in stream mode where it behaves like a
+	// client subscribing with an empty `since`: it recovers from the beginning of the
+	// available history. This is why Centrifugo only auto-enables forced recovery in cache
+	// mode - in stream mode it would replay the whole history.
+	t.Parallel()
+	node := defaultTestNode()
+	defer func() { _ = node.Shutdown(context.Background()) }()
+
+	const channel = "test-stream"
+
+	node.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
+			cb(SubscribeReply{
+				Options: SubscribeOptions{
+					EnableRecovery:    true,
+					RecoveryMode:      RecoveryModeStream,
+					EnablePositioning: true,
+					Recover:           true,
+				},
+			}, nil)
+		})
+	})
+
+	for i := 0; i < 3; i++ {
+		_, err := node.Publish(channel, []byte(`{"input": "msg"}`), WithHistory(10, time.Minute))
+		require.NoError(t, err)
+	}
+
+	client := newTestClient(t, node, "42")
+	connectClientV2(t, client)
+
+	rwWrapper := testReplyWriterWrapper()
+	// Note: no Recover flag and no position in the subscribe request.
+	err := client.handleSubscribe(&protocol.SubscribeRequest{
+		Channel: channel,
+	}, &protocol.Command{Id: 1}, time.Now(), rwWrapper.rw)
+	require.NoError(t, err)
+
+	result := rwWrapper.replies[0].Subscribe
+	require.NotNil(t, result)
+	require.True(t, result.Recovered)
+	require.True(t, result.WasRecovering)
+	require.Len(t, result.Publications, 3, "stream forced recovery delivers the whole available history")
+}
+
+func TestClientSubscribeForcedCacheRecovery(t *testing.T) {
+	// A client-side subscription with EnableRecovery + RecoveryModeCache + Recover must
+	// deliver the latest publication even though the client did not set the recover flag
+	// (i.e. did not provide an empty `since`). See
+	// https://github.com/centrifugal/centrifugo/issues/1156.
+	t.Parallel()
+	node := defaultTestNode()
+	defer func() { _ = node.Shutdown(context.Background()) }()
+
+	const channel = "test"
+
+	node.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
+			cb(SubscribeReply{
+				Options: SubscribeOptions{
+					EnableRecovery:    true,
+					RecoveryMode:      RecoveryModeCache,
+					EnablePositioning: true,
+					Recover:           true,
+				},
+			}, nil)
+		})
+	})
+
+	_, err := node.Publish(channel, []byte(`{"input": "latest"}`), WithHistory(1, time.Minute))
+	require.NoError(t, err)
+
+	client := newTestClient(t, node, "42")
+	connectClientV2(t, client)
+
+	rwWrapper := testReplyWriterWrapper()
+	// Note: no Recover flag in the subscribe request.
+	err = client.handleSubscribe(&protocol.SubscribeRequest{
+		Channel: channel,
+	}, &protocol.Command{Id: 1}, time.Now(), rwWrapper.rw)
+	require.NoError(t, err)
+
+	require.True(t, len(rwWrapper.replies) > 0)
+	result := rwWrapper.replies[0].Subscribe
+	require.NotNil(t, result)
+	require.True(t, result.Recoverable)
+	require.True(t, result.Recovered, "subscription must be recovered without client recover request")
+	require.True(t, result.WasRecovering, "forced recovery must report was_recovering")
+	require.Len(t, result.Publications, 1)
+	require.Equal(t, `{"input": "latest"}`, string(result.Publications[0].Data))
+}
+
 func TestClientRefresh(t *testing.T) {
 	t.Parallel()
 	node := defaultTestNode()

--- a/options.go
+++ b/options.go
@@ -177,6 +177,18 @@ type SubscribeOptions struct {
 	Data []byte
 	// RecoverSince will try to subscribe a client and recover from a certain StreamPosition.
 	RecoverSince *StreamPosition
+	// Recover, when set, makes Centrifuge initiate recovery for a subscription even if the
+	// client did not request it (i.e. without a recover flag/position in the subscribe
+	// request). It applies to both client-initiated and server-side subscriptions and
+	// requires EnableRecovery to be set. Recovery starts from an empty StreamPosition: in
+	// cache recovery mode (RecoveryModeCache) this delivers the latest publication on each
+	// (re)subscribe, which is especially useful for unidirectional clients with server-side
+	// subscriptions that can't request recovery themselves, or to avoid requiring an empty
+	// "since" on the client. In stream recovery mode an empty position means recovery from
+	// the beginning of the available history, so prefer RecoverSince to recover from a
+	// specific position. The option applies to stream and cache subscriptions and is ignored
+	// for map subscriptions.
+	Recover bool
 
 	// HistoryMetaTTL allows to override default (set in Config.HistoryMetaTTL) history
 	// meta information expiration time.
@@ -339,6 +351,15 @@ func WithSubscribeData(data []byte) SubscribeOption {
 func WithRecoverSince(since *StreamPosition) SubscribeOption {
 	return func(opts *SubscribeOptions) {
 		opts.RecoverSince = since
+	}
+}
+
+// WithRecover allows setting SubscribeOptions.Recover. It makes Centrifuge initiate
+// recovery for a subscription even if the client did not request it. See
+// SubscribeOptions.Recover for details.
+func WithRecover(enabled bool) SubscribeOption {
+	return func(opts *SubscribeOptions) {
+		opts.Recover = enabled
 	}
 }
 


### PR DESCRIPTION
Adds a new `SubscribeOptions.Recover` boolean (with a `WithRecover` option helper) that lets the server initiate recovery for a subscription **even when the client did not request it** — i.e. without a `recover` flag / `StreamPosition` in the subscribe request.

This is the missing primitive needed to support cache recovery for subscriptions where the client can't ask for recovery itself:

- **Server-side subscriptions of unidirectional clients** (SSE, HTTP-streaming, unidirectional WebSocket). Such clients only send a token, may not even know channel names, and have no protocol way to attach `recover: true` / `since`.
- **Avoiding the empty `since`** requirement in cache recovery mode — today a client must subscribe with an empty `since` (which the SDK turns into `recover: true` with an empty position) just to receive the latest publication.

Downstream motivation: [centrifugal/centrifugo#1156](https://github.com/centrifugal/centrifugo/issues/1156).

## API

```go
type SubscribeOptions struct {
    // ...
    // Recover, when set, makes Centrifuge initiate recovery for a subscription even if the
    // client did not request it. Applies to both client-initiated and server-side
    // subscriptions and requires EnableRecovery. Recovery starts from an empty
    // StreamPosition: in cache recovery mode this delivers the latest publication on each
    // (re)subscribe. In stream recovery mode an empty position means recovery from the
    // beginning of available history, so prefer RecoverSince for a specific position.
    // Ignored for map subscriptions.
    Recover bool
}

// WithRecover sets SubscribeOptions.Recover.
func WithRecover(enabled bool) SubscribeOption
```

## Behavior

The single behavioral change is in `subscribeCmd`. The recovery trigger:

```go
// before
if reply.Options.EnableRecovery && req.Recover {

// after
if reply.Options.EnableRecovery && (req.Recover || reply.Options.Recover) {
```

When recovery is forced via `Recover` and the client provided no position (`req.Offset == 0`, `req.Epoch == ""`), the behavior is identical to a client subscribing with an empty `since`:

- **Cache mode** (`RecoveryModeCache`): delivers the latest publication; `recovered == true` when a latest publication exists, `false` (and no publications) when the cache is empty.
- **Stream mode** (`RecoveryModeStream`): recovers from the beginning of available history (same as a client `since: {}`). This can replay the whole history, so `RecoverSince` is the right tool when a specific position is desired.

`WasRecovering` now reflects forced recovery as well:

```go
res.WasRecovering = req.Recover || (reply.Options.EnableRecovery && reply.Options.Recover)
```

This preserves the documented invariant that `Recovered` can only be `true` when `WasRecovering` is `true`, and makes a server-forced recovery look the same to the client as a client-initiated one.

## Backward compatibility

Fully backward compatible:

- `Recover` defaults to `false`; existing subscriptions are unaffected.
- The change only adds the `reply.Options.Recover` term to the recovery condition — when it's `false` the condition is exactly as before.
- `Recover` is a no-op without `EnableRecovery`.
- Map subscriptions do not honor `Recover` (recovery there continues to key off `req.Recover` only).
