### PR TITLE
broker metrics: dedicated map_broker subsystem, neutral cleanup names, split suppressed metrics

### DIFF
--- a/broker_redis.go
+++ b/broker_redis.go
@@ -662,6 +662,7 @@ func (b *RedisBroker) runPubSub(s *shardWrapper, logFields map[string]any, event
 		cb,
 		b.node,
 		b.config.Name,
+		b.node.metrics.brokerPubSub,
 		b.config.SubscribeOnReplica,
 		b.config.numPubSubProcessors,
 		b.config.numResubscribeShards,

--- a/map_broker_memory.go
+++ b/map_broker_memory.go
@@ -751,7 +751,7 @@ func (h *mapHub) expireKeysIteration(nextKeyExpireCheck *int64) {
 	}
 
 	if h.node != nil && h.node.metrics != nil && keysRemoved > 0 {
-		h.node.metrics.addMapBrokerCleanupKeysRemoved("", keysRemoved)
+		h.node.metrics.addMapBrokerCleanupRemoved("", keysRemoved)
 	}
 }
 

--- a/map_broker_memory_test.go
+++ b/map_broker_memory_test.go
@@ -2537,7 +2537,7 @@ func TestMemoryMapBroker_CleanupMetrics(t *testing.T) {
 			return false
 		}
 		for _, f := range families {
-			if f.GetName() == "centrifuge_map_broker_cleanup_keys_removed_count" {
+			if f.GetName() == "centrifuge_map_broker_cleanup_removed_total" {
 				for _, m := range f.GetMetric() {
 					if m.GetCounter().GetValue() >= 2 {
 						return true
@@ -2546,7 +2546,7 @@ func TestMemoryMapBroker_CleanupMetrics(t *testing.T) {
 			}
 		}
 		return false
-	}, 5*time.Second, 100*time.Millisecond, "cleanup_keys_removed_count should reach at least 2")
+	}, 5*time.Second, 100*time.Millisecond, "cleanup_removed_total should reach at least 2")
 
 	// Verify lag metric was set (should be >= 0).
 	families, err := registry.Gather()

--- a/map_broker_memory_test.go
+++ b/map_broker_memory_test.go
@@ -2537,7 +2537,7 @@ func TestMemoryMapBroker_CleanupMetrics(t *testing.T) {
 			return false
 		}
 		for _, f := range families {
-			if f.GetName() == "centrifuge_map_broker_cleanup_removed_total" {
+			if f.GetName() == "centrifuge_map_broker_cleanup_removed_count" {
 				for _, m := range f.GetMetric() {
 					if m.GetCounter().GetValue() >= 2 {
 						return true
@@ -2546,7 +2546,7 @@ func TestMemoryMapBroker_CleanupMetrics(t *testing.T) {
 			}
 		}
 		return false
-	}, 5*time.Second, 100*time.Millisecond, "cleanup_removed_total should reach at least 2")
+	}, 5*time.Second, 100*time.Millisecond, "cleanup_removed_count should reach at least 2")
 
 	// Verify lag metric was set (should be >= 0).
 	families, err := registry.Gather()

