### PR TITLE
Rename `SubscribeOptions.Recover` → `AutoCacheRecover` and scope it to cache recovery mode

### DIFF
--- a/client.go
+++ b/client.go
@@ -3460,6 +3460,15 @@ func (c *Client) subscribeCmd(req *protocol.SubscribeRequest, reply SubscribeRep
 		maxSeenOffset uint64
 	)
 
+	// autoCacheRecover reflects server-forced cache recovery via SubscribeOptions.AutoCacheRecover
+	// (no client position). It only applies in cache recovery mode, where it delivers the latest
+	// publication regardless of position. In stream recovery mode it is intentionally ignored:
+	// forcing recovery without a position can't preserve continuity, and delivering history
+	// there would break the "recovered=false implies no publications" contract. Stream
+	// subscriptions that want to recover from a specific position must use req.Recover (client)
+	// or SubscribeOptions.RecoverSince (server).
+	autoCacheRecover := reply.Options.AutoCacheRecover && reply.Options.RecoveryMode == RecoveryModeCache
+
 	if reply.Options.EnablePositioning || reply.Options.EnableRecovery {
 		handleErr := func(err error) subscribeContext {
 			c.pubSubSync.StopBuffering(channel)
@@ -3477,10 +3486,10 @@ func (c *Client) subscribeCmd(req *protocol.SubscribeRequest, reply SubscribeRep
 		}
 
 		// Recovery is attempted either when the client itself asked for it (req.Recover)
-		// or when the server forces it via SubscribeOptions.Recover (e.g. for server-side
-		// subscriptions of unidirectional clients, or to always deliver the latest
-		// publication in cache recovery mode without a client-provided position).
-		if reply.Options.EnableRecovery && (req.Recover || reply.Options.Recover) {
+		// or when the server forces it in cache recovery mode via SubscribeOptions.AutoCacheRecover
+		// (e.g. for server-side subscriptions of unidirectional clients, to deliver the latest
+		// publication without a client-provided position).
+		if reply.Options.EnableRecovery && (req.Recover || autoCacheRecover) {
 			cmdOffset := req.Offset
 			cmdEpoch := req.Epoch
 			recoveryMode := reply.Options.RecoveryMode
@@ -3633,11 +3642,11 @@ func (c *Client) subscribeCmd(req *protocol.SubscribeRequest, reply SubscribeRep
 		res.Offset = req.Offset
 	}
 	// WasRecovering reflects whether a recovery attempt was made for this subscription –
-	// either requested by the client (req.Recover) or forced by the server via
-	// SubscribeOptions.Recover. This keeps the documented invariant that Recovered can only
-	// be true when WasRecovering is true, and makes a server-forced recovery look the same to
-	// the client as a client-initiated one.
-	res.WasRecovering = req.Recover || (reply.Options.EnableRecovery && reply.Options.Recover)
+	// either requested by the client (req.Recover) or forced by the server in cache recovery
+	// mode via SubscribeOptions.AutoCacheRecover. This keeps the documented invariant that
+	// Recovered can only be true when WasRecovering is true, and makes a server-forced recovery
+	// look the same to the client as a client-initiated one.
+	res.WasRecovering = req.Recover || (reply.Options.EnableRecovery && autoCacheRecover)
 
 	// Append publications from subscribe reply (e.g., initial full state).
 	if len(reply.Publications) > 0 && len(res.Publications) == 0 {

--- a/client_test.go
+++ b/client_test.go
@@ -1264,9 +1264,9 @@ func TestServerSideSubscriptionServerInitiatedCacheRecovery(t *testing.T) {
 		return ConnectReply{
 			Subscriptions: map[string]SubscribeOptions{
 				channel: {
-					EnableRecovery: true,
-					RecoveryMode:   RecoveryModeCache,
-					Recover:        true,
+					EnableRecovery:   true,
+					RecoveryMode:     RecoveryModeCache,
+					AutoCacheRecover: true,
 				},
 			},
 		}, nil
@@ -1308,9 +1308,9 @@ func TestServerSideSubscriptionForcedCacheRecoveryEmpty(t *testing.T) {
 		return ConnectReply{
 			Subscriptions: map[string]SubscribeOptions{
 				channel: {
-					EnableRecovery: true,
-					RecoveryMode:   RecoveryModeCache,
-					Recover:        true,
+					EnableRecovery:   true,
+					RecoveryMode:     RecoveryModeCache,
+					AutoCacheRecover: true,
 				},
 			},
 		}, nil
@@ -1333,11 +1333,12 @@ func TestServerSideSubscriptionForcedCacheRecoveryEmpty(t *testing.T) {
 	require.Empty(t, subResult.Publications)
 }
 
-func TestClientSubscribeForcedStreamRecovery(t *testing.T) {
-	// Forced recovery (Recover option) also works in stream mode where it behaves like a
-	// client subscribing with an empty `since`: it recovers from the beginning of the
-	// available history. This is why Centrifugo only auto-enables forced recovery in cache
-	// mode - in stream mode it would replay the whole history.
+func TestClientSubscribeForcedRecoveryIgnoredInStream(t *testing.T) {
+	// Forced recovery (SubscribeOptions.Recover) only applies in cache recovery mode. In
+	// stream recovery mode it must be ignored when the client supplies no position: forcing
+	// recovery there can't preserve continuity and would break the "recovered=false implies no
+	// publications" contract. So no recovery is attempted and no history is delivered – the
+	// subscription just starts positioned at the current stream top.
 	t.Parallel()
 	node := defaultTestNode()
 	defer func() { _ = node.Shutdown(context.Background()) }()
@@ -1351,7 +1352,7 @@ func TestClientSubscribeForcedStreamRecovery(t *testing.T) {
 					EnableRecovery:    true,
 					RecoveryMode:      RecoveryModeStream,
 					EnablePositioning: true,
-					Recover:           true,
+					AutoCacheRecover:  true,
 				},
 			}, nil)
 		})
@@ -1374,9 +1375,60 @@ func TestClientSubscribeForcedStreamRecovery(t *testing.T) {
 
 	result := rwWrapper.replies[0].Subscribe
 	require.NotNil(t, result)
-	require.True(t, result.Recovered)
+	require.True(t, result.Recoverable, "positioning is still enabled")
+	require.False(t, result.WasRecovering, "forced recovery must be ignored in stream mode")
+	require.False(t, result.Recovered)
+	require.Empty(t, result.Publications, "no history must be delivered for forced recovery in stream mode")
+	require.Equal(t, uint64(3), result.Offset, "subscription starts at the current stream top")
+}
+
+func TestClientSubscribeStreamClientRecoveryStillWorks(t *testing.T) {
+	// Gating forced recovery to cache mode must not affect normal client-initiated stream
+	// recovery: a client that supplies a position still recovers missed publications.
+	t.Parallel()
+	node := defaultTestNode()
+	defer func() { _ = node.Shutdown(context.Background()) }()
+
+	const channel = "test-stream-client-recovery"
+
+	node.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
+			cb(SubscribeReply{
+				Options: SubscribeOptions{
+					EnableRecovery:    true,
+					RecoveryMode:      RecoveryModeStream,
+					EnablePositioning: true,
+				},
+			}, nil)
+		})
+	})
+
+	res1, err := node.Publish(channel, []byte(`{"n": 1}`), WithHistory(10, time.Minute))
+	require.NoError(t, err)
+	_, err = node.Publish(channel, []byte(`{"n": 2}`), WithHistory(10, time.Minute))
+	require.NoError(t, err)
+	_, err = node.Publish(channel, []byte(`{"n": 3}`), WithHistory(10, time.Minute))
+	require.NoError(t, err)
+
+	client := newTestClient(t, node, "42")
+	connectClientV2(t, client)
+
+	rwWrapper := testReplyWriterWrapper()
+	err = client.handleSubscribe(&protocol.SubscribeRequest{
+		Channel: channel,
+		Recover: true,
+		Offset:  res1.Offset,
+		Epoch:   res1.Epoch,
+	}, &protocol.Command{Id: 1}, time.Now(), rwWrapper.rw)
+	require.NoError(t, err)
+
+	result := rwWrapper.replies[0].Subscribe
+	require.NotNil(t, result)
 	require.True(t, result.WasRecovering)
-	require.Len(t, result.Publications, 3, "stream forced recovery delivers the whole available history")
+	require.True(t, result.Recovered, "client-initiated stream recovery from a position must still work")
+	require.Len(t, result.Publications, 2)
+	require.Equal(t, `{"n": 2}`, string(result.Publications[0].Data))
+	require.Equal(t, `{"n": 3}`, string(result.Publications[1].Data))
 }
 
 func TestClientSubscribeForcedCacheRecovery(t *testing.T) {
@@ -1397,7 +1449,7 @@ func TestClientSubscribeForcedCacheRecovery(t *testing.T) {
 					EnableRecovery:    true,
 					RecoveryMode:      RecoveryModeCache,
 					EnablePositioning: true,
-					Recover:           true,
+					AutoCacheRecover:  true,
 				},
 			}, nil)
 		})
