### PR TITLE
Clear write deadline after frame ping to fix HTTP/2 stream failure

### DIFF
--- a/handler_websocket.go
+++ b/handler_websocket.go
@@ -476,18 +476,27 @@ func (t *websocketTransport) writeData(data []byte) error {
 		}
 	}
 
-	if t.opts.writeTimeout > 0 {
-		_ = t.conn.SetWriteDeadline(time.Time{})
-		if t.opts.protoMajor > 1 {
-			// For HTTP/2 connections, we need to actually clear the deadline on the underlying
-			// connection. The websocket Conn.SetWriteDeadline only sets a field, but doesn't
-			// clear the deadline that was already set on the underlying net.Conn during write.
-			// This is critical for HTTP/2 ResponseController where expired deadlines cannot be
-			// extended and will cause the stream to fail permanently.
-			_ = t.conn.NetConn().SetWriteDeadline(time.Time{})
-		}
-	}
+	t.clearWriteDeadline()
 	return nil
+}
+
+// clearWriteDeadline resets the write deadline set before a write. It must be
+// called after every write that armed a deadline (both data writes and frame
+// control writes such as pings), otherwise on HTTP/2 a lingering expired
+// deadline makes all subsequent writes fail permanently.
+func (t *websocketTransport) clearWriteDeadline() {
+	if t.opts.writeTimeout <= 0 {
+		return
+	}
+	_ = t.conn.SetWriteDeadline(time.Time{})
+	if t.opts.protoMajor > 1 {
+		// For HTTP/2 connections, we need to actually clear the deadline on the underlying
+		// connection. The websocket Conn.SetWriteDeadline only sets a field, but doesn't
+		// clear the deadline that was already set on the underlying net.Conn during write.
+		// This is critical for HTTP/2 ResponseController where expired deadlines cannot be
+		// extended and will cause the stream to fail permanently.
+		_ = t.conn.NetConn().SetWriteDeadline(time.Time{})
+	}
 }
 
 // Write data to transport.
@@ -585,6 +594,11 @@ func (t *websocketTransport) ping() {
 			_ = t.Close(DisconnectWriteError)
 			return
 		}
+		// WriteControl arms a write deadline on the underlying connection just
+		// like a data write, so it must be cleared the same way — otherwise on
+		// HTTP/2 the expired deadline cannot be extended by a later write and
+		// the stream fails permanently. See writeData for the data-path clear.
+		t.clearWriteDeadline()
 		t.addPing()
 	}
 }


### PR DESCRIPTION
The data write path (`writeData`) already clears the write deadline after every write, including the extra `NetConn().SetWriteDeadline` clear required on HTTP/2, where an expired deadline cannot be extended by a later write. The frame ping path armed the same deadline via `WriteControl` but never cleared it.

**Fix**
- Extract the clear into `clearWriteDeadline()` and call it on both the data path and the frame ping path.

**Impact**
- Only affects WebSocket carried over HTTP/2 (`protoMajor > 1`) **with frame ping-pong enabled** (`cf_ws_frame_ping_pong=true`). In that mode the ping set a short (`writeTimeout`) deadline on the underlying connection and left it; once it expired, the next write (a data message or the following ping) could not re-arm the deadline and the stream failed permanently.
- Default app-level ping-pong is unaffected (it flows through `writeData`, which already clears). Plain HTTP/1 is unaffected.