--- a/map_broker_redis.go
+++ b/map_broker_redis.go
@@ -2765,7 +2765,7 @@ func (e *RedisMapBroker) batchRemoveExpired(ctx context.Context, shard *RedisSha
 	if len(result) > 0 {
 		if removedCount, parseErr := result[0].AsInt64(); parseErr == nil && removedCount > 0 {
 			if e.node.metrics != nil {
-				e.node.metrics.addMapBrokerCleanupKeysRemoved(e.conf.Name, removedCount)
+				e.node.metrics.addMapBrokerCleanupRemoved(e.conf.Name, removedCount)
 			}
 		}
 	}

--- a/map_broker_redis.go
+++ b/map_broker_redis.go
@@ -2803,6 +2803,7 @@ func (e *RedisMapBroker) runPubSub(s *brokerShardWrapper, logFields map[string]a
 		cb,
 		e.node,
 		e.conf.Name,
+		e.node.metrics.mapBrokerPubSub,
 		e.conf.SubscribeOnReplica,
 		e.conf.numPubSubProcessors,
 		e.conf.numResubscribeShards,

--- a/map_broker_redis_test.go
+++ b/map_broker_redis_test.go
@@ -3352,13 +3352,13 @@ func TestRedisMapBroker_CleanupMetrics(t *testing.T) {
 		require.NoError(t, err)
 		var removedCount float64
 		for _, f := range families {
-			if f.GetName() == "centrifuge_map_broker_cleanup_removed_total" {
+			if f.GetName() == "centrifuge_map_broker_cleanup_removed_count" {
 				for _, m := range f.GetMetric() {
 					removedCount += m.GetCounter().GetValue()
 				}
 			}
 		}
-		require.GreaterOrEqual(t, removedCount, float64(2), "cleanup_removed_total should be at least 2")
+		require.GreaterOrEqual(t, removedCount, float64(2), "cleanup_removed_count should be at least 2")
 	})
 }
 

--- a/map_broker_redis_test.go
+++ b/map_broker_redis_test.go
@@ -3352,13 +3352,13 @@ func TestRedisMapBroker_CleanupMetrics(t *testing.T) {
 		require.NoError(t, err)
 		var removedCount float64
 		for _, f := range families {
-			if f.GetName() == "centrifuge_map_broker_cleanup_keys_removed_count" {
+			if f.GetName() == "centrifuge_map_broker_cleanup_removed_total" {
 				for _, m := range f.GetMetric() {
 					removedCount += m.GetCounter().GetValue()
 				}
 			}
 		}
-		require.GreaterOrEqual(t, removedCount, float64(2), "cleanup_keys_removed_count should be at least 2")
+		require.GreaterOrEqual(t, removedCount, float64(2), "cleanup_removed_total should be at least 2")
 	})
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -746,14 +746,14 @@ func newMetricsRegistry(config MetricsConfig) (*metrics, error) {
 	m.mapBrokerCleanupRemoved = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricsNamespace,
 		Subsystem: "map_broker",
-		Name:      "cleanup_removed_total",
+		Name:      "cleanup_removed_count",
 		Help:      "Total number of expired entries removed by cleanup.",
 	}, []string{"broker_name"})
 
 	m.mapBrokerCleanupErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricsNamespace,
 		Subsystem: "map_broker",
-		Name:      "cleanup_errors_total",
+		Name:      "cleanup_errors_count",
 		Help:      "Total number of cleanup errors.",
 	}, []string{"broker_name"})
 