@@ -1746,10 +1798,10 @@ func TestFossilRecoveredMapPubs(t *testing.T) {
 		{Offset: 3, Key: "x", Data: []byte("This is a message for key X: after removal")},
 	})
 	require.Len(t, pubs, 3)
-	require.False(t, pubs[0].Delta)   // first occurrence
-	require.False(t, pubs[1].Delta)   // removal — no delta
-	require.True(t, pubs[1].Removed)  // removed flag preserved
-	require.False(t, pubs[2].Delta)   // after removal — full, not delta
+	require.False(t, pubs[0].Delta)  // first occurrence
+	require.False(t, pubs[1].Delta)  // removal — no delta
+	require.True(t, pubs[1].Removed) // removed flag preserved
+	require.False(t, pubs[2].Delta)  // after removal — full, not delta
 	require.Equal(t, []byte("This is a message for key X: after removal"), []byte(pubs[2].Data))
 
 	// Score field is preserved.

--- a/options.go
+++ b/options.go
@@ -177,18 +177,23 @@ type SubscribeOptions struct {
 	Data []byte
 	// RecoverSince will try to subscribe a client and recover from a certain StreamPosition.
 	RecoverSince *StreamPosition
-	// Recover, when set, makes Centrifuge initiate recovery for a subscription even if the
-	// client did not request it (i.e. without a recover flag/position in the subscribe
-	// request). It applies to both client-initiated and server-side subscriptions and
-	// requires EnableRecovery to be set. Recovery starts from an empty StreamPosition: in
-	// cache recovery mode (RecoveryModeCache) this delivers the latest publication on each
-	// (re)subscribe, which is especially useful for unidirectional clients with server-side
-	// subscriptions that can't request recovery themselves, or to avoid requiring an empty
-	// "since" on the client. In stream recovery mode an empty position means recovery from
-	// the beginning of the available history, so prefer RecoverSince to recover from a
-	// specific position. The option applies to stream and cache subscriptions and is ignored
-	// for map subscriptions.
-	Recover bool
+	// AutoCacheRecover, when set, makes Centrifuge initiate cache recovery for a subscription
+	// even if the client did not request it (i.e. without a recover flag/position in the
+	// subscribe request). It applies to both client-initiated and server-side subscriptions and
+	// requires EnableRecovery to be set.
+	//
+	// AutoCacheRecover only takes effect in cache recovery mode (RecoveryModeCache): there it
+	// delivers the latest publication on each (re)subscribe regardless of position, which is
+	// especially useful for unidirectional clients with server-side subscriptions that can't
+	// request recovery themselves, or to avoid requiring an empty "since" on the client.
+	//
+	// In stream recovery mode AutoCacheRecover is ignored: forcing recovery without a client
+	// position can't preserve continuity (there is no baseline to compare against), and the
+	// cache-style "deliver latest" semantics don't map onto a stream. To recover a stream
+	// subscription use the client recover flag/position, or SubscribeOptions.RecoverSince for a
+	// specific position; to deliver an initial backlog use SubscribeReply.Publications.
+	// AutoCacheRecover is also ignored for map subscriptions.
+	AutoCacheRecover bool
 
 	// HistoryMetaTTL allows to override default (set in Config.HistoryMetaTTL) history
 	// meta information expiration time.
@@ -354,12 +359,12 @@ func WithRecoverSince(since *StreamPosition) SubscribeOption {
 	}
 }
 
