### PR TITLE
Limit WebSocket decompressed message size and track outgoing close codes

### DIFF
--- a/handler_websocket.go
+++ b/handler_websocket.go
@@ -18,7 +18,7 @@ import (
 	"github.com/maypok86/otter/v2"
 )
 
-// DefaultWebsocketDecompressedMessageSizeLimitMultiplier is the default factor
+// defaultWebsocketDecompressedMessageSizeLimitMultiplier is the default factor
 // applied to MessageSizeLimit to derive the maximum allowed decompressed
 // message size when permessage-deflate compression is negotiated and
 // WebsocketConfig.DecompressedMessageSizeLimit is not set explicitly.
@@ -27,7 +27,7 @@ import (
 // amount of memory (a "decompression bomb"). The multiplier leaves generous
 // headroom for legitimately compressible messages while still rejecting
 // extreme expansion ratios.
-const DefaultWebsocketDecompressedMessageSizeLimitMultiplier = 10
+const defaultWebsocketDecompressedMessageSizeLimitMultiplier = 10
 
 // WebsocketConfig represents config for WebsocketHandler.
 type WebsocketConfig struct {
@@ -60,8 +60,7 @@ type WebsocketConfig struct {
 	// bytes received on the wire, so without this limit a small compressed frame
 	// could be inflated into a much larger amount of memory (a "decompression
 	// bomb"). When set to zero (the default) the limit is derived from
-	// MessageSizeLimit multiplied by
-	// DefaultWebsocketDecompressedMessageSizeLimitMultiplier.
+	// MessageSizeLimit multiplied by 10 (const multiplier).
 	DecompressedMessageSizeLimit int
 
 	// WriteTimeout is maximum time of write message operation.
@@ -204,7 +203,7 @@ func (s *WebsocketHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if compression {
 		decompressedMessageSizeLimit := s.config.DecompressedMessageSizeLimit
 		if decompressedMessageSizeLimit == 0 {
-			decompressedMessageSizeLimit = messageSizeLimit * DefaultWebsocketDecompressedMessageSizeLimitMultiplier
+			decompressedMessageSizeLimit = messageSizeLimit * defaultWebsocketDecompressedMessageSizeLimitMultiplier
 		}
 		if decompressedMessageSizeLimit > 0 {
 			conn.SetDecompressedReadLimit(int64(decompressedMessageSizeLimit))

--- a/handler_websocket.go
+++ b/handler_websocket.go
@@ -18,6 +18,17 @@ import (
 	"github.com/maypok86/otter/v2"
 )
 
+// DefaultWebsocketDecompressedMessageSizeLimitMultiplier is the default factor
+// applied to MessageSizeLimit to derive the maximum allowed decompressed
+// message size when permessage-deflate compression is negotiated and
+// WebsocketConfig.DecompressedMessageSizeLimit is not set explicitly.
+// MessageSizeLimit alone only bounds the compressed bytes received on the wire,
+// so a small compressed frame could otherwise be inflated into a much larger
+// amount of memory (a "decompression bomb"). The multiplier leaves generous
+// headroom for legitimately compressible messages while still rejecting
+// extreme expansion ratios.
+const DefaultWebsocketDecompressedMessageSizeLimitMultiplier = 10
+
 // WebsocketConfig represents config for WebsocketHandler.
 type WebsocketConfig struct {
 	// CheckOrigin func to provide custom origin check logic.
@@ -38,7 +49,20 @@ type WebsocketConfig struct {
 
 	// MessageSizeLimit sets the maximum size in bytes of allowed message from client.
 	// By default, 65536 bytes (64KB) will be used.
+	// Note that with Compression enabled this only bounds the compressed bytes
+	// received on the wire - see DecompressedMessageSizeLimit which bounds the
+	// size after decompression.
 	MessageSizeLimit int
+
+	// DecompressedMessageSizeLimit sets the maximum size in bytes of a single
+	// message after permessage-deflate decompression. It only has an effect when
+	// Compression is enabled. MessageSizeLimit alone bounds only the compressed
+	// bytes received on the wire, so without this limit a small compressed frame
+	// could be inflated into a much larger amount of memory (a "decompression
+	// bomb"). When set to zero (the default) the limit is derived from
+	// MessageSizeLimit multiplied by
+	// DefaultWebsocketDecompressedMessageSizeLimitMultiplier.
+	DecompressedMessageSizeLimit int
 
 	// WriteTimeout is maximum time of write message operation.
 	// Slow client will be disconnected.
@@ -177,6 +201,15 @@ func (s *WebsocketHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if messageSizeLimit > 0 {
 		conn.SetReadLimit(int64(messageSizeLimit))
 	}
+	if compression {
+		decompressedMessageSizeLimit := s.config.DecompressedMessageSizeLimit
+		if decompressedMessageSizeLimit == 0 {
+			decompressedMessageSizeLimit = messageSizeLimit * DefaultWebsocketDecompressedMessageSizeLimitMultiplier
+		}
+		if decompressedMessageSizeLimit > 0 {
+			conn.SetDecompressedReadLimit(int64(decompressedMessageSizeLimit))
+		}
+	}
 
 	if useFramePingPong {
 		pongTimeout := s.config.PingPongConfig.PongTimeout
@@ -196,6 +229,14 @@ func (s *WebsocketHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	handleConn := func() {
+		// Registered first so it runs last, after any teardown close frame has
+		// been written. Only server-sent (outgoing) close codes are recorded -
+		// client-supplied codes are skipped to keep metric cardinality bounded.
+		defer func() {
+			if code, incoming := conn.CloseCode(); code != 0 && !incoming {
+				s.node.IncTransportOutgoingClose(transportWebsocket, code)
+			}
+		}()
 		opts := websocketTransportOptions{
 			pingPong:           s.config.PingPongConfig,
 			writeTimeout:       writeTimeout,

--- a/handler_websocket_test.go
+++ b/handler_websocket_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/centrifugal/centrifuge/internal/websocket"
 
 	"github.com/centrifugal/protocol"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1281,4 +1282,144 @@ func TestWebsocketTransportAcceptProtocol(t *testing.T) {
 		},
 	}
 	require.Equal(t, "h1", transport.AcceptProtocol())
+}
+
+// dialCompressed opens a permessage-deflate WebSocket connection to handler and
+// returns the client conn. The client compresses outbound frames at the maximum
+// level so a redundant payload yields a tiny compressed frame.
+func dialCompressed(t *testing.T, config WebsocketConfig) *websocket.Conn {
+	t.Helper()
+	n, _ := New(Config{})
+	require.NoError(t, n.Run())
+	t.Cleanup(func() { _ = n.Shutdown(context.Background()) })
+
+	config.CheckOrigin = func(r *http.Request) bool { return true }
+	mux := http.NewServeMux()
+	mux.Handle("/connection/websocket", NewWebsocketHandler(n, config))
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	dialer := &websocket.Dialer{EnableCompression: true}
+	url := "ws" + server.URL[4:]
+	conn, resp, _, err := dialer.Dial(url+"/connection/websocket", nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	t.Cleanup(func() { _ = conn.Close() })
+	require.NoError(t, conn.SetCompressionLevel(9))
+	return conn
+}
+
+// TestWebsocketHandlerDecompressionBombRejected proves end-to-end that with
+// compression enabled the default decompressed limit (MessageSizeLimit *
+// DefaultWebsocketDecompressedMessageSizeLimitMultiplier) rejects a tiny
+// compressed frame that inflates past the limit, before any authentication.
+func TestWebsocketHandlerDecompressionBombRejected(t *testing.T) {
+	t.Parallel()
+	// MessageSizeLimit 1024 -> decompressed limit = 1024 * 10 = 10240 bytes.
+	conn := dialCompressed(t, WebsocketConfig{
+		Compression:      true,
+		MessageSizeLimit: 1024,
+	})
+
+	// 64KB of zeros compresses to well under the 1024-byte compressed limit but
+	// inflates far past the 10240-byte decompressed limit.
+	bomb := make([]byte, 64*1024)
+	require.NoError(t, conn.WriteMessage(websocket.BinaryMessage, bomb))
+
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, _, err := conn.ReadMessage()
+	require.Error(t, err)
+	require.Truef(t, websocket.IsCloseError(err, websocket.CloseMessageTooBig),
+		"expected close %d, got %v", websocket.CloseMessageTooBig, err)
+	var closeErr *websocket.CloseError
+	require.ErrorAs(t, err, &closeErr)
+	require.Contains(t, closeErr.Text, "after decompression")
+}
+
+// TestWebsocketHandlerOutgoingCloseMetric proves the server-sent 1009 close from
+// the decompression-limit path is recorded in the outgoing close metric labeled
+// by transport and code.
+func TestWebsocketHandlerOutgoingCloseMetric(t *testing.T) {
+	t.Parallel()
+	n, _ := New(Config{})
+	require.NoError(t, n.Run())
+	defer func() { _ = n.Shutdown(context.Background()) }()
+	mux := http.NewServeMux()
+	mux.Handle("/connection/websocket", NewWebsocketHandler(n, WebsocketConfig{
+		Compression:      true,
+		MessageSizeLimit: 1024, // decompressed limit = 10240
+		CheckOrigin:      func(r *http.Request) bool { return true },
+	}))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	dialer := &websocket.Dialer{EnableCompression: true}
+	url := "ws" + server.URL[4:]
+	conn, resp, _, err := dialer.Dial(url+"/connection/websocket", nil)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	defer func() { _ = conn.Close() }()
+	require.NoError(t, conn.SetCompressionLevel(9))
+
+	bomb := make([]byte, 64*1024)
+	require.NoError(t, conn.WriteMessage(websocket.BinaryMessage, bomb))
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, _, _ = conn.ReadMessage() // server closes with 1009
+
+	counter := n.metrics.transportOutgoingCloseCount.WithLabelValues(transportWebsocket, "1009")
+	require.Eventually(t, func() bool {
+		var m dto.Metric
+		if err := counter.Write(&m); err != nil {
+			return false
+		}
+		return m.GetCounter().GetValue() == 1
+	}, 2*time.Second, 10*time.Millisecond, "expected outgoing close 1009 to be metered")
+}
+
+// TestWebsocketHandlerDecompressedMessageSizeLimitOverride proves the explicit
+// DecompressedMessageSizeLimit takes precedence over the multiplier-derived
+// default: a payload that would pass the multiplier limit (10240) but exceeds
+// the override (2048) is rejected.
+func TestWebsocketHandlerDecompressedMessageSizeLimitOverride(t *testing.T) {
+	t.Parallel()
+	conn := dialCompressed(t, WebsocketConfig{
+		Compression:                  true,
+		MessageSizeLimit:             1024, // multiplier default would be 10240
+		DecompressedMessageSizeLimit: 2048, // explicit, must win
+	})
+
+	// 4096 zeros: > 2048 (override) but < 10240 (multiplier). A 1009 close
+	// therefore proves the override is in effect; otherwise the frame would
+	// pass the size gate and be rejected later as an invalid command.
+	payload := make([]byte, 4096)
+	require.NoError(t, conn.WriteMessage(websocket.BinaryMessage, payload))
+
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, _, err := conn.ReadMessage()
+	require.Error(t, err)
+	require.Truef(t, websocket.IsCloseError(err, websocket.CloseMessageTooBig),
+		"expected close %d (override in effect), got %v", websocket.CloseMessageTooBig, err)
+}
+
+// TestWebsocketHandlerCompressedHeadroom proves the multiplier leaves headroom
+// above MessageSizeLimit for legitimately compressible inbound frames: a payload
+// larger than MessageSizeLimit but within the decompressed limit is NOT rejected
+// for being too big (it is only later rejected as an invalid command, with a
+// different close code).
+func TestWebsocketHandlerCompressedHeadroom(t *testing.T) {
+	t.Parallel()
+	conn := dialCompressed(t, WebsocketConfig{
+		Compression:      true,
+		MessageSizeLimit: 1024, // decompressed limit = 10240
+	})
+
+	// 4096 zeros: > MessageSizeLimit (1024) but < decompressed limit (10240).
+	payload := make([]byte, 4096)
+	require.NoError(t, conn.WriteMessage(websocket.BinaryMessage, payload))
+
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, _, err := conn.ReadMessage()
+	require.Error(t, err) // invalid command -> disconnect, but...
+	require.Falsef(t, websocket.IsCloseError(err, websocket.CloseMessageTooBig),
+		"frame within decompressed limit must not be rejected as too big, got %v", err)
 }

--- a/handler_websocket_test.go
+++ b/handler_websocket_test.go
@@ -1311,7 +1311,7 @@ func dialCompressed(t *testing.T, config WebsocketConfig) *websocket.Conn {
 
 // TestWebsocketHandlerDecompressionBombRejected proves end-to-end that with
 // compression enabled the default decompressed limit (MessageSizeLimit *
-// DefaultWebsocketDecompressedMessageSizeLimitMultiplier) rejects a tiny
+// defaultWebsocketDecompressedMessageSizeLimitMultiplier) rejects a tiny
 // compressed frame that inflates past the limit, before any authentication.
 func TestWebsocketHandlerDecompressionBombRejected(t *testing.T) {
 	t.Parallel()

--- a/internal/websocket/close_code_test.go
+++ b/internal/websocket/close_code_test.go
@@ -1,0 +1,72 @@
+package websocket
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+// TestCloseCode_Unset returns zero values before any close frame is observed.
+func TestCloseCode_Unset(t *testing.T) {
+	c := newTestConn(nil, &bytes.Buffer{}, true)
+	if code, incoming := c.CloseCode(); code != 0 || incoming {
+		t.Fatalf("CloseCode() = (%d, %v), want (0, false)", code, incoming)
+	}
+}
+
+// TestCloseCode_Outgoing records a close code we write as outgoing.
+func TestCloseCode_Outgoing(t *testing.T) {
+	c := newTestConn(nil, &bytes.Buffer{}, true)
+	_ = c.WriteControl(CloseMessage, FormatCloseMessage(CloseMessageTooBig, ""), time.Now().Add(time.Second))
+	if code, incoming := c.CloseCode(); code != CloseMessageTooBig || incoming {
+		t.Fatalf("CloseCode() = (%d, %v), want (%d, false)", code, incoming, CloseMessageTooBig)
+	}
+}
+
+// TestCloseCode_Incoming records a close code received from the peer as incoming
+// (and the subsequent RFC echo must not flip it to outgoing).
+func TestCloseCode_Incoming(t *testing.T) {
+	var buf bytes.Buffer
+	// Client writes a close frame (masked) into buf.
+	wc := newTestConn(nil, &buf, false)
+	_ = wc.WriteControl(CloseMessage, FormatCloseMessage(CloseGoingAway, ""), time.Now().Add(time.Second))
+
+	// Server reads it; advanceFrame records it as incoming and echoes a close.
+	rc := newTestConn(&buf, &bytes.Buffer{}, true)
+	if _, _, err := rc.NextReader(); !IsCloseError(err, CloseGoingAway) {
+		t.Fatalf("NextReader err = %v, want CloseError(%d)", err, CloseGoingAway)
+	}
+	if code, incoming := rc.CloseCode(); code != CloseGoingAway || !incoming {
+		t.Fatalf("CloseCode() = (%d, %v), want (%d, true)", code, incoming, CloseGoingAway)
+	}
+}
+
+// TestCloseCode_FirstWins keeps the initiating close, ignoring later frames.
+func TestCloseCode_FirstWins(t *testing.T) {
+	c := newTestConn(nil, &bytes.Buffer{}, true)
+	deadline := time.Now().Add(time.Second)
+	_ = c.WriteControl(CloseMessage, FormatCloseMessage(CloseMessageTooBig, ""), deadline)
+	_ = c.WriteControl(CloseMessage, FormatCloseMessage(CloseNormalClosure, ""), deadline)
+	if code, incoming := c.CloseCode(); code != CloseMessageTooBig || incoming {
+		t.Fatalf("CloseCode() = (%d, %v), want (%d, false)", code, incoming, CloseMessageTooBig)
+	}
+}
+
+// TestCloseCode_IncomingAppRangeStillIncoming proves an attacker-supplied
+// application-range close code (3000-4999) is recorded as incoming, so the
+// Centrifuge layer (which only records !incoming) will not turn it into a label.
+func TestCloseCode_IncomingAppRangeStillIncoming(t *testing.T) {
+	const appCode = 4321
+	var buf bytes.Buffer
+	wc := newTestConn(nil, &buf, false)
+	_ = wc.WriteControl(CloseMessage, FormatCloseMessage(appCode, ""), time.Now().Add(time.Second))
+
+	rc := newTestConn(&buf, &bytes.Buffer{}, true)
+	if _, _, err := rc.NextReader(); !IsCloseError(err, appCode) {
+		t.Fatalf("NextReader err = %v, want CloseError(%d)", err, appCode)
+	}
+	code, incoming := rc.CloseCode()
+	if code != appCode || !incoming {
+		t.Fatalf("CloseCode() = (%d, %v), want (%d, true)", code, incoming, appCode)
+	}
+}

--- a/internal/websocket/compression_limit_test.go
+++ b/internal/websocket/compression_limit_test.go
@@ -1,0 +1,350 @@
+package websocket
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"math/rand"
+	"testing"
+)
+
+// writeCompressedFrame returns a buffer holding a single permessage-deflate
+// compressed binary message carrying payload. The frame is written as a client
+// (masked) so it can be consumed by a server-side reader.
+func writeCompressedFrame(t *testing.T, payload []byte, level int) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	wc := newTestConn(nil, &buf, false)
+	wc.newCompressionWriter = compressNoContextTakeover
+	if level != 0 {
+		if err := wc.SetCompressionLevel(level); err != nil {
+			t.Fatalf("SetCompressionLevel: %v", err)
+		}
+	}
+	w, err := wc.NextWriter(BinaryMessage)
+	if err != nil {
+		t.Fatalf("NextWriter: %v", err)
+	}
+	if _, err := w.Write(payload); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	return &buf
+}
+
+// newCompressedReader builds a server-side reader for frames stored in src,
+// with permessage-deflate decompression enabled and the given decompressed read
+// limit. out captures any control frames (e.g. CloseMessageTooBig) the reader
+// writes back to the peer.
+func newCompressedReader(src *bytes.Buffer, decompressedLimit int64) (rc *Conn, out *bytes.Buffer) {
+	out = &bytes.Buffer{}
+	rc = newTestConn(src, out, true)
+	rc.newDecompressionReader = decompressNoContextTakeover
+	rc.SetDecompressedReadLimit(decompressedLimit)
+	return rc, out
+}
+
+func sentTooBig(out *bytes.Buffer) bool {
+	// FormatCloseMessage encodes the 2-byte close code; the server reader does
+	// not mask control frames, so the encoded code appears verbatim in out.
+	return bytes.Contains(out.Bytes(), FormatCloseMessage(CloseMessageTooBig, ""))
+}
+
+// TestDecompressedReadLimit_Bomb proves that a tiny compressed frame that
+// inflates to a huge payload is rejected with ErrReadLimit, that the close
+// frame is sent, and crucially that memory is bounded: io.ReadAll stops after
+// at most limit+1 bytes instead of materializing the whole bomb.
+func TestDecompressedReadLimit_Bomb(t *testing.T) {
+	const limit = 64 * 1024
+	const decompressedSize = 8 * 1024 * 1024 // 8MB inflates from a few KB.
+
+	src := writeCompressedFrame(t, bytes.Repeat([]byte{'A'}, decompressedSize), 9)
+	if src.Len() >= limit {
+		t.Fatalf("compressed frame %d bytes is not under the compressed read limit %d; test would not isolate the decompressed limit", src.Len(), limit)
+	}
+
+	rc, out := newCompressedReader(src, limit)
+
+	mt, r, err := rc.NextReader()
+	if err != nil {
+		t.Fatalf("NextReader: %v", err)
+	}
+	if mt != BinaryMessage {
+		t.Fatalf("message type = %d, want %d", mt, BinaryMessage)
+	}
+
+	data, err := io.ReadAll(r)
+	if !errors.Is(err, ErrReadLimit) {
+		t.Fatalf("io.ReadAll error = %v, want ErrReadLimit", err)
+	}
+	if int64(len(data)) > limit+1 {
+		t.Fatalf("read %d bytes, want at most %d (memory must stay bounded)", len(data), limit+1)
+	}
+	if !sentTooBig(out) {
+		t.Fatalf("expected CloseMessageTooBig control frame to be sent")
+	}
+	// The server-sent 1009 must be observable as an outgoing close code.
+	if code, incoming := rc.CloseCode(); code != CloseMessageTooBig || incoming {
+		t.Fatalf("CloseCode() = (%d, %v), want (%d, false)", code, incoming, CloseMessageTooBig)
+	}
+}
+
+// TestDecompressedReadLimit_Boundary proves the exact accept/reject boundary:
+// a message of exactly limit bytes is accepted, limit+1 is rejected.
+func TestDecompressedReadLimit_Boundary(t *testing.T) {
+	const limit = 4096
+
+	cases := []struct {
+		name       string
+		size       int
+		wantErr    bool
+		wantTooBig bool
+	}{
+		{"under", limit - 1, false, false},
+		{"exact", limit, false, false},
+		{"over_by_one", limit + 1, true, true},
+		{"over_by_many", limit * 4, true, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := bytes.Repeat([]byte{'x'}, tc.size)
+			src := writeCompressedFrame(t, payload, 0)
+			rc, out := newCompressedReader(src, limit)
+
+			_, r, err := rc.NextReader()
+			if err != nil {
+				t.Fatalf("NextReader: %v", err)
+			}
+			data, err := io.ReadAll(r)
+
+			if tc.wantErr {
+				if !errors.Is(err, ErrReadLimit) {
+					t.Fatalf("error = %v, want ErrReadLimit", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !bytes.Equal(data, payload) {
+					t.Fatalf("decompressed payload mismatch: got %d bytes, want %d", len(data), len(payload))
+				}
+			}
+			if got := sentTooBig(out); got != tc.wantTooBig {
+				t.Fatalf("sentTooBig = %v, want %v", got, tc.wantTooBig)
+			}
+		})
+	}
+}
+
+// TestDecompressedReadLimit_LegitCompressible proves the fix does not break the
+// legitimate case the report worried about: a message whose compressed size is
+// small but whose decompressed size is well above the compressed bytes is still
+// accepted, as long as it stays within the (higher) decompressed limit.
+func TestDecompressedReadLimit_LegitCompressible(t *testing.T) {
+	const compressedReadLimit = 8 * 1024    // mimics MessageSizeLimit
+	const decompressedReadLimit = 80 * 1024 // mimics MessageSizeLimit * multiplier
+	const payloadSize = 64 * 1024           // > compressed limit, < decompressed limit
+
+	payload := bytes.Repeat([]byte("centrifuge "), payloadSize/11+1)[:payloadSize]
+	src := writeCompressedFrame(t, payload, 9)
+	if src.Len() >= compressedReadLimit {
+		t.Fatalf("compressed size %d not under compressed read limit %d", src.Len(), compressedReadLimit)
+	}
+
+	rc, out := newCompressedReader(src, decompressedReadLimit)
+	rc.SetReadLimit(compressedReadLimit) // compressed-bytes limit also active
+
+	_, r, err := rc.NextReader()
+	if err != nil {
+		t.Fatalf("NextReader: %v", err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("legit compressible message rejected: %v", err)
+	}
+	if !bytes.Equal(data, payload) {
+		t.Fatalf("payload mismatch: got %d bytes, want %d", len(data), len(payload))
+	}
+	if sentTooBig(out) {
+		t.Fatalf("unexpected CloseMessageTooBig for a legit message")
+	}
+}
+
+// TestDecompressedReadLimit_ReproducesPreFixVulnerability documents the
+// vulnerability the fix addresses: with only the compressed-bytes limit
+// (SetReadLimit, the protection that existed before this change) and no
+// decompressed limit, a small compressed frame that satisfies the compressed
+// limit still inflates without bound. This is exactly the pre-fix behavior
+// (decompressedReadLimit == 0 is equivalent to the code before the fix).
+func TestDecompressedReadLimit_ReproducesPreFixVulnerability(t *testing.T) {
+	const compressedReadLimit = 64 * 1024    // the old message_size_limit default
+	const decompressedSize = 8 * 1024 * 1024 // 8MB from a few KB on the wire
+
+	src := writeCompressedFrame(t, bytes.Repeat([]byte{'A'}, decompressedSize), 9)
+	compressedLen := src.Len() // capture before reading drains the buffer
+	// The compressed frame is comfortably under the compressed read limit, so
+	// the pre-fix defense does not trigger.
+	if compressedLen >= compressedReadLimit {
+		t.Fatalf("compressed frame %d bytes not under compressed limit %d", compressedLen, compressedReadLimit)
+	}
+
+	rc, out := newCompressedReader(src, 0) // 0 == no decompressed limit (pre-fix)
+	rc.SetReadLimit(compressedReadLimit)   // only the old compressed-bytes defense
+
+	_, r, err := rc.NextReader()
+	if err != nil {
+		t.Fatalf("NextReader: %v", err)
+	}
+	data, err := io.ReadAll(r)
+	// Pre-fix: no error and the full 8MB is materialized despite the compressed
+	// read limit, demonstrating the unbounded amplification (the bug).
+	if err != nil {
+		t.Fatalf("pre-fix path unexpectedly errored: %v", err)
+	}
+	if len(data) != decompressedSize {
+		t.Fatalf("inflated to %d bytes, want full %d (unbounded amplification)", len(data), decompressedSize)
+	}
+	if sentTooBig(out) {
+		t.Fatalf("pre-fix path should not send CloseMessageTooBig")
+	}
+	t.Logf("reproduced: %d compressed wire bytes (<= %d limit) inflated to %d bytes unbounded",
+		compressedLen, compressedReadLimit, len(data))
+}
+
+// TestDecompressedReadLimit_Disabled proves that a zero limit means unlimited
+// (the fork primitive's contract): the bomb fully inflates without error.
+func TestDecompressedReadLimit_Disabled(t *testing.T) {
+	const decompressedSize = 1 * 1024 * 1024
+	payload := bytes.Repeat([]byte{'A'}, decompressedSize)
+	src := writeCompressedFrame(t, payload, 9)
+
+	rc, out := newCompressedReader(src, 0) // 0 == unlimited
+
+	_, r, err := rc.NextReader()
+	if err != nil {
+		t.Fatalf("NextReader: %v", err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("unexpected error with limit disabled: %v", err)
+	}
+	if len(data) != decompressedSize {
+		t.Fatalf("read %d bytes, want %d", len(data), decompressedSize)
+	}
+	if sentTooBig(out) {
+		t.Fatalf("unexpected CloseMessageTooBig with limit disabled")
+	}
+}
+
+// TestDecompressedReadLimit_IgnoredWithoutCompression proves the decompressed
+// limit only applies to compressed frames: an uncompressed message larger than
+// the decompressed limit (but within the compressed read limit) passes through,
+// because the limit is gated on the RSV1/decompress path.
+func TestDecompressedReadLimit_IgnoredWithoutCompression(t *testing.T) {
+	const decompressedReadLimit = 1024
+	const payloadSize = 8 * 1024
+
+	var src bytes.Buffer
+	wc := newTestConn(nil, &src, false) // no compression writer -> plain frame
+	w, err := wc.NextWriter(BinaryMessage)
+	if err != nil {
+		t.Fatalf("NextWriter: %v", err)
+	}
+	payload := bytes.Repeat([]byte{'y'}, payloadSize)
+	if _, err := w.Write(payload); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	rc, _ := newCompressedReader(&src, decompressedReadLimit)
+	// readLimit (compressed bytes) generous enough to admit the plain frame.
+	rc.SetReadLimit(payloadSize + 1024)
+
+	_, r, err := rc.NextReader()
+	if err != nil {
+		t.Fatalf("NextReader: %v", err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("uncompressed message wrongly limited: %v", err)
+	}
+	if !bytes.Equal(data, payload) {
+		t.Fatalf("payload mismatch: got %d bytes, want %d", len(data), len(payload))
+	}
+}
+
+// TestDecompressedReadLimit_CompressedLimitStillApplies proves the two limits
+// are independent: with a decompressed limit set, the compressed-bytes limit
+// enforced in advanceFrame still trips for an oversized compressed frame.
+func TestDecompressedReadLimit_CompressedLimitStillApplies(t *testing.T) {
+	const compressedReadLimit = 1024
+	// Incompressible (deterministic pseudo-random) payload so compressed size
+	// stays large and exceeds the compressed read limit before decompression
+	// even matters.
+	payload := make([]byte, 8*1024)
+	rng := rand.New(rand.NewSource(1))
+	_, _ = rng.Read(payload)
+	src := writeCompressedFrame(t, payload, 0)
+	if src.Len() <= compressedReadLimit {
+		t.Fatalf("payload compressed too well (%d bytes) to exceed compressed limit", src.Len())
+	}
+
+	rc, _ := newCompressedReader(src, 10*1024*1024) // generous decompressed limit
+	rc.SetReadLimit(compressedReadLimit)
+
+	_, r, err := rc.NextReader()
+	if err != nil {
+		// Limit may surface from NextReader itself (advanceFrame) ...
+		if !errors.Is(err, ErrReadLimit) {
+			t.Fatalf("NextReader error = %v, want ErrReadLimit", err)
+		}
+		return
+	}
+	// ... or while reading.
+	if _, err := io.ReadAll(r); !errors.Is(err, ErrReadLimit) {
+		t.Fatalf("io.ReadAll error = %v, want ErrReadLimit", err)
+	}
+}
+
+// TestDecompressedReadLimit_StreamingReads proves the limit is enforced on the
+// incremental NextReader path (used by the bidirectional handler's streaming
+// command decoder), not only via io.ReadAll: reading small chunks still trips
+// the limit and keeps total consumed bytes bounded.
+func TestDecompressedReadLimit_StreamingReads(t *testing.T) {
+	const limit = 4096
+	payload := bytes.Repeat([]byte{'z'}, 1*1024*1024)
+	src := writeCompressedFrame(t, payload, 9)
+
+	rc, out := newCompressedReader(src, limit)
+	_, r, err := rc.NextReader()
+	if err != nil {
+		t.Fatalf("NextReader: %v", err)
+	}
+
+	buf := make([]byte, 256)
+	var total int
+	for {
+		n, err := r.Read(buf)
+		total += n
+		if err != nil {
+			if !errors.Is(err, ErrReadLimit) {
+				t.Fatalf("Read error = %v, want ErrReadLimit", err)
+			}
+			break
+		}
+		if total > limit+1 {
+			t.Fatalf("consumed %d bytes without hitting limit %d", total, limit)
+		}
+	}
+	if total > limit+1 {
+		t.Fatalf("consumed %d bytes, want at most %d", total, limit+1)
+	}
+	if !sentTooBig(out) {
+		t.Fatalf("expected CloseMessageTooBig control frame to be sent")
+	}
+}

--- a/internal/websocket/conn.go
+++ b/internal/websocket/conn.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 )
@@ -261,10 +262,14 @@ type Conn struct {
 	writeBuf               []byte // frame is constructed in this buffer.
 	readLength             int64  // Message size.
 	readLimit              int64  // Maximum message size.
-	compressionLevel       int
-	readMaskPos            int
-	writeBufSize           int
-	writeErrMu             sync.Mutex
+	decompressedReadLimit  int64  // Maximum decompressed message size (0 = unlimited).
+	// closeCode holds the first close frame observed on the connection, packed
+	// as bits 0-15 = code, bit 16 = incoming flag; 0 means none observed yet.
+	closeCode        atomic.Int32
+	compressionLevel int
+	readMaskPos      int
+	writeBufSize     int
+	writeErrMu       sync.Mutex
 	// bytes remaining in current frame.
 	// set setReadRemaining to safely update this value and prevent overflow
 	readRemaining          int64
@@ -403,6 +408,14 @@ func (c *Conn) WriteControl(messageType int, data []byte, deadline time.Time) er
 	}
 	if len(data) > maxControlFramePayloadSize {
 		return errInvalidControlFrame
+	}
+
+	if messageType == CloseMessage {
+		code := CloseNoStatusReceived
+		if len(data) >= 2 {
+			code = int(binary.BigEndian.Uint16(data))
+		}
+		c.recordCloseCode(code, false)
 	}
 
 	b0 := byte(messageType) | finalBit
@@ -942,6 +955,7 @@ func (c *Conn) advanceFrame() (int, error) {
 				return noFrame, c.handleProtocolError("invalid utf8 payload in close frame")
 			}
 		}
+		c.recordCloseCode(closeCode, true)
 		if err := c.defaultCloseHandler(closeCode, closeText); err != nil {
 			return noFrame, err
 		}
@@ -992,6 +1006,14 @@ func (c *Conn) NextReader() (messageType int, r io.Reader, err error) {
 			c.reader = c.messageReader
 			if c.readDecompress {
 				c.reader = c.newDecompressionReader(c.reader)
+				if c.decompressedReadLimit > 0 {
+					// readLimit bounds only the compressed bytes counted in
+					// advanceFrame. With permessage-deflate a small compressed
+					// frame can inflate into an unbounded amount of memory
+					// (a "decompression bomb"), so additionally bound the
+					// decompressed output here.
+					c.reader = &limitedReader{c: c, r: c.reader, remaining: c.decompressedReadLimit + 1}
+				}
 			}
 			return frameType, c.reader, nil
 		}
@@ -1053,6 +1075,56 @@ func (r *messageReader) Close() error {
 	return nil
 }
 
+// limitedReader wraps a decompression reader and bounds the number of
+// decompressed bytes that may be read from a single message. Unlike
+// io.LimitedReader it returns ErrReadLimit (and sends a CloseMessageTooBig
+// control frame, mirroring the compressed-bytes limit enforced in
+// advanceFrame) instead of io.EOF when the limit is exceeded, so callers do
+// not mistake a truncated message for a complete one.
+type limitedReader struct {
+	c         *Conn
+	r         io.Reader
+	remaining int64 // decompressed bytes that may still be read (configured limit + 1)
+	tooBig    bool  // whether the close control frame was already sent
+}
+
+func (l *limitedReader) Read(p []byte) (int, error) {
+	if l.remaining <= 0 {
+		return 0, l.limitExceeded()
+	}
+	if int64(len(p)) > l.remaining {
+		// Never read more than one byte past the configured limit: that single
+		// extra byte is enough to prove the decompressed message is too big
+		// while keeping buffered memory bounded.
+		p = p[:l.remaining]
+	}
+	n, err := l.r.Read(p)
+	l.remaining -= int64(n)
+	if l.remaining <= 0 {
+		// Read limit+1 decompressed bytes, so the message exceeds the limit
+		// regardless of whether the underlying reader also reported EOF.
+		return n, l.limitExceeded()
+	}
+	return n, err
+}
+
+func (l *limitedReader) limitExceeded() error {
+	if !l.tooBig {
+		l.tooBig = true
+		// Distinct reason from the compressed-frame limit (which sends an empty
+		// reason) so the peer/operator can tell the decompressed limit was hit.
+		_ = l.c.WriteControl(CloseMessage, FormatCloseMessage(CloseMessageTooBig, "message too big after decompression"), time.Now().Add(writeWait))
+	}
+	return ErrReadLimit
+}
+
+func (l *limitedReader) Close() error {
+	if rc, ok := l.r.(io.Closer); ok {
+		return rc.Close()
+	}
+	return nil
+}
+
 // ReadMessage is a helper method for getting a reader using NextReader and
 // reading from that reader to a buffer.
 func (c *Conn) ReadMessage() (messageType int, p []byte, err error) {
@@ -1078,6 +1150,46 @@ func (c *Conn) SetReadDeadline(t time.Time) error {
 // and returns ErrReadLimit to the application.
 func (c *Conn) SetReadLimit(limit int64) {
 	c.readLimit = limit
+}
+
+// SetDecompressedReadLimit sets the maximum size in bytes for a single
+// decompressed message read from the peer when permessage-deflate compression
+// is negotiated. SetReadLimit only bounds the compressed bytes received on the
+// wire, which allows a small compressed frame to be inflated into a much larger
+// amount of memory (a "decompression bomb"). This limit additionally bounds the
+// decompressed output of each message. If a message exceeds the limit, the
+// connection sends a close message to the peer and reads return ErrReadLimit. A
+// value of zero (the default) disables the decompressed limit.
+func (c *Conn) SetDecompressedReadLimit(limit int64) {
+	c.decompressedReadLimit = limit
+}
+
+const closeCodeIncomingBit = int32(1) << 16
+
+func (c *Conn) recordCloseCode(code int, incoming bool) {
+	if code <= 0 || code > 0xFFFF {
+		return
+	}
+	v := int32(code)
+	if incoming {
+		v |= closeCodeIncomingBit
+	}
+	// The first close frame observed wins, so the initiating close (and its
+	// true direction) is preserved rather than the handshake response or
+	// teardown close that follows it.
+	c.closeCode.CompareAndSwap(0, v)
+}
+
+// CloseCode returns the close code of the first close frame observed on the
+// connection and whether it was received from the peer (incoming) rather than
+// sent locally (outgoing). It returns (0, false) if no close frame has been
+// observed yet.
+func (c *Conn) CloseCode() (code int, incoming bool) {
+	v := c.closeCode.Load()
+	if v == 0 {
+		return 0, false
+	}
+	return int(v & 0xFFFF), v&closeCodeIncomingBit != 0
 }
 
 func (c *Conn) defaultCloseHandler(code int, _ string) error {

--- a/metrics.go
+++ b/metrics.go
@@ -73,25 +73,30 @@ var (
 		Subsystem: "transport",
 		Name:      "messages_received_size",
 	}
+	metricTransportOutgoingClose = clientMetricDef{
+		Subsystem: "transport",
+		Name:      "outgoing_close_count",
+	}
 )
 
 type metrics struct {
-	messagesSentCount      *prometheus.CounterVec
-	messagesReceivedCount  *prometheus.CounterVec
-	actionCount            *prometheus.CounterVec
-	buildInfoGauge         *prometheus.GaugeVec
-	numClientsGauge        prometheus.Gauge
-	numUsersGauge          prometheus.Gauge
-	numSubsGauge           prometheus.Gauge
-	numChannelsGauge       prometheus.Gauge
-	numNodesGauge          prometheus.Gauge
-	replyErrorCount        *prometheus.CounterVec
-	connectionsAccepted    *prometheus.CounterVec
-	connectionsInflight    *prometheus.GaugeVec
-	subscriptionsAccepted  *prometheus.CounterVec
-	subscriptionsInflight  *prometheus.GaugeVec
-	serverUnsubscribeCount *prometheus.CounterVec
-	serverDisconnectCount  *prometheus.CounterVec
+	messagesSentCount           *prometheus.CounterVec
+	messagesReceivedCount       *prometheus.CounterVec
+	actionCount                 *prometheus.CounterVec
+	buildInfoGauge              *prometheus.GaugeVec
+	numClientsGauge             prometheus.Gauge
+	numUsersGauge               prometheus.Gauge
+	numSubsGauge                prometheus.Gauge
+	numChannelsGauge            prometheus.Gauge
+	numNodesGauge               prometheus.Gauge
+	replyErrorCount             *prometheus.CounterVec
+	connectionsAccepted         *prometheus.CounterVec
+	connectionsInflight         *prometheus.GaugeVec
+	subscriptionsAccepted       *prometheus.CounterVec
+	subscriptionsInflight       *prometheus.GaugeVec
+	serverUnsubscribeCount      *prometheus.CounterVec
+	serverDisconnectCount       *prometheus.CounterVec
+	transportOutgoingCloseCount *prometheus.CounterVec
 	// commandDurationSummary holds the legacy Summary by default; when
 	// EnableNativeHistograms is true it is a no-op (the Summary is not
 	// exposed). The companion commandDurationHistogram below always carries
@@ -592,6 +597,18 @@ func newMetricsRegistry(config MetricsConfig) (*metrics, error) {
 		Help:      "Number of server initiated disconnects.",
 	}, m.buildMetricLabels([]string{"code"}))
 
+	// Note: only server-sent (outgoing) close codes are recorded. They are
+	// chosen by the server/operator, so the "code" label cardinality is bounded.
+	// Client-supplied (incoming) close codes are deliberately not recorded - a
+	// client may send any code in the RFC 6455 application range (3000-4999),
+	// which would let an unauthenticated peer inflate metric cardinality.
+	m.transportOutgoingCloseCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricTransportOutgoingClose.Subsystem,
+		Name:      metricTransportOutgoingClose.Name,
+		Help:      "Number of close frames sent to clients, by transport and code.",
+	}, []string{"transport", "code"})
+
 	m.recoverCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricsNamespace,
 		Subsystem: "client",
@@ -922,6 +939,7 @@ func newMetricsRegistry(config MetricsConfig) (*metrics, error) {
 		m.subscriptionsInflight,
 		m.serverUnsubscribeCount,
 		m.serverDisconnectCount,
+		m.transportOutgoingCloseCount,
 		m.recoverCount,
 		m.pingPongDurationHistogram,
 		m.transportMessagesSent,
@@ -1290,6 +1308,10 @@ func (m *metrics) getCodeLabel(code uint32) string {
 
 type disconnectLabels struct {
 	Code string
+}
+
+func (m *metrics) incTransportOutgoingClose(transport string, code int) {
+	m.transportOutgoingCloseCount.WithLabelValues(transport, m.getCodeLabel(uint32(code))).Inc()
 }
 
 func (m *metrics) incServerDisconnect(code uint32, c *Client) {

--- a/node.go
+++ b/node.go
@@ -361,6 +361,18 @@ func (n *Node) SetMapBrokerCleanupLag(name string, seconds float64) {
 	}
 }
 
+// IncTransportOutgoingClose increments the counter of close frames sent to
+// clients, labeled by transport and close code. It is exported so that custom
+// transports implemented outside this package (e.g. unidirectional WebSocket)
+// can record their outgoing close codes too. Only server-sent close codes
+// should be passed - client-supplied close codes must not be recorded as their
+// label cardinality is not bounded.
+func (n *Node) IncTransportOutgoingClose(transport string, code int) {
+	if n.metrics != nil {
+		n.metrics.incTransportOutgoingClose(transport, code)
+	}
+}
+
 // Shutdown sets shutdown flag to Node so handlers could stop accepting
 // new requests and disconnects clients with shutdown reason.
 func (n *Node) Shutdown(ctx context.Context) error {


### PR DESCRIPTION
This branch adds two related WebSocket hardening / observability features:

1. **Decompressed message size limit** — protects against "decompression bombs"
   over `permessage-deflate`, where a tiny compressed frame inflates into a huge
   amount of memory.
2. **Outgoing close code metric** — a new Prometheus counter recording the close
   frames the server sends to clients, labeled by transport and code.

## Motivation

`MessageSizeLimit` (via `SetReadLimit`) only bounds the **compressed** bytes
received on the wire. When `permessage-deflate` is negotiated, a small compressed
frame can decompress into a much larger payload, allowing a malicious or buggy
peer to force large memory allocations. There was previously no bound on the
decompressed output of a single message.

Separately, there was no metric to observe how often — and with which codes —
the server closes WebSocket connections.

## Changes

### Decompressed read limit (`internal/websocket/conn.go`)

- New `Conn.SetDecompressedReadLimit(limit int64)` to bound the size of a single
  decompressed message. Zero (default) disables the limit.
- New `limitedReader` wraps the decompression reader. Unlike `io.LimitedReader`,
  when the limit is exceeded it sends a `CloseMessageTooBig` control frame (with
  a distinct reason `"message too big after decompression"`) and returns
  `ErrReadLimit`, so callers don't mistake a truncated message for a complete
  one. It reads at most one byte past the configured limit to keep buffered
  memory bounded while still proving the message is too big.

### Public config (`handler_websocket.go`)

- New `WebsocketConfig.DecompressedMessageSizeLimit` field. When `Compression`
  is enabled and this is zero, the limit defaults to `MessageSizeLimit * 10`
  (`defaultWebsocketDecompressedMessageSizeLimitMultiplier`), leaving generous
  headroom for legitimately compressible messages while rejecting extreme
  expansion ratios.
- Clarified `MessageSizeLimit` doc to note it only bounds compressed bytes when
  compression is enabled.

### Outgoing close code tracking

- `internal/websocket/conn.go`: records the first close frame observed on the
  connection (packed code + incoming/outgoing flag in an `atomic.Int32`).
  Exposed via `Conn.CloseCode() (code int, incoming bool)`. The first frame wins,
  preserving the true initiator/direction.
- `handler_websocket.go`: a deferred hook records the close code after teardown.
  **Only server-sent (outgoing) close codes are recorded** — client-supplied
  codes are skipped to keep metric cardinality bounded (a client may send any
  code in the RFC 6455 application range 3000–4999).
- `metrics.go`: new `centrifuge_transport_outgoing_close_count` counter
  (`{transport, code}` labels) plus `incTransportOutgoingClose` helper.
- `node.go`: new exported `Node.IncTransportOutgoingClose(transport string, code int)`
  so custom transports (e.g. unidirectional WebSocket) can record their outgoing
  close codes too.

## Compatibility

Backward compatible. The decompressed limit only applies when compression is
negotiated and defaults to a generous `10×` of `MessageSizeLimit`; operators can
override or disable it via `DecompressedMessageSizeLimit`. The new metric is
additive.