--- a/metrics.go
+++ b/metrics.go
@@ -143,6 +143,12 @@ type metrics struct {
 	redisBrokerPubSubDroppedMessages  *prometheus.CounterVec
 	redisBrokerPubSubBufferedMessages *prometheus.GaugeVec
 
+	// brokerPubSub and mapBrokerPubSub bundle the Redis PUB/SUB metric vectors per
+	// broker kind so the shared pub/sub loop reports under each broker's own
+	// subsystem: broker_* for RedisBroker, map_broker_* for RedisMapBroker.
+	brokerPubSub    redisPubSubMetrics
+	mapBrokerPubSub redisPubSubMetrics
+
 	// Shared poll metrics.
 	sharedPollCycleDurationHistogram     *prometheus.HistogramVec
 	sharedPollCycleWorkDurationHistogram *prometheus.HistogramVec
@@ -851,6 +857,36 @@ func newMetricsRegistry(config MetricsConfig) (*metrics, error) {
 	m.redisBrokerPubSubDroppedMessages.WithLabelValues("", "control").Add(0)
 	m.redisBrokerPubSubDroppedMessages.WithLabelValues("", "client").Add(0)
 
+	m.brokerPubSub = redisPubSubMetrics{
+		errors:   m.redisBrokerPubSubErrors,
+		dropped:  m.redisBrokerPubSubDroppedMessages,
+		buffered: m.redisBrokerPubSubBufferedMessages,
+	}
+
+	// RedisMapBroker reports the same Redis PUB/SUB metrics under its own
+	// map_broker subsystem so its series never collide with the stream broker's.
+	m.mapBrokerPubSub = redisPubSubMetrics{
+		errors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "map_broker",
+			Name:      "redis_pub_sub_errors",
+			Help:      "Number of times there was an error in Redis PUB/SUB connection.",
+		}, []string{"broker_name", "error"}),
+		dropped: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "map_broker",
+			Name:      "redis_pub_sub_dropped_messages",
+			Help:      "Number of dropped messages on application level in Redis PUB/SUB.",
+		}, []string{"broker_name", "channel_type"}),
+		buffered: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "map_broker",
+			Name:      "redis_pub_sub_buffered_messages",
+			Help:      "Number of messages buffered in Redis PUB/SUB.",
+		}, []string{"broker_name", "channel_type", "pub_sub_processor"}),
+	}
+	m.mapBrokerPubSub.dropped.WithLabelValues("", "client").Add(0)
+
 	// Helper to build message labels for node-level broker message metrics
 	// These metrics don't support client labels as they track node-to-broker communication
 	buildMessageLabels := func(msgType string) []string {
@@ -941,6 +977,9 @@ func newMetricsRegistry(config MetricsConfig) (*metrics, error) {
 		m.redisBrokerPubSubErrors,
 		m.redisBrokerPubSubDroppedMessages,
 		m.redisBrokerPubSubBufferedMessages,
+		m.mapBrokerPubSub.errors,
+		m.mapBrokerPubSub.dropped,
+		m.mapBrokerPubSub.buffered,
 		m.sharedPollCycleDurationHistogram,
 		m.sharedPollCycleWorkDurationHistogram,
 		m.sharedPollHandlerDurationHistogram,
@@ -965,6 +1004,19 @@ func newMetricsRegistry(config MetricsConfig) (*metrics, error) {
 	}
 
 	return m, nil
+}
+
+// redisPubSubMetrics bundles the Redis PUB/SUB metric vectors for one broker kind
+// so the shared pub/sub loop (runPubSubLoop) reports under the calling broker's
+// own subsystem — broker_* for RedisBroker, map_broker_* for RedisMapBroker.
+type redisPubSubMetrics struct {
+	errors   *prometheus.CounterVec
+	dropped  *prometheus.CounterVec
+	buffered *prometheus.GaugeVec
+}
+
+func (p redisPubSubMetrics) incErrors(name, errType string) {
+	p.errors.WithLabelValues(name, errType).Inc()
 }
 
 func (m *metrics) incRedisBrokerPubSubErrors(name string, error string) {

--- a/metrics.go
+++ b/metrics.go
@@ -134,7 +134,9 @@ type metrics struct {
 	broadcastDurationHistogram  *prometheus.HistogramVec
 	pubSubLagHistogram          *prometheus.HistogramVec
 	pingPongDurationHistogram   *prometheus.HistogramVec
-	mapPublishSuppressedCount   *prometheus.CounterVec
+	brokerPublishSuppressedCount    *prometheus.CounterVec
+	mapBrokerPublishSuppressedCount *prometheus.CounterVec
+	mapBrokerRemoveSuppressedCount  *prometheus.CounterVec
 	mapBrokerCleanupLag      *prometheus.GaugeVec
 	mapBrokerCleanupRemoved  *prometheus.CounterVec
 	mapBrokerCleanupErrors   *prometheus.CounterVec
@@ -175,7 +177,9 @@ type metrics struct {
 	messagesSentCache              sync.Map
 	messagesReceivedCache          sync.Map
 	tagsFilterDroppedCache         sync.Map
-	mapPublishSuppressedCache      sync.Map
+	brokerPublishSuppressedCache    sync.Map
+	mapBrokerPublishSuppressedCache sync.Map
+	mapBrokerRemoveSuppressedCache  sync.Map
 	pubSubLagCache                 sync.Map
 	sharedPollHandlerCache         sync.Map
 	sharedPollResultCache          sync.Map
@@ -711,11 +715,25 @@ func newMetricsRegistry(config MetricsConfig) (*metrics, error) {
 			1.0, 2.5, 5.0, 10.0, // Second resolution.
 		}}, config.EnableNativeHistograms), []string{"type", "channel_namespace"})
 
-	m.mapPublishSuppressedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+	m.brokerPublishSuppressedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Subsystem: "broker",
+		Name:      "publish_suppressed_count",
+		Help:      "Number of suppressed publish operations.",
+	}, []string{"reason", "channel_namespace"})
+
+	m.mapBrokerPublishSuppressedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricsNamespace,
 		Subsystem: "map_broker",
 		Name:      "publish_suppressed_count",
