### PR TITLE
Make error on decompress permanent

### DIFF
--- a/internal/websocket/compression_limit_test.go
+++ b/internal/websocket/compression_limit_test.go
@@ -311,6 +311,47 @@ func TestDecompressedReadLimit_CompressedLimitStillApplies(t *testing.T) {
 	}
 }
 
+// TestDecompressedReadLimit_ErrorIsPermanent proves that once the decompressed
+// limit trips, the error is sticky: subsequent NextReader calls keep returning
+// ErrReadLimit instead of advancing to the next frame. This mirrors the
+// compressed-bytes limit (enforced in advanceFrame, which sets c.readErr via
+// NextReader) and honors the gorilla contract that read errors are permanent.
+func TestDecompressedReadLimit_ErrorIsPermanent(t *testing.T) {
+	const limit = 4096
+
+	// Two back-to-back compressed frames in one stream. The first is a bomb that
+	// trips the decompressed limit; the second is a small legitimate message that
+	// must NOT be delivered once the connection is in its terminal error state.
+	src := writeCompressedFrame(t, bytes.Repeat([]byte{'A'}, 1*1024*1024), 9)
+	next := writeCompressedFrame(t, []byte("should never be read"), 9)
+	src.Write(next.Bytes())
+
+	rc, out := newCompressedReader(src, limit)
+
+	_, r, err := rc.NextReader()
+	if err != nil {
+		t.Fatalf("NextReader: %v", err)
+	}
+	if _, err := io.ReadAll(r); !errors.Is(err, ErrReadLimit) {
+		t.Fatalf("io.ReadAll error = %v, want ErrReadLimit", err)
+	}
+	if !sentTooBig(out) {
+		t.Fatalf("expected CloseMessageTooBig control frame to be sent")
+	}
+
+	// The error must now be permanent: NextReader keeps returning ErrReadLimit
+	// rather than reading the second frame.
+	for i := 0; i < 3; i++ {
+		mt, r, err := rc.NextReader()
+		if !errors.Is(err, ErrReadLimit) {
+			t.Fatalf("NextReader #%d after limit = (%d, %v), want ErrReadLimit", i, mt, err)
+		}
+		if r != nil {
+			t.Fatalf("NextReader #%d returned non-nil reader after permanent error", i)
+		}
+	}
+}
+
 // TestDecompressedReadLimit_StreamingReads proves the limit is enforced on the
 // incremental NextReader path (used by the bidirectional handler's streaming
 // command decoder), not only via io.ReadAll: reading small chunks still trips

--- a/internal/websocket/conn.go
+++ b/internal/websocket/conn.go
@@ -1115,6 +1115,13 @@ func (l *limitedReader) limitExceeded() error {
 		// reason) so the peer/operator can tell the decompressed limit was hit.
 		_ = l.c.WriteControl(CloseMessage, FormatCloseMessage(CloseMessageTooBig, "message too big after decompression"), time.Now().Add(writeWait))
 	}
+	// Make the error permanent, mirroring the compressed-bytes limit enforced in
+	// advanceFrame: that path returns ErrReadLimit through NextReader, which sets
+	// c.readErr. The decompressed limit trips inside this reader (the one handed
+	// to the application), bypassing that assignment, so set it here too. Once set
+	// every subsequent NextReader call returns ErrReadLimit, honoring the gorilla
+	// contract that read errors are permanent.
+	l.c.readErr = ErrReadLimit
 	return ErrReadLimit
 }
 


### PR DESCRIPTION
`readErr` was not set on decompressed-limit hit. When the limit trips, limitedReader returns ErrReadLimit but does not set c.readErr, unlike the compressed-limit path in advanceFrame.

So the error isn't "permanent" the way the gorilla contract promises — a caller that ignored the error and called NextReader() again would read the next frame instead of getting a sticky error.

Fixing here