### PR TITLE
Use unnamed/unversioned label names instead of empty

### DIFF
--- a/client.go
+++ b/client.go
@@ -2615,14 +2615,19 @@ const (
 // connectCmd handles connect command from client - client must send connect
 // command immediately after establishing connection with server.
 func (c *Client) connectCmd(req *protocol.ConnectRequest, cmd *protocol.Command, started time.Time, rw *replyWriter) error {
-	var metricClientName string
+	// Client name/version metric labels use fixed sentinels to keep metric
+	// cardinality bounded: a reported value is only used verbatim when it's
+	// explicitly registered, otherwise it collapses to "unregistered". A client
+	// that reports nothing at all gets "unnamed"/"unversioned" so the series stays
+	// visible and self-describing rather than carrying an empty label value.
+	metricClientName := "unnamed"
 	if req.Name != "" {
 		metricClientName = "unregistered"
 		if slices.Contains(c.node.config.Metrics.RegisteredClientNames, req.Name) {
 			metricClientName = req.Name
 		}
 	}
-	var metricClientVersion string
+	metricClientVersion := "unversioned"
 	if req.Version != "" {
 		metricClientVersion = "unregistered"
 		if c.node.config.Metrics.CheckRegisteredClientVersion != nil && c.node.config.Metrics.CheckRegisteredClientVersion(req.Name, req.Version) {

--- a/config.go
+++ b/config.go
@@ -384,13 +384,14 @@ type MetricsConfig struct {
 
 	// RegisteredClientNames is an optional list of known client names which will be allowed to be
 	// attached as labels to metrics. If client passed a name which is not in the list – then Centrifuge
-	// will use string "unregistered" as a client_name label. We need to be strict here to avoid
-	// Prometheus cardinality issues.
+	// will use string "unregistered" as a client_name label. If a client passed no name at all Centrifuge
+	// will use string "unnamed". We need to be strict here to avoid Prometheus cardinality issues.
 	RegisteredClientNames []string
 	// CheckRegisteredClientVersion is a function to check whether the version passed by a client with a
 	// particular name is valid and can be used in metric values. When function is not set or returns
-	// false Centrifuge will use "unregistered" value for a client version. Note, the name argument here
-	// is an original name of client passed to Centrifuge.
+	// false Centrifuge will use "unregistered" value for a client version. If a client passed no version
+	// at all Centrifuge will use string "unversioned". Note, the name argument here is an original name of
+	// client passed to Centrifuge.
 	CheckRegisteredClientVersion func(clientName string, clientVersion string) bool
 	// EnableRecoveredPublicationsHistogram enables histogram tracking of number of publications
 	// recovered during subscription successful recovery operations.


### PR DESCRIPTION
Makes it more obvious to see in metrics.