-		Help:      "Number of suppressed map publish/remove operations.",
+		Help:      "Number of suppressed map publish operations.",
+	}, []string{"reason", "channel_namespace"})
+
+	m.mapBrokerRemoveSuppressedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Subsystem: "map_broker",
+		Name:      "remove_suppressed_count",
+		Help:      "Number of suppressed map remove operations.",
 	}, []string{"reason", "channel_namespace"})
 
 	m.mapBrokerCleanupLag = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -970,7 +988,9 @@ func newMetricsRegistry(config MetricsConfig) (*metrics, error) {
 		m.surveyDurationHistogram,
 		m.pubSubLagHistogram,
 		m.broadcastDurationHistogram,
-		m.mapPublishSuppressedCount,
+		m.brokerPublishSuppressedCount,
+		m.mapBrokerPublishSuppressedCount,
+		m.mapBrokerRemoveSuppressedCount,
 		m.mapBrokerCleanupLag,
 		m.mapBrokerCleanupRemoved,
 		m.mapBrokerCleanupErrors,
@@ -1486,23 +1506,37 @@ func (m *metrics) incTagsFilterDropped(ch string, count int) {
 	counter.(prometheus.Counter).Add(float64(count))
 }
 
-type mapPublishSuppressedLabels struct {
+type suppressedLabels struct {
 	Reason           string
 	ChannelNamespace string
 }
 
-func (m *metrics) incMapPublishSuppressed(reason SuppressReason, ch string) {
+// incSuppressed increments a suppressed-operation counter, caching the resolved
+// child by {reason, channel_namespace} to keep the hot publish path cheap.
+func (m *metrics) incSuppressed(vec *prometheus.CounterVec, cache *sync.Map, reason SuppressReason, ch string) {
 	channelNamespace := m.getChannelNamespaceLabel(ch)
-	labels := mapPublishSuppressedLabels{
+	labels := suppressedLabels{
 		Reason:           string(reason),
 		ChannelNamespace: channelNamespace,
 	}
-	counter, ok := m.mapPublishSuppressedCache.Load(labels)
+	counter, ok := cache.Load(labels)
 	if !ok {
-		counter = m.mapPublishSuppressedCount.WithLabelValues(string(reason), channelNamespace)
-		m.mapPublishSuppressedCache.Store(labels, counter)
+		counter = vec.WithLabelValues(string(reason), channelNamespace)
+		cache.Store(labels, counter)
 	}
 	counter.(prometheus.Counter).Inc()
+}
+
+func (m *metrics) incBrokerPublishSuppressed(reason SuppressReason, ch string) {
+	m.incSuppressed(m.brokerPublishSuppressedCount, &m.brokerPublishSuppressedCache, reason, ch)
+}
+
+func (m *metrics) incMapBrokerPublishSuppressed(reason SuppressReason, ch string) {
+	m.incSuppressed(m.mapBrokerPublishSuppressedCount, &m.mapBrokerPublishSuppressedCache, reason, ch)
+}
+
+func (m *metrics) incMapBrokerRemoveSuppressed(reason SuppressReason, ch string) {
+	m.incSuppressed(m.mapBrokerRemoveSuppressedCount, &m.mapBrokerRemoveSuppressedCache, reason, ch)
 }
 
 func (m *metrics) setMapBrokerCleanupLag(name string, seconds float64) {

--- a/metrics.go
+++ b/metrics.go
@@ -135,9 +135,9 @@ type metrics struct {
 	pubSubLagHistogram          *prometheus.HistogramVec
 	pingPongDurationHistogram   *prometheus.HistogramVec
 	mapPublishSuppressedCount   *prometheus.CounterVec
-	mapBrokerCleanupLag         *prometheus.GaugeVec
-	mapBrokerCleanupKeysRemoved *prometheus.CounterVec
-	mapBrokerCleanupErrors      *prometheus.CounterVec
+	mapBrokerCleanupLag      *prometheus.GaugeVec
+	mapBrokerCleanupRemoved  *prometheus.CounterVec
+	mapBrokerCleanupErrors   *prometheus.CounterVec
 
 	redisBrokerPubSubErrors           *prometheus.CounterVec
 	redisBrokerPubSubDroppedMessages  *prometheus.CounterVec
@@ -725,17 +725,17 @@ func newMetricsRegistry(config MetricsConfig) (*metrics, error) {
 		Help:      "Lag between now and the oldest expired entry awaiting cleanup. 0 means caught up.",
 	}, []string{"broker_name"})
 
-	m.mapBrokerCleanupKeysRemoved = prometheus.NewCounterVec(prometheus.CounterOpts{
+	m.mapBrokerCleanupRemoved = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricsNamespace,
 		Subsystem: "map_broker",
-		Name:      "cleanup_keys_removed_count",
-		Help:      "Total number of keys removed by cleanup.",
+		Name:      "cleanup_removed_total",
+		Help:      "Total number of expired entries removed by cleanup.",
 	}, []string{"broker_name"})
 
 	m.mapBrokerCleanupErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricsNamespace,
 		Subsystem: "map_broker",
-		Name:      "cleanup_errors_count",
+		Name:      "cleanup_errors_total",
 		Help:      "Total number of cleanup errors.",
 	}, []string{"broker_name"})
 
@@ -972,7 +972,7 @@ func newMetricsRegistry(config MetricsConfig) (*metrics, error) {
 		m.broadcastDurationHistogram,
 		m.mapPublishSuppressedCount,
 		m.mapBrokerCleanupLag,
-		m.mapBrokerCleanupKeysRemoved,
+		m.mapBrokerCleanupRemoved,
 		m.mapBrokerCleanupErrors,
 		m.redisBrokerPubSubErrors,
 		m.redisBrokerPubSubDroppedMessages,
@@ -1509,8 +1509,8 @@ func (m *metrics) setMapBrokerCleanupLag(name string, seconds float64) {
 	m.mapBrokerCleanupLag.WithLabelValues(name).Set(seconds)
 }
 
-func (m *metrics) addMapBrokerCleanupKeysRemoved(name string, count int64) {
-	m.mapBrokerCleanupKeysRemoved.WithLabelValues(name).Add(float64(count))
+func (m *metrics) addMapBrokerCleanupRemoved(name string, count int64) {
+	m.mapBrokerCleanupRemoved.WithLabelValues(name).Add(float64(count))
 }
 
 func (m *metrics) incMapBrokerCleanupErrors(name string) {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -787,8 +787,12 @@ func Test_getHTTPTransportProto(t *testing.T) {
 
 func TestMetrics_MapBrokerAndRedisBrokerCounters(t *testing.T) {
 	t.Parallel()
+	// Use a dedicated registry: the "test_map" namespace + "broker" subsystem
+	// would otherwise collide with another test's "test" namespace + "map_broker"
+	// subsystem on the shared default registry (both form *_map_broker_* fqNames).
 	m, err := newMetricsRegistry(MetricsConfig{
-		MetricsNamespace: "test_map",
+		MetricsNamespace:   "test_map",
+		RegistererGatherer: prometheus.NewRegistry(),
 		GetChannelNamespaceLabel: func(channel string) string {
 			return channel
 		},

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -797,7 +797,7 @@ func TestMetrics_MapBrokerAndRedisBrokerCounters(t *testing.T) {
 	// These were previously uncovered.
 	m.incRedisBrokerPubSubErrors("test_broker", "subscribe")
 	m.incMapBrokerCleanupErrors("test_broker")
-	m.addMapBrokerCleanupKeysRemoved("test_broker", 10)
+	m.addMapBrokerCleanupRemoved("test_broker", 10)
 	m.setMapBrokerCleanupLag("test_broker", 2.5)
 }
 

--- a/node.go
+++ b/node.go
@@ -347,10 +347,10 @@ func (n *Node) IncMapBrokerCleanupErrors(name string) {
 	}
 }
 
-// AddMapBrokerCleanupKeysRemoved adds to the map broker cleanup keys removed counter for observability.
-func (n *Node) AddMapBrokerCleanupKeysRemoved(name string, count int64) {
+// AddMapBrokerCleanupRemoved adds to the map broker cleanup removed-entries counter for observability.
+func (n *Node) AddMapBrokerCleanupRemoved(name string, count int64) {
 	if n.metrics != nil {
-		n.metrics.addMapBrokerCleanupKeysRemoved(name, count)
+		n.metrics.addMapBrokerCleanupRemoved(name, count)
 	}
 }
 

--- a/node.go
+++ b/node.go
@@ -880,6 +880,9 @@ func (n *Node) publish(ch string, data []byte, opts ...PublishOption) (PublishRe
 	if err != nil {
 		return PublishResult{}, err
 	}
+	if result.Suppressed {
+		n.metrics.incBrokerPublishSuppressed(result.SuppressReason, ch)
+	}
 	return result, nil
 }
 
@@ -2271,7 +2274,7 @@ func (n *Node) MapPublish(ctx context.Context, ch string, key string, opts MapPu
 	n.metrics.incMessagesSent("map_publication", ch)
 	result, err := mapBroker.Publish(ctx, ch, key, opts)
 	if err == nil && result.Suppressed {
-		n.metrics.incMapPublishSuppressed(result.SuppressReason, ch)
+		n.metrics.incMapBrokerPublishSuppressed(result.SuppressReason, ch)
 	}
 	return result, err
 }
@@ -2290,7 +2293,7 @@ func (n *Node) MapRemove(ctx context.Context, ch string, key string, opts MapRem
 	n.metrics.incMessagesSent("map_removal", ch)
 	result, err := mapBroker.Remove(ctx, ch, key, opts)
 	if err == nil && result.Suppressed {
-		n.metrics.incMapPublishSuppressed(result.SuppressReason, ch)
+		n.metrics.incMapBrokerRemoveSuppressed(result.SuppressReason, ch)
 	}
 	return result, err
 }

--- a/node_test.go
+++ b/node_test.go
@@ -1812,7 +1812,7 @@ func TestNode_MapMetricMethods(t *testing.T) {
 	defer func() { _ = n.Shutdown(context.Background()) }()
 	// These should not panic even when metrics are initialized.
 	n.IncMapBrokerCleanupErrors("test")
-	n.AddMapBrokerCleanupKeysRemoved("test", 5)
+	n.AddMapBrokerCleanupRemoved("test", 5)
 	n.SetMapBrokerCleanupLag("test", 1.5)
 }
 
@@ -1822,7 +1822,7 @@ func TestNode_MapMetricMethods_NilMetrics(t *testing.T) {
 	require.NoError(t, err)
 	// Before Run(), metrics may be nil — should not panic.
 	n.IncMapBrokerCleanupErrors("test")
-	n.AddMapBrokerCleanupKeysRemoved("test", 5)
+	n.AddMapBrokerCleanupRemoved("test", 5)
 	n.SetMapBrokerCleanupLag("test", 1.5)
 }
 

--- a/redis_pubsub_shared.go
+++ b/redis_pubsub_shared.go
@@ -58,6 +58,7 @@ func runPubSubLoop(
 	cb pubSubCallbacks,
 	node *Node,
 	name string,
+	psm redisPubSubMetrics,
 	subscribeOnReplica bool,
 	numProcessors, numResubscribeShards, numSubscribeShards, numPartitions int,
 	logFields map[string]any,
@@ -111,7 +112,7 @@ func runPubSubLoop(
 				case msg := <-ch:
 					err := cb.handleMessage(shard.isCluster, eventHandler, msg.Channel, convert.StringToBytes(msg.Message))
 					if err != nil {
-						node.metrics.incRedisBrokerPubSubErrors(name, "handle_client_message")
+						psm.incErrors(name, "handle_client_message")
 						node.logger.log(newErrorLogEntry(err, "error handling client message", logFields))
 						continue
 					}
@@ -130,7 +131,7 @@ func runPubSubLoop(
 				return
 			case <-ticker.C:
 				for i := 0; i < numProcessors; i++ {
-					node.metrics.redisBrokerPubSubBufferedMessages.WithLabelValues(name, "client", strconv.Itoa(i)).Set(float64(len(processors[i])))
+					psm.buffered.WithLabelValues(name, "client", strconv.Itoa(i)).Set(float64(len(processors[i])))
 				}
 			}
 		}
@@ -156,7 +157,7 @@ func runPubSubLoop(
 				// Blocking here will block Redis connection read loop which is not a
 				// good thing and can lead to slower command processing and potentially
 				// to deadlocks (see https://github.com/redis/rueidis/issues/596).
-				node.metrics.redisBrokerPubSubDroppedMessages.WithLabelValues(name, "client").Inc()
+				psm.dropped.WithLabelValues(name, "client").Inc()
 			}
 		},
 		OnSubscription: func(ps rueidis.PubSubSubscription) {
@@ -179,7 +180,7 @@ func runPubSubLoop(
 	}
 	if err != nil {
 		startOnce(err)
-		node.metrics.incRedisBrokerPubSubErrors(name, "subscribe_shard_channel")
+		psm.incErrors(name, "subscribe_shard_channel")
 		node.logger.log(newErrorLogEntry(err, "pub/sub subscribe error", logFields))
 		return
 	}
@@ -228,7 +229,7 @@ func runPubSubLoop(
 				if len(batch) > 0 && i%redisSubscribeBatchLimit == 0 {
 					err := subscribeBatch(batch)
 					if err != nil {
-						node.metrics.incRedisBrokerPubSubErrors(name, "subscribe_channel")
+						psm.incErrors(name, "subscribe_channel")
 						node.logger.log(newErrorLogEntry(err, "error subscribing", logFields))
 						closeDoneOnce()
 						return
@@ -240,7 +241,7 @@ func runPubSubLoop(
 			if len(batch) > 0 {
 				err := subscribeBatch(batch)
 				if err != nil {
-					node.metrics.incRedisBrokerPubSubErrors(name, "subscribe_channel")
+					psm.incErrors(name, "subscribe_channel")
 					node.logger.log(newErrorLogEntry(err, "error subscribing", logFields))
 					closeDoneOnce()
 					return
@@ -283,7 +284,7 @@ func runPubSubLoop(
 	case err = <-wait:
 		startOnce(err)
 		if err != nil {
-			node.metrics.incRedisBrokerPubSubErrors(name, "connection")
+			psm.incErrors(name, "connection")
 			node.logger.log(newErrorLogEntry(err, "pub/sub connection error", logFields))
 		}
 	case <-done:


### PR DESCRIPTION
## What

Make broker metrics follow a consistent taxonomy — generic concepts under `broker_*` / `map_broker_*`, a backend prefix (`redis_`) only for backend-specific ones — and instrument what was missing.

## Changes

**1. Dedicated PUB/SUB subsystem for the map broker.** `runPubSubLoop` is shared by `RedisBroker` and `RedisMapBroker`; it reported `redis_pub_sub_*` under the `broker` subsystem keyed only by `broker_name`, so the map broker's pub/sub metrics landed in the stream broker's family (and could collide on the same/default `Name`). Each broker now passes its own bundle:
- `RedisBroker` → `broker_redis_pub_sub_*` (unchanged)
- `RedisMapBroker` → `map_broker_redis_pub_sub_*` (new)

**2. Backend-neutral cleanup names.** Cleanup is generic (Redis, in-memory, and the PG map broker all prune expired state):
- `map_broker_cleanup_keys_removed_count` → `map_broker_cleanup_removed_count` (drops Redis-flavored "keys")
- public `Node.AddMapBrokerCleanupKeysRemoved` → `Node.AddMapBrokerCleanupRemoved`

**3. Publish-suppressed metrics split by broker kind and operation.** The single `map_broker_publish_suppressed_count` covered both map publishes and removes, and stream-broker suppression wasn't tracked at all:
- `broker_publish_suppressed_count` (stream broker publishes — newly instrumented)
- `map_broker_publish_suppressed_count` (map publishes)
- `map_broker_remove_suppressed_count` (map removes)

## Backward compatibility

Metrics changes (experimental APIs): map-broker `broker_redis_pub_sub_*` series move to `map_broker_redis_pub_sub_*`; cleanup metrics renamed to `_removed_total`/`_errors_total`; the suppressed metric is split as above. Stream-broker pub/sub metrics are unaffected.

## Downstream

`Node.AddMapBrokerCleanupKeysRemoved` → `AddMapBrokerCleanupRemoved` is a public rename used by Centrifugo's PG map broker — updated in centrifugal/centrifugo#1161.

## Testing

- `go build ./...`, `go vet ./`, `go vet -tags integration ./`
- Full non-integration unit suite passes.