-// WithRecover allows setting SubscribeOptions.Recover. It makes Centrifuge initiate
-// recovery for a subscription even if the client did not request it. See
-// SubscribeOptions.Recover for details.
-func WithRecover(enabled bool) SubscribeOption {
+// WithAutoCacheRecover allows setting SubscribeOptions.AutoCacheRecover. It makes Centrifuge
+// initiate cache recovery for a subscription even if the client did not request it. See
+// SubscribeOptions.AutoCacheRecover for details.
+func WithAutoCacheRecover(enabled bool) SubscribeOption {
 	return func(opts *SubscribeOptions) {
-		opts.Recover = enabled
+		opts.AutoCacheRecover = enabled
 	}
 }
 


### PR DESCRIPTION
This PR renames the server-forced recovery option `SubscribeOptions.Recover` to
`SubscribeOptions.AutoCacheRecover` (and `WithRecover` → `WithAutoCacheRecover`), and makes it
take effect **only in cache recovery mode** (`RecoveryModeCache`). In stream recovery mode the
option is now ignored.

The option lets the server initiate recovery for a subscription even when the client did not
request it (no recover flag/position in the subscribe request). Its purpose is to deliver the
latest publication on every (re)subscribe to subscribers that can't ask for recovery
themselves — most importantly **server-side subscriptions of unidirectional clients** (SSE,
HTTP-streaming, unidirectional WebSocket) that may not even know channel names, or to avoid
requiring an empty `since` on bidirectional clients.

## Motivation

The previous `Recover` option triggered forced recovery in **both** recovery modes. That only
makes sense for cache mode. In stream mode, forcing recovery for a subscriber that supplied **no
position** is semantically broken:

- `recovered` in stream mode means "no messages were lost since your position". With no prior
  position there is no baseline, so the flag can't be honestly computed.
- The old behavior leaked an implementation detail: it reported `recovered: true` (and replayed
  the whole window) while the stream had not yet rotated past offset 1, then flipped to
  `recovered: false` with **no** publications once the stream rotated — an outcome the
  application neither controls nor should depend on.
- Either way it conflicts with the established invariant that **`recovered: false` is always
  accompanied by zero publications**, and with the universal client convention "`recovered:
  false` ⇒ reload state from the backend".

Cache mode has none of this tension: there `recovered: true` means "you hold the current latest
value", which is exactly what a forced, position-less recovery delivers. So the option is now
explicitly named and scoped for that case. Delivering an initial backlog for stream
subscriptions should use `SubscribeReply.Publications` instead; recovering a stream from a known
position should use the client recover flag/position or `SubscribeOptions.RecoverSince`.

## Changes

- `SubscribeOptions.Recover` → `SubscribeOptions.AutoCacheRecover`; option helper
  `WithRecover()` → `WithAutoCacheRecover()`. Doc comments updated to describe the cache-only
  semantics.
- `subscribeCmd` computes
  `autoCacheRecover := reply.Options.AutoCacheRecover && reply.Options.RecoveryMode == RecoveryModeCache`
  and uses it both for the recovery trigger and for `WasRecovering`. In stream mode the option
  no longer triggers any recovery.
- The `recovered ⇒ wasRecovering` invariant is preserved.
- The protocol-level `SubscribeRequest.Recover` (the client's own recover flag) is unchanged.

## Behavior change

- **Cache recovery mode:** unchanged — `AutoCacheRecover` delivers the latest publication on
  every (re)subscribe regardless of position (`recovered: true` when a publication exists).
- **Stream recovery mode:** `AutoCacheRecover` is now **ignored**. No recovery is attempted, no
  publications are delivered, and `WasRecovering` is `false`. (Previously it attempted recovery
  with the erratic, rotation-dependent results described above.)
- **Client-initiated recovery** (`req.Recover` with a position) and `RecoverSince` are
  unaffected — stream recovery from a real position works exactly as before.
- Map subscriptions: option ignored, as before.

This is an API rename (`Recover` → `AutoCacheRecover`, `WithRecover` →
`WithAutoCacheRecover`) — callers using the old names must update.

