### PR TITLE
Verify Redis PUB/SUB delivery with liveness probes

### DIFF
--- a/broker_redis.go
+++ b/broker_redis.go
@@ -727,6 +727,9 @@ func (b *RedisBroker) makePubSubCallbacks(s *shardWrapper) pubSubCallbacks {
 		shardForChannel: func(ch string) *RedisShard {
 			return b.getShard(ch).shard
 		},
+		extraResubscribeChannels: func() []string {
+			return b.node.extraBrokerPubSubChannels(b)
+		},
 	}
 }
 

--- a/broker_redis.go
+++ b/broker_redis.go
@@ -135,19 +135,6 @@ type RedisBrokerConfig struct {
 	// publishing to channels and using PUB/SUB.
 	SkipPubSub bool
 
-	// PubSubProbeInterval configures how often the broker verifies that its
-	// PUB/SUB connections still deliver messages. A connection that received
-	// nothing for this interval gets a small probe published to its service
-	// channel through the regular publish path; if a further interval passes
-	// without receiving anything, the connection is considered stale and
-	// re-established. This protects from the state where a connection
-	// remains healthy on the TCP level but is attached to a Redis node which
-	// no longer receives published traffic — possible after a failover (see
-	// centrifugal/centrifugo#1189). Probes are only sent on idle connections,
-	// so the mechanism costs nothing under regular message flow.
-	// Zero value means 30 seconds. Set to a negative value to disable probing.
-	PubSubProbeInterval time.Duration
-
 	// Name of broker, for observability purposes – i.e. becomes part of metrics/logs.
 	// By default, empty string is used.
 	Name string
@@ -205,6 +192,23 @@ type RedisBrokerConfig struct {
 	// Centrifuge to use 16 subscriber goroutines per subscribe shard.
 	numResubscribeShards int
 
+	// pubSubProbeInterval configures how often the broker verifies that its
+	// PUB/SUB connections still deliver messages — both the client ones and
+	// the control connection. A connection that received nothing for this
+	// interval gets a small probe published to its service channel through
+	// the regular publish path; if a further interval passes without
+	// receiving anything, the connection is considered stale and
+	// re-established. This protects from the state where a connection
+	// remains healthy on the TCP level but is attached to a Redis node which
+	// no longer receives published traffic — possible after a failover (see
+	// centrifugal/centrifugo#1189). Probes are only sent on idle connections,
+	// so the mechanism costs nothing under regular message flow.
+	// Zero value means defaultPubSubProbeInterval, values below
+	// minPubSubProbeInterval are raised to it, a negative value disables
+	// probing. Not exported: the default is expected to work everywhere, the
+	// knob only exists for tests.
+	pubSubProbeInterval time.Duration
+
 	// numPubSubProcessors allows configuring number of workers which will process
 	// messages coming from Redis PUB/SUB. Zero value tells Centrifuge to use the
 	// number calculated as:
@@ -246,9 +250,7 @@ func NewRedisBroker(n *Node, config RedisBrokerConfig) (*RedisBroker, error) {
 		config.numResubscribeShards = 16
 	}
 
-	if config.PubSubProbeInterval == 0 {
-		config.PubSubProbeInterval = defaultPubSubProbeInterval
-	}
+	config.pubSubProbeInterval = normalizePubSubProbeInterval(config.pubSubProbeInterval)
 
 	if config.numPubSubProcessors == 0 {
 		config.numPubSubProcessors = runtime.NumCPU() / config.numSubscribeShards
@@ -374,13 +376,16 @@ func (r *defaultBrokerPubSubRunner) run(s *shardWrapper, h BrokerEventHandler) e
 			pubSubShardIndex := j
 			logFields := getBaseLogFields(s)
 			logFields["pub_sub_shard"] = pubSubShardIndex
+			// Allocated outside runForever: probe state must survive loop
+			// restarts, that is the whole point of it.
+			probeState := &pubSubProbeState{}
 			go b.runForever(func() {
 				select {
 				case <-b.closeCh:
 					return
 				default:
 				}
-				b.runPubSub(s, logFields, h, clusterShardIndex, pubSubShardIndex, b.useShardedPubSub(s.shard), func(err error) {
+				b.runPubSub(s, logFields, h, clusterShardIndex, pubSubShardIndex, b.useShardedPubSub(s.shard), probeState, func(err error) {
 					s.pubSubStartChannels[clusterShardIndex][pubSubShardIndex].once.Do(func() {
 						s.pubSubStartChannels[clusterShardIndex][pubSubShardIndex].errCh <- err
 					})
@@ -612,7 +617,7 @@ func (b *RedisBroker) runControlPubSub(s *RedisShard, logFields map[string]any, 
 	}()
 
 	// receivedCount counts messages delivered by this connection, feeding the
-	// liveness probing below. See the PubSubProbeInterval option docs.
+	// liveness probing below. See the pubSubProbeInterval option docs.
 	var receivedCount atomic.Uint64
 
 	wait := conn.SetPubSubHooks(rueidis.PubSubHooks{
@@ -661,7 +666,7 @@ func (b *RedisBroker) runControlPubSub(s *RedisShard, logFields map[string]any, 
 	// activates when the pings are absent (connection stopped delivering, or
 	// a broker used without Node.Run) — the check stays valid without
 	// depending on the ping schedule.
-	probeInterval := b.config.PubSubProbeInterval
+	probeInterval := b.config.pubSubProbeInterval
 	var probeTickerCh <-chan time.Time
 	if probeInterval > 0 {
 		probeTicker := time.NewTicker(probeInterval)
@@ -669,7 +674,15 @@ func (b *RedisBroker) runControlPubSub(s *RedisShard, logFields map[string]any, 
 		probeTickerCh = probeTicker.C
 	}
 	var seenCount uint64
-	var probeOutstanding bool
+	// probeSent is non-nil while a probe attempt is outstanding and becomes
+	// true once Redis has accepted that PUBLISH — see the same pattern in
+	// runPubSubLoop.
+	//
+	// No restart backoff here, unlike the client loop: restarting the control
+	// connection resubscribes three fixed channels, so even a restart loop
+	// against a wedged node costs nothing, while delaying restarts would
+	// prolong control starvation.
+	var probeSent *atomic.Bool
 	for {
 		select {
 		case err := <-wait:
@@ -686,15 +699,19 @@ func (b *RedisBroker) runControlPubSub(s *RedisShard, logFields map[string]any, 
 			cur := receivedCount.Load()
 			if cur != seenCount {
 				seenCount = cur
-				probeOutstanding = false
+				probeSent = nil
 				continue
 			}
-			if probeOutstanding {
+			if probeSent != nil && probeSent.Load() {
 				b.node.metrics.incRedisBrokerPubSubErrors(b.config.Name, "control_probe_timeout")
 				b.node.logger.log(newLogEntry(LogLevelWarn, "no control PUB/SUB message received since liveness probe was sent, restarting control PUB/SUB connection", logFields))
 				return
 			}
-			probeOutstanding = true
+			// The outstanding probe (if any) never reached Redis: the publish
+			// path is broken, which says nothing about the receive path.
+			// Start a fresh attempt instead of restarting the connection.
+			sent := &atomic.Bool{}
+			probeSent = sent
 			go func() {
 				ctx, cancel := context.WithTimeout(context.Background(), probeInterval)
 				defer cancel()
@@ -702,7 +719,9 @@ func (b *RedisBroker) runControlPubSub(s *RedisShard, logFields map[string]any, 
 				if pubErr := s.client.Do(ctx, cmd).Error(); pubErr != nil {
 					b.node.metrics.incRedisBrokerPubSubErrors(b.config.Name, "control_probe_publish")
 					b.node.logger.log(newErrorLogEntry(pubErr, "error publishing control PUB/SUB probe", logFields))
+					return
 				}
+				sent.Store(true)
 			}()
 		}
 	}
@@ -733,7 +752,7 @@ func (b *RedisBroker) makePubSubCallbacks(s *shardWrapper) pubSubCallbacks {
 	}
 }
 
-func (b *RedisBroker) runPubSub(s *shardWrapper, logFields map[string]any, eventHandler BrokerEventHandler, clusterShardIndex, psShardIndex int, useShardedPubSub bool, startOnce func(error)) {
+func (b *RedisBroker) runPubSub(s *shardWrapper, logFields map[string]any, eventHandler BrokerEventHandler, clusterShardIndex, psShardIndex int, useShardedPubSub bool, probeState *pubSubProbeState, startOnce func(error)) {
 	cb := b.makePubSubCallbacks(s)
 	numPartitions := b.config.NumShardedPubSubPartitions
 	if numPartitions == 0 {
@@ -748,7 +767,8 @@ func (b *RedisBroker) runPubSub(s *shardWrapper, logFields map[string]any, event
 		b.config.Name,
 		b.node.metrics.brokerPubSub,
 		b.config.SubscribeOnReplica,
-		b.config.PubSubProbeInterval,
+		b.config.pubSubProbeInterval,
+		probeState,
 		b.config.numPubSubProcessors,
 		b.config.numResubscribeShards,
 		b.config.numSubscribeShards,

--- a/broker_redis.go
+++ b/broker_redis.go
@@ -135,6 +135,19 @@ type RedisBrokerConfig struct {
 	// publishing to channels and using PUB/SUB.
 	SkipPubSub bool
 
+	// PubSubProbeInterval configures how often the broker verifies that its
+	// PUB/SUB connections still deliver messages. A connection that received
+	// nothing for this interval gets a small probe published to its service
+	// channel through the regular publish path; if a further interval passes
+	// without receiving anything, the connection is considered stale and
+	// re-established. This protects from the state where a connection
+	// remains healthy on the TCP level but is attached to a Redis node which
+	// no longer receives published traffic — possible after a failover (see
+	// centrifugal/centrifugo#1189). Probes are only sent on idle connections,
+	// so the mechanism costs nothing under regular message flow.
+	// Zero value means 30 seconds. Set to a negative value to disable probing.
+	PubSubProbeInterval time.Duration
+
 	// Name of broker, for observability purposes – i.e. becomes part of metrics/logs.
 	// By default, empty string is used.
 	Name string
@@ -231,6 +244,10 @@ func NewRedisBroker(n *Node, config RedisBrokerConfig) (*RedisBroker, error) {
 
 	if config.numResubscribeShards == 0 {
 		config.numResubscribeShards = 16
+	}
+
+	if config.PubSubProbeInterval == 0 {
+		config.PubSubProbeInterval = defaultPubSubProbeInterval
 	}
 
 	if config.numPubSubProcessors == 0 {
@@ -537,6 +554,10 @@ func (b *RedisBroker) runControlPubSub(s *RedisShard, logFields map[string]any, 
 
 	controlChannel := b.controlChannel
 	nodeChannel := b.nodeChannel
+	// probeChannel is a per-node service channel used only by liveness
+	// probes. The node channel itself carries real control commands, so
+	// probes get their own channel and are recognized by channel name.
+	probeChannel := nodeChannel + ".probe"
 
 	done := make(chan struct{})
 	var doneOnce sync.Once
@@ -590,8 +611,18 @@ func (b *RedisBroker) runControlPubSub(s *RedisShard, logFields map[string]any, 
 		}
 	}()
 
+	// receivedCount counts messages delivered by this connection, feeding the
+	// liveness probing below. See the PubSubProbeInterval option docs.
+	var receivedCount atomic.Uint64
+
 	wait := conn.SetPubSubHooks(rueidis.PubSubHooks{
 		OnMessage: func(msg rueidis.PubSubMessage) {
+			receivedCount.Add(1)
+			if msg.Channel == probeChannel {
+				// Liveness probe: consumed right here by updating
+				// receivedCount, must not reach the control handler.
+				return
+			}
 			select {
 			case workCh <- msg:
 			case <-done:
@@ -606,7 +637,7 @@ func (b *RedisBroker) runControlPubSub(s *RedisShard, logFields map[string]any, 
 		},
 	})
 
-	err := conn.Do(context.Background(), conn.B().Subscribe().Channel(controlChannel, nodeChannel).Build()).Error()
+	err := conn.Do(context.Background(), conn.B().Subscribe().Channel(controlChannel, nodeChannel, probeChannel).Build()).Error()
 	if err != nil {
 		startOnce(err)
 		b.node.metrics.incRedisBrokerPubSubErrors(b.config.Name, "subscribe_control_channel")
@@ -616,14 +647,64 @@ func (b *RedisBroker) runControlPubSub(s *RedisShard, logFields map[string]any, 
 
 	startOnce(nil)
 
-	select {
-	case err := <-wait:
-		if err != nil {
-			b.node.metrics.incRedisBrokerPubSubErrors(b.config.Name, "control_connection")
-			b.node.logger.log(newErrorLogEntry(err, "control pub/sub connection error", logFields))
+	// Same liveness probing as in runPubSubLoop: a control connection that
+	// received nothing for a full interval gets a probe published to its
+	// per-node probe channel through the regular publish path; a further
+	// silent interval means the connection is attached to a node that does
+	// not deliver published traffic — restart it. A stale control connection
+	// is as harmful as a stale client one: the node stops receiving control
+	// commands and other nodes' pings, silently.
+	//
+	// In a running node this machinery is dormant: every node publishes node
+	// info to the control channel each nodeInfoPublishInterval, that traffic
+	// keeps the connection non-idle, and probes are never sent. Probing only
+	// activates when the pings are absent (connection stopped delivering, or
+	// a broker used without Node.Run) — the check stays valid without
+	// depending on the ping schedule.
+	probeInterval := b.config.PubSubProbeInterval
+	var probeTickerCh <-chan time.Time
+	if probeInterval > 0 {
+		probeTicker := time.NewTicker(probeInterval)
+		defer probeTicker.Stop()
+		probeTickerCh = probeTicker.C
+	}
+	var seenCount uint64
+	var probeOutstanding bool
+	for {
+		select {
+		case err := <-wait:
+			if err != nil {
+				b.node.metrics.incRedisBrokerPubSubErrors(b.config.Name, "control_connection")
+				b.node.logger.log(newErrorLogEntry(err, "control pub/sub connection error", logFields))
+			}
+			return
+		case <-done:
+			return
+		case <-s.closeCh:
+			return
+		case <-probeTickerCh:
+			cur := receivedCount.Load()
+			if cur != seenCount {
+				seenCount = cur
+				probeOutstanding = false
+				continue
+			}
+			if probeOutstanding {
+				b.node.metrics.incRedisBrokerPubSubErrors(b.config.Name, "control_probe_timeout")
+				b.node.logger.log(newLogEntry(LogLevelWarn, "no control PUB/SUB message received since liveness probe was sent, restarting control PUB/SUB connection", logFields))
+				return
+			}
+			probeOutstanding = true
+			go func() {
+				ctx, cancel := context.WithTimeout(context.Background(), probeInterval)
+				defer cancel()
+				cmd := s.client.B().Publish().Channel(probeChannel).Message(pubSubProbeMessage).Build()
+				if pubErr := s.client.Do(ctx, cmd).Error(); pubErr != nil {
+					b.node.metrics.incRedisBrokerPubSubErrors(b.config.Name, "control_probe_publish")
+					b.node.logger.log(newErrorLogEntry(pubErr, "error publishing control PUB/SUB probe", logFields))
+				}
+			}()
 		}
-	case <-done:
-	case <-s.closeCh:
 	}
 }
 
@@ -664,6 +745,7 @@ func (b *RedisBroker) runPubSub(s *shardWrapper, logFields map[string]any, event
 		b.config.Name,
 		b.node.metrics.brokerPubSub,
 		b.config.SubscribeOnReplica,
+		b.config.PubSubProbeInterval,
 		b.config.numPubSubProcessors,
 		b.config.numResubscribeShards,
 		b.config.numSubscribeShards,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,10 +27,14 @@ services:
       - -c
       - |
         redis-server --save "" --appendonly no --port 6380 &
+        redis-server --save "" --appendonly no --port 6381 --replicaof 127.0.0.1 6380 &
+        redis-server --save "" --appendonly no --port 6382 --replicaof 127.0.0.1 6380 &
         echo "sentinel monitor mymaster 127.0.0.1 6380 2\n" > sentinel.conf
         redis-server sentinel.conf --sentinel
     ports:
       - "6380:6380"
+      - "6381:6381"
+      - "6382:6382"
       - "26379:26379"
   valkey:
     image: valkey/valkey:${VALKEY_VERSION:-8}-alpine

--- a/map_broker_redis.go
+++ b/map_broker_redis.go
@@ -2795,6 +2795,9 @@ func (e *RedisMapBroker) makePubSubCallbacks(s *brokerShardWrapper) pubSubCallba
 		shardForChannel: func(ch string) *RedisShard {
 			return e.getShard(ch).shard
 		},
+		// extraResubscribeChannels is not set: shared poll key channels are
+		// subscribed via node.getBroker which returns Broker implementations
+		// only — RedisMapBroker is not one, so no key channels can live here.
 	}
 }
 

--- a/map_broker_redis.go
+++ b/map_broker_redis.go
@@ -137,6 +137,11 @@ type RedisMapBrokerConfig struct {
 	// SkipPubSub enables mode when broker only works with data structures, without
 	// publishing to channels and using PUB/SUB.
 	SkipPubSub bool
+	// PubSubProbeInterval configures how often the broker verifies that its
+	// PUB/SUB connections still deliver messages. See the field with the same
+	// name in RedisBrokerConfig for the details.
+	// Zero value means 30 seconds. Set to a negative value to disable probing.
+	PubSubProbeInterval time.Duration
 	// NumShardedPubSubPartitions when greater than zero allows turning on a mode in which
 	// broker will use Redis Cluster with sharded PUB/SUB feature available in
 	// Redis >= 7: https://redis.io/docs/manual/pubsub/#sharded-pubsub
@@ -202,6 +207,9 @@ func NewRedisMapBroker(n *Node, conf RedisMapBrokerConfig) (*RedisMapBroker, err
 	}
 	if conf.numResubscribeShards == 0 {
 		conf.numResubscribeShards = 16
+	}
+	if conf.PubSubProbeInterval == 0 {
+		conf.PubSubProbeInterval = defaultPubSubProbeInterval
 	}
 	if conf.numPubSubProcessors == 0 {
 		conf.numPubSubProcessors = runtime.NumCPU() / conf.numSubscribeShards
@@ -2805,6 +2813,7 @@ func (e *RedisMapBroker) runPubSub(s *brokerShardWrapper, logFields map[string]a
 		e.conf.Name,
 		e.node.metrics.mapBrokerPubSub,
 		e.conf.SubscribeOnReplica,
+		e.conf.PubSubProbeInterval,
 		e.conf.numPubSubProcessors,
 		e.conf.numResubscribeShards,
 		e.conf.numSubscribeShards,

--- a/map_broker_redis.go
+++ b/map_broker_redis.go
@@ -137,11 +137,6 @@ type RedisMapBrokerConfig struct {
 	// SkipPubSub enables mode when broker only works with data structures, without
 	// publishing to channels and using PUB/SUB.
 	SkipPubSub bool
-	// PubSubProbeInterval configures how often the broker verifies that its
-	// PUB/SUB connections still deliver messages. See the field with the same
-	// name in RedisBrokerConfig for the details.
-	// Zero value means 30 seconds. Set to a negative value to disable probing.
-	PubSubProbeInterval time.Duration
 	// NumShardedPubSubPartitions when greater than zero allows turning on a mode in which
 	// broker will use Redis Cluster with sharded PUB/SUB feature available in
 	// Redis >= 7: https://redis.io/docs/manual/pubsub/#sharded-pubsub
@@ -167,6 +162,12 @@ type RedisMapBrokerConfig struct {
 	// numResubscribeShards defines how many subscriber goroutines will be used for
 	// resubscribing process for each subscribe shard.
 	numResubscribeShards int
+	// pubSubProbeInterval configures how often the broker verifies that its
+	// PUB/SUB connections still deliver messages. See the field with the same
+	// name in RedisBrokerConfig for the details. Not exported: the default is
+	// expected to work everywhere, the knob only exists for tests.
+	pubSubProbeInterval time.Duration
+
 	// numPubSubProcessors allows configuring number of workers which will process
 	// messages coming from Redis PUB/SUB.
 	numPubSubProcessors int
@@ -208,9 +209,7 @@ func NewRedisMapBroker(n *Node, conf RedisMapBrokerConfig) (*RedisMapBroker, err
 	if conf.numResubscribeShards == 0 {
 		conf.numResubscribeShards = 16
 	}
-	if conf.PubSubProbeInterval == 0 {
-		conf.PubSubProbeInterval = defaultPubSubProbeInterval
-	}
+	conf.pubSubProbeInterval = normalizePubSubProbeInterval(conf.pubSubProbeInterval)
 	if conf.numPubSubProcessors == 0 {
 		conf.numPubSubProcessors = runtime.NumCPU() / conf.numSubscribeShards
 		if conf.NumShardedPubSubPartitions > 0 {
@@ -2355,13 +2354,16 @@ func (r *defaultMapBrokerPubSubRunner) run(s *brokerShardWrapper, h BrokerEventH
 				"cluster_shards": len(s.subClients),
 				"pub_sub_shards": len(s.subClients[i]),
 			}
+			// Allocated outside runForever: probe state must survive loop
+			// restarts, that is the whole point of it.
+			probeState := &pubSubProbeState{}
 			go e.runForever(func() {
 				select {
 				case <-e.closeCh:
 					return
 				default:
 				}
-				e.runPubSub(s, logFields, h, clusterShardIndex, pubSubShardIndex, e.useShardedPubSub(s.shard), func(err error) {
+				e.runPubSub(s, logFields, h, clusterShardIndex, pubSubShardIndex, e.useShardedPubSub(s.shard), probeState, func(err error) {
 					s.pubSubStartChannels[clusterShardIndex][pubSubShardIndex].once.Do(func() {
 						s.pubSubStartChannels[clusterShardIndex][pubSubShardIndex].errCh <- err
 					})
@@ -2801,7 +2803,7 @@ func (e *RedisMapBroker) makePubSubCallbacks(s *brokerShardWrapper) pubSubCallba
 	}
 }
 
-func (e *RedisMapBroker) runPubSub(s *brokerShardWrapper, logFields map[string]any, eventHandler BrokerEventHandler, clusterShardIndex, psShardIndex int, useShardedPubSub bool, startOnce func(error)) {
+func (e *RedisMapBroker) runPubSub(s *brokerShardWrapper, logFields map[string]any, eventHandler BrokerEventHandler, clusterShardIndex, psShardIndex int, useShardedPubSub bool, probeState *pubSubProbeState, startOnce func(error)) {
 	cb := e.makePubSubCallbacks(s)
 	numPartitions := e.conf.NumShardedPubSubPartitions
 	if numPartitions == 0 {
@@ -2816,7 +2818,8 @@ func (e *RedisMapBroker) runPubSub(s *brokerShardWrapper, logFields map[string]a
 		e.conf.Name,
 		e.node.metrics.mapBrokerPubSub,
 		e.conf.SubscribeOnReplica,
-		e.conf.PubSubProbeInterval,
+		e.conf.pubSubProbeInterval,
+		probeState,
 		e.conf.numPubSubProcessors,
 		e.conf.numResubscribeShards,
 		e.conf.numSubscribeShards,

--- a/node.go
+++ b/node.go
@@ -311,6 +311,17 @@ func (n *Node) Hub() *Hub {
 // Run performs node startup actions. At moment must be called once on start
 // after Controller and Broker set to Node.
 func (n *Node) Run() error {
+	// Initialize shared poll manager if configured. This must happen before
+	// any broker registration below: brokers start goroutines from their
+	// Register*EventHandler methods, and those goroutines read
+	// n.sharedPollManager (see extraBrokerPubSubChannels) for the rest of the
+	// node lifetime. Assigning the field after they start is a data race.
+	if n.config.SharedPoll.GetSharedPollChannelOptions != nil {
+		if n.clientEvents.sharedPollHandler == nil {
+			return errors.New("GetSharedPollChannelOptions is set but OnSharedPoll handler is not registered")
+		}
+		n.sharedPollManager = newSharedPollManager(n)
+	}
 	if n.controller != nil {
 		if err := n.controller.RegisterControlEventHandler(n); err != nil {
 			return err
@@ -334,14 +345,6 @@ func (n *Node) Run() error {
 		n.logger.log(newErrorLogEntry(err, "error publishing node control command", map[string]any{"error": err.Error()}))
 		return err
 	}
-	// Initialize shared poll manager if configured.
-	if n.config.SharedPoll.GetSharedPollChannelOptions != nil {
-		if n.clientEvents.sharedPollHandler == nil {
-			return errors.New("GetSharedPollChannelOptions is set but OnSharedPoll handler is not registered")
-		}
-		n.sharedPollManager = newSharedPollManager(n)
-	}
-
 	go n.sendNodePing()
 	go n.cleanNodeInfo()
 	go n.updateMetrics()

--- a/node.go
+++ b/node.go
@@ -1675,6 +1675,19 @@ func (n *Node) getBroker(ch string) Broker {
 	return n.broker
 }
 
+// extraBrokerPubSubChannels returns channels subscribed at the given broker
+// outside the Hub. The Hub is not the complete registry of broker-level
+// subscriptions: shared poll subscribes per-key channels directly and tracks
+// them itself. PUB/SUB reconnect paths must restore these together with
+// Hub().Channels(), otherwise key channels are silently lost on every
+// reconnect and key events stop flowing until keys are re-tracked.
+func (n *Node) extraBrokerPubSubChannels(b Broker) []string {
+	if n.sharedPollManager == nil {
+		return nil
+	}
+	return n.sharedPollManager.brokerChannelsSnapshot(b)
+}
+
 func (n *Node) getMapBroker(ch string) MapBroker {
 	if n.config.Map.GetMapBroker != nil {
 		if broker, ok := n.config.Map.GetMapBroker(ch); ok {

--- a/redis_pubsub_probe_test.go
+++ b/redis_pubsub_probe_test.go
@@ -704,3 +704,107 @@ func TestRedisMapBrokerPubSubProbeIdle(t *testing.T) {
 	}
 }
 
+// TestRedisBrokerPubSubRestartRestoresSharedPollKeyChannels is a regression
+// test for shared poll key channels being lost on PUB/SUB reconnect.
+//
+// Shared poll subscribes per-key channels at broker level and tracks them in
+// its own registry — they are not in the Hub. The PUB/SUB loop used to
+// resubscribe only Hub().Channels() after re-establishing a connection, so
+// every reconnect (connection error, failover, probe restart) silently
+// dropped all key channels at Redis while shared poll still believed they
+// were subscribed. Key events then never arrived again on this node until
+// each key was untracked and re-tracked — live-query push latency degraded
+// to poll cadence, permanently, with no error anywhere.
+//
+// The test drives the real subscription path (subscribeToBrokerKeys — the
+// exact function shared poll uses when a key starts being tracked), kills
+// the PUB/SUB connections through Redis (CLIENT KILL, the same connection
+// error a Redis restart produces), and requires the key channel to be
+// subscribed and delivering again after the loop reconnects. Fails against
+// the Hub-only resubscribe: the shard service channel comes back, the key
+// channel never does.
+func TestRedisBrokerPubSubRestartRestoresSharedPollKeyChannels(t *testing.T) {
+	name := "sp-keys-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	node := testNode(t)
+	s, err := NewRedisShard(node, testSingleRedisConf(6379))
+	require.NoError(t, err)
+	b, err := NewRedisBroker(node, RedisBrokerConfig{
+		Prefix: getUniquePrefix(),
+		Name:   name,
+		Shards: []*RedisShard{s},
+	})
+	require.NoError(t, err)
+	node.SetBroker(b)
+	// The manager is normally created by Node.Run when shared poll is
+	// configured; construct it directly to keep the test at broker level.
+	node.sharedPollManager = newSharedPollManager(node)
+	t.Cleanup(func() {
+		_ = node.Shutdown(context.Background())
+		stopRedisBroker(b)
+	})
+
+	received := make(chan string, 128)
+	handler := &testBrokerEventHandler{
+		HandleControlFunc: func([]byte) error { return nil },
+		HandlePublicationFunc: func(ch string, pub *Publication, sp StreamPosition, delta bool, prevPub *Publication) error {
+			received <- ch
+			return nil
+		},
+	}
+	require.NoError(t, b.RegisterBrokerEventHandler(handler))
+
+	// Subscribe a key channel through the real shared poll path.
+	channel := "sp-channel"
+	require.NoError(t, node.sharedPollManager.subscribeToBrokerKeys(channel, []string{"k1"}))
+	keyChannel := sharedPollKeyChannel(channel, "k1")
+	redisKeyChannel := string(b.messageChannelID(s, keyChannel))
+	redisShardChannel := string(b.pubSubShardChannelID(0, 0, false))
+
+	subscribedAtRedis := func(redisChannel string) bool {
+		chans, err := probeTestRedisDo(t, "127.0.0.1:6379", "PUBSUB", "CHANNELS", redisChannel).ToArray()
+		return err == nil && len(chans) > 0
+	}
+	require.Eventually(t, func() bool { return subscribedAtRedis(redisKeyChannel) },
+		5*time.Second, 50*time.Millisecond, "key channel must be subscribed at Redis after subscribeToBrokerKeys")
+
+	// Sanity: key channel delivers.
+	_, err = b.Publish(keyChannel, []byte("v1"), PublishOptions{})
+	require.NoError(t, err)
+	select {
+	case ch := <-received:
+		require.Equal(t, keyChannel, ch)
+	case <-time.After(5 * time.Second):
+		t.Fatal("key channel publication not delivered before reconnect")
+	}
+
+	// Kill all PUB/SUB connections — the same connection error a Redis
+	// restart or failover produces. The loop restarts and resubscribes.
+	require.NoError(t, probeTestRedisDo(t, "127.0.0.1:6379", "CLIENT", "KILL", "TYPE", "pubsub").Error())
+
+	// The loop is back once its shard service channel is subscribed again.
+	require.Eventually(t, func() bool { return subscribedAtRedis(redisShardChannel) },
+		10*time.Second, 50*time.Millisecond, "PUB/SUB loop did not come back after CLIENT KILL")
+
+	// Regression assertion: the key channel must come back too. Against the
+	// Hub-only resubscribe it never does.
+	require.Eventually(t, func() bool { return subscribedAtRedis(redisKeyChannel) },
+		10*time.Second, 50*time.Millisecond,
+		"shared poll key channel was not restored after PUB/SUB reconnect")
+
+	// And it must actually deliver again.
+	drainReceived(received)
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		_, err = b.Publish(keyChannel, []byte("v2"), PublishOptions{})
+		require.NoError(t, err)
+		select {
+		case ch := <-received:
+			require.Equal(t, keyChannel, ch)
+			return
+		case <-time.After(500 * time.Millisecond):
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("key channel publication not delivered after reconnect")
+		}
+	}
+}

--- a/redis_pubsub_probe_test.go
+++ b/redis_pubsub_probe_test.go
@@ -119,7 +119,7 @@ func newProbeTestSentinelBroker(tb testing.TB, probeInterval time.Duration, name
 		Name:                name,
 		Shards:              []*RedisShard{s},
 		SubscribeOnReplica:  true,
-		PubSubProbeInterval: probeInterval,
+		pubSubProbeInterval: probeInterval,
 	})
 	require.NoError(tb, err)
 	node.SetBroker(b)
@@ -311,7 +311,7 @@ func TestRedisBrokerPubSubProbeIdleConnection(t *testing.T) {
 		Prefix:              getUniquePrefix(),
 		Name:                name,
 		Shards:              []*RedisShard{s},
-		PubSubProbeInterval: 150 * time.Millisecond,
+		pubSubProbeInterval: 150 * time.Millisecond,
 	})
 	require.NoError(t, err)
 	node.SetBroker(b)
@@ -432,7 +432,7 @@ func TestRedisBrokerControlPubSubProbeIdle(t *testing.T) {
 		Prefix:              getUniquePrefix(),
 		Name:                name,
 		Shards:              []*RedisShard{s},
-		PubSubProbeInterval: 150 * time.Millisecond,
+		pubSubProbeInterval: 150 * time.Millisecond,
 	})
 	require.NoError(t, err)
 	node.SetBroker(b)
@@ -567,7 +567,7 @@ func TestRedisBrokerPubSubProbeShardedIdle(t *testing.T) {
 		Name:                       name,
 		Shards:                     []*RedisShard{s},
 		NumShardedPubSubPartitions: numPartitions,
-		PubSubProbeInterval:        150 * time.Millisecond,
+		pubSubProbeInterval:        150 * time.Millisecond,
 	})
 	require.NoError(t, err)
 	node.SetBroker(b)
@@ -652,7 +652,7 @@ func TestRedisMapBrokerPubSubProbeIdle(t *testing.T) {
 	e := redisMapBrokerFactory{}.makeCustom(t, node, handler, func(c *RedisMapBrokerConfig) {
 		c.Prefix = prefix
 		c.Name = name
-		c.PubSubProbeInterval = 150 * time.Millisecond
+		c.pubSubProbeInterval = 150 * time.Millisecond
 	})
 
 	shardChannel := e.pubSubShardChannelID(0, 0, false)

--- a/redis_pubsub_probe_test.go
+++ b/redis_pubsub_probe_test.go
@@ -1,0 +1,706 @@
+//go:build integration
+
+package centrifuge
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/redis/rueidis"
+	"github.com/stretchr/testify/require"
+)
+
+func counterValue(tb testing.TB, c prometheus.Counter) float64 {
+	tb.Helper()
+	m := &dto.Metric{}
+	require.NoError(tb, c.Write(m))
+	return m.GetCounter().GetValue()
+}
+
+// Helpers for talking to specific Redis instances directly (out-of-band from
+// the broker under test).
+
+func probeTestRedisDo(tb testing.TB, addr string, args ...string) rueidis.RedisResult {
+	tb.Helper()
+	client, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:       []string{addr},
+		DisableCache:      true,
+		ForceSingleClient: true,
+	})
+	require.NoError(tb, err)
+	defer client.Close()
+	return client.Do(context.Background(), client.B().Arbitrary(args...).Build())
+}
+
+const (
+	probeTestSentinelAddr = "127.0.0.1:26379"
+	probeTestMasterHost   = "127.0.0.1"
+	probeTestMasterPort   = "6380"
+)
+
+var probeTestReplicaAddrs = []string{"127.0.0.1:6381", "127.0.0.1:6382"}
+
+// waitReplicasHealthy waits until both replicas replicate from the master and
+// the sentinel knows about them — the precondition for building a broker with
+// a replica client.
+func waitReplicasHealthy(tb testing.TB) {
+	tb.Helper()
+	require.Eventually(tb, func() bool {
+		for _, addr := range probeTestReplicaAddrs {
+			info, err := probeTestRedisDo(tb, addr, "INFO", "replication").ToString()
+			if err != nil {
+				return false
+			}
+			if !strings.Contains(info, "role:slave") || !strings.Contains(info, "master_link_status:up") {
+				return false
+			}
+		}
+		replicas, err := probeTestRedisDo(tb, probeTestSentinelAddr, "SENTINEL", "REPLICAS", "mymaster").ToArray()
+		return err == nil && len(replicas) >= 2
+	}, 60*time.Second, 500*time.Millisecond, "replicas did not become healthy — is docker-compose sentinel service running?")
+}
+
+// replicaHoldingSubscription returns the address of the replica the broker's
+// PUB/SUB connection landed on (detected via PUBSUB CHANNELS on each replica)
+// and the address of the other replica.
+func replicaHoldingSubscription(tb testing.TB, shardChannel string) (subscribed string, other string) {
+	tb.Helper()
+	require.Eventually(tb, func() bool {
+		for i, addr := range probeTestReplicaAddrs {
+			channels, err := probeTestRedisDo(tb, addr, "PUBSUB", "CHANNELS", shardChannel).ToArray()
+			if err == nil && len(channels) > 0 {
+				subscribed = addr
+				other = probeTestReplicaAddrs[1-i]
+				return true
+			}
+		}
+		return false
+	}, 10*time.Second, 100*time.Millisecond, "PUB/SUB subscription not found on any replica")
+	return subscribed, other
+}
+
+func newProbeTestSentinelBroker(tb testing.TB, probeInterval time.Duration, name string) (*RedisBroker, chan string, chan []byte) {
+	tb.Helper()
+	var logMu sync.Mutex
+	var logClosed bool
+	node, err := New(Config{
+		LogLevel: LogLevelDebug,
+		LogHandler: func(entry LogEntry) {
+			logMu.Lock()
+			defer logMu.Unlock()
+			if !logClosed {
+				tb.Logf("[node] %s %v", entry.Message, entry.Fields)
+			}
+		},
+	})
+	require.NoError(tb, err)
+	tb.Cleanup(func() {
+		logMu.Lock()
+		logClosed = true
+		logMu.Unlock()
+	})
+	redisConf := RedisShardConfig{
+		SentinelAddresses:    []string{probeTestSentinelAddr},
+		SentinelMasterName:   "mymaster",
+		ReplicaClientEnabled: true,
+		IOTimeout:            10 * time.Second,
+		ConnectTimeout:       10 * time.Second,
+	}
+	s, err := NewRedisShard(node, redisConf)
+	require.NoError(tb, err)
+	b, err := NewRedisBroker(node, RedisBrokerConfig{
+		Prefix:              getUniquePrefix(),
+		Name:                name,
+		Shards:              []*RedisShard{s},
+		SubscribeOnReplica:  true,
+		PubSubProbeInterval: probeInterval,
+	})
+	require.NoError(tb, err)
+	node.SetBroker(b)
+	tb.Cleanup(func() {
+		_ = node.Shutdown(context.Background())
+		stopRedisBroker(b)
+	})
+
+	received := make(chan string, 128)
+	controlReceived := make(chan []byte, 128)
+	handler := &testBrokerEventHandler{
+		HandleControlFunc: func(data []byte) error {
+			controlReceived <- data
+			return nil
+		},
+		HandlePublicationFunc: func(ch string, pub *Publication, sp StreamPosition, delta bool, prevPub *Publication) error {
+			received <- ch
+			return nil
+		},
+	}
+	require.NoError(tb, b.RegisterControlEventHandler(handler))
+	require.NoError(tb, b.RegisterBrokerEventHandler(handler))
+	return b, received, controlReceived
+}
+
+func drainReceived(received chan string) {
+	for {
+		select {
+		case <-received:
+		default:
+			return
+		}
+	}
+}
+
+// waitDelivery publishes to the channel until a publication is delivered or
+// the deadline passes. Returns true when delivery works.
+//
+// It re-issues the channel subscription on every attempt. In production,
+// channels are resubscribed automatically after a PUB/SUB loop restart from
+// Hub().Channels(); broker-level tests bypass the Hub, so the restarted loop
+// would not resubscribe test channels on its own. Re-subscribing does not
+// weaken the test: subscribing goes to whatever node the current PUB/SUB
+// connection is attached to, so while the loop sits on a detached node the
+// published messages still do not arrive.
+func waitDelivery(tb testing.TB, b *RedisBroker, received chan string, channel string, deadline time.Duration) bool {
+	tb.Helper()
+	until := time.Now().Add(deadline)
+	for time.Now().Before(until) {
+		if err := b.Subscribe(channel); err != nil {
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+		_, err := b.Publish(channel, []byte("payload"), PublishOptions{})
+		if err != nil {
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+		select {
+		case <-received:
+			return true
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+	return false
+}
+
+// detachReplica turns the given replica into a standalone Redis and makes the
+// sentinel forget it, so nothing ever reconfigures it back during the test.
+// This reproduces, through real Redis commands only, the state behind
+// centrifugal/centrifugo#1189: the broker's PUB/SUB connection stays perfectly
+// healthy on the TCP level — the node answers keepalive pings and accepts
+// commands — but the node is outside the master's replication chain, so no
+// published message ever reaches it. No connection error fires, ever.
+func detachReplica(tb testing.TB, addr string) {
+	tb.Helper()
+	require.NoError(tb, probeTestRedisDo(tb, addr, "REPLICAOF", "NO", "ONE").Error())
+	tb.Cleanup(func() {
+		// Restore topology for other tests.
+		_ = probeTestRedisDo(tb, addr, "REPLICAOF", probeTestMasterHost, probeTestMasterPort).Error()
+	})
+	// Give the master a moment to drop the replication link, so the sentinel
+	// re-discovers only the still-attached replica after the reset below.
+	time.Sleep(500 * time.Millisecond)
+	require.NoError(tb, probeTestRedisDo(tb, probeTestSentinelAddr, "SENTINEL", "RESET", "mymaster").Error())
+}
+
+// TestRedisBrokerPubSubProbeRecoversDetachedReplica reproduces the silent
+// starvation from centrifugal/centrifugo#1189 end to end and checks that the
+// liveness probe recovers from it.
+//
+// Geometry: the broker subscribes on a replica (SubscribeOnReplica) while
+// publishes go to the master. The replica holding the PUB/SUB connection is
+// then detached from the master and forgotten by the sentinel. The connection
+// stays healthy — the detached node answers pings — but published messages no
+// longer reach it. Without the probe the subscriber starves until process
+// restart (see TestRedisBrokerPubSubDisabledProbeStarves). With the probe the
+// idle connection fails its liveness check, the loop restarts, the client
+// re-resolves replicas via the sentinel, lands on the surviving replica, and
+// delivery resumes — with no connection error involved at any point.
+func TestRedisBrokerPubSubProbeRecoversDetachedReplica(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in short mode: requires sentinel with replicas")
+	}
+	waitReplicasHealthy(t)
+
+	name := "probe-recover-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	b, received, _ := newProbeTestSentinelBroker(t, 300*time.Millisecond, name)
+
+	channel := "probe-test-ch"
+	require.NoError(t, b.Subscribe(channel))
+
+	// Sanity: delivery works through the replica before the detach.
+	require.True(t, waitDelivery(t, b, received, channel, 10*time.Second),
+		"initial publish was not delivered via replica subscription")
+
+	shardChannel := string(b.pubSubShardChannelID(0, 0, false))
+	subscribedReplica, _ := replicaHoldingSubscription(t, shardChannel)
+	detachReplica(t, subscribedReplica)
+	drainReceived(received)
+
+	// Starvation: publishes succeed, nothing arrives, no error anywhere.
+	_, err := b.Publish(channel, []byte("starved"), PublishOptions{})
+	require.NoError(t, err)
+	select {
+	case ch := <-received:
+		t.Fatalf("unexpected delivery on %s right after replica detach", ch)
+	case <-time.After(1 * time.Second):
+	}
+
+	// Recovery: probe detects the stale connection, the loop restarts and
+	// re-resolves to the surviving replica. The sentinel needs up to ~10s
+	// (one INFO period) to re-discover the surviving replica after RESET,
+	// so the deadline is generous.
+	require.True(t, waitDelivery(t, b, received, channel, 45*time.Second),
+		"delivery did not recover after replica detach — probe restart did not happen or did not help")
+
+	// Prove recovery came from the probe: the probe timeout must have fired
+	// at least once for this broker.
+	probeTimeouts := counterValue(t, b.node.metrics.brokerPubSub.errors.WithLabelValues(name, "probe_timeout"))
+	require.GreaterOrEqual(t, probeTimeouts, 1.0, "expected at least one probe timeout to trigger the restart")
+}
+
+// TestRedisBrokerPubSubDisabledProbeStarves documents the behavior this probe
+// exists to fix: with probing disabled, the same detached-replica state
+// starves the subscriber indefinitely — publishes succeed, the PUB/SUB
+// connection stays healthy, and nothing ever restarts it.
+func TestRedisBrokerPubSubDisabledProbeStarves(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in short mode: requires sentinel with replicas")
+	}
+	waitReplicasHealthy(t)
+
+	name := "probe-disabled-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	b, received, _ := newProbeTestSentinelBroker(t, -1, name)
+
+	channel := "probe-test-ch-disabled"
+	require.NoError(t, b.Subscribe(channel))
+	require.True(t, waitDelivery(t, b, received, channel, 10*time.Second),
+		"initial publish was not delivered via replica subscription")
+
+	shardChannel := string(b.pubSubShardChannelID(0, 0, false))
+	subscribedReplica, _ := replicaHoldingSubscription(t, shardChannel)
+	detachReplica(t, subscribedReplica)
+	drainReceived(received)
+
+	until := time.Now().Add(4 * time.Second)
+	for time.Now().Before(until) {
+		_, err := b.Publish(channel, []byte("starved"), PublishOptions{})
+		require.NoError(t, err, "publishes must keep succeeding — that is what makes this failure silent")
+		select {
+		case ch := <-received:
+			t.Fatalf("unexpected delivery on %s: without the probe nothing should recover the subscription", ch)
+		case <-time.After(400 * time.Millisecond):
+		}
+	}
+}
+
+// TestRedisBrokerPubSubProbeIdleConnection checks the probe steady state on a
+// healthy idle connection: probes are published to the shard service channel,
+// loop back through Redis, are consumed by the loop itself without reaching
+// message handlers, and no restart happens.
+func TestRedisBrokerPubSubProbeIdleConnection(t *testing.T) {
+	name := "probe-idle-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	node := testNode(t)
+	s, err := NewRedisShard(node, testSingleRedisConf(6379))
+	require.NoError(t, err)
+	b, err := NewRedisBroker(node, RedisBrokerConfig{
+		Prefix:              getUniquePrefix(),
+		Name:                name,
+		Shards:              []*RedisShard{s},
+		PubSubProbeInterval: 150 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	node.SetBroker(b)
+	t.Cleanup(func() {
+		_ = node.Shutdown(context.Background())
+		stopRedisBroker(b)
+	})
+
+	received := make(chan string, 128)
+	handler := &testBrokerEventHandler{
+		HandleControlFunc: func([]byte) error { return nil },
+		HandlePublicationFunc: func(ch string, pub *Publication, sp StreamPosition, delta bool, prevPub *Publication) error {
+			received <- ch
+			return nil
+		},
+	}
+	require.NoError(t, b.RegisterBrokerEventHandler(handler))
+	channel := "probe-idle-ch"
+	require.NoError(t, b.Subscribe(channel))
+
+	// Observe the shard service channel out-of-band: the probes the broker
+	// publishes there are visible to any subscriber of that channel.
+	shardChannel := string(b.pubSubShardChannelID(0, 0, false))
+	probeSeen := make(chan struct{}, 16)
+	observer, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:       []string{"127.0.0.1:6379"},
+		DisableCache:      true,
+		ForceSingleClient: true,
+	})
+	require.NoError(t, err)
+	defer observer.Close()
+	observerDone := make(chan struct{})
+	go func() {
+		defer close(observerDone)
+		_ = observer.Receive(context.Background(), observer.B().Subscribe().Channel(shardChannel).Build(), func(msg rueidis.PubSubMessage) {
+			if msg.Message == pubSubProbeMessage {
+				select {
+				case probeSeen <- struct{}{}:
+				default:
+				}
+			}
+		})
+	}()
+
+	// Idle through several probe intervals.
+	select {
+	case <-probeSeen:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no liveness probe observed on the shard channel while the connection was idle")
+	}
+	time.Sleep(500 * time.Millisecond) // a few more cycles
+
+	// Probes must not surface as publications and must not be treated as
+	// probe timeouts (the loopback keeps the connection alive).
+	select {
+	case ch := <-received:
+		t.Fatalf("unexpected publication on %s: probes must be consumed by the PUB/SUB loop", ch)
+	default:
+	}
+	probeTimeouts := counterValue(t, b.node.metrics.brokerPubSub.errors.WithLabelValues(name, "probe_timeout"))
+	require.Equal(t, 0.0, probeTimeouts, "healthy idle connection must not fail liveness checks")
+
+	// And the connection still delivers real messages.
+	_, err = b.Publish(channel, []byte("after-idle"), PublishOptions{})
+	require.NoError(t, err)
+	select {
+	case <-received:
+	case <-time.After(5 * time.Second):
+		t.Fatal("publication not delivered after idle probing period")
+	}
+
+	observer.Close()
+	<-observerDone
+}
+
+// drainControl empties the control receive channel.
+func drainControl(controlReceived chan []byte) {
+	for {
+		select {
+		case <-controlReceived:
+		default:
+			return
+		}
+	}
+}
+
+// waitControlDelivery publishes a control message until one is delivered back
+// through the control PUB/SUB connection or the deadline passes.
+func waitControlDelivery(tb testing.TB, b *RedisBroker, controlReceived chan []byte, deadline time.Duration) bool {
+	tb.Helper()
+	until := time.Now().Add(deadline)
+	for time.Now().Before(until) {
+		if err := b.PublishControl([]byte("control-payload"), "", ""); err != nil {
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+		select {
+		case <-controlReceived:
+			return true
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+	return false
+}
+
+// TestRedisBrokerControlPubSubProbeIdle verifies control-loop probing on a
+// healthy but silent control connection. In production the control channel
+// carries node info pings every few seconds, which keeps the connection
+// non-idle and probing dormant. Here the node is not running, so the control
+// channel is genuinely silent — the state in which probing must activate,
+// loop back through the per-node probe channel, and cause no restarts.
+func TestRedisBrokerControlPubSubProbeIdle(t *testing.T) {
+	name := "ctl-probe-idle-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	node := testNode(t)
+	s, err := NewRedisShard(node, testSingleRedisConf(6379))
+	require.NoError(t, err)
+	b, err := NewRedisBroker(node, RedisBrokerConfig{
+		Prefix:              getUniquePrefix(),
+		Name:                name,
+		Shards:              []*RedisShard{s},
+		PubSubProbeInterval: 150 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	node.SetBroker(b)
+	t.Cleanup(func() {
+		_ = node.Shutdown(context.Background())
+		stopRedisBroker(b)
+	})
+
+	controlReceived := make(chan []byte, 128)
+	handler := &testBrokerEventHandler{
+		HandleControlFunc: func(data []byte) error {
+			controlReceived <- data
+			return nil
+		},
+	}
+	require.NoError(t, b.RegisterControlEventHandler(handler))
+
+	// Observe the per-node probe channel out-of-band.
+	probeChannel := b.nodeChannel + ".probe"
+	probeSeen := make(chan struct{}, 16)
+	observer, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:       []string{"127.0.0.1:6379"},
+		DisableCache:      true,
+		ForceSingleClient: true,
+	})
+	require.NoError(t, err)
+	defer observer.Close()
+	observerDone := make(chan struct{})
+	observerCtx, observerCancel := context.WithCancel(context.Background())
+	defer observerCancel()
+	go func() {
+		defer close(observerDone)
+		_ = observer.Receive(observerCtx, observer.B().Subscribe().Channel(probeChannel).Build(), func(msg rueidis.PubSubMessage) {
+			if msg.Message == pubSubProbeMessage {
+				select {
+				case probeSeen <- struct{}{}:
+				default:
+				}
+			}
+		})
+	}()
+
+	select {
+	case <-probeSeen:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no control liveness probe observed while the control connection was idle")
+	}
+	time.Sleep(500 * time.Millisecond) // a few more probe cycles
+
+	// Probes must not reach the control handler and must not count as
+	// timeouts (the loopback keeps the connection alive).
+	select {
+	case data := <-controlReceived:
+		t.Fatalf("unexpected control message %q: probes must be consumed by the control PUB/SUB loop", data)
+	default:
+	}
+	timeouts := counterValue(t, b.node.metrics.redisBrokerPubSubErrors.WithLabelValues(name, "control_probe_timeout"))
+	require.Equal(t, 0.0, timeouts, "healthy idle control connection must not fail liveness checks")
+
+	// Real control messages still flow.
+	require.True(t, waitControlDelivery(t, b, controlReceived, 5*time.Second),
+		"control message not delivered after idle probing period")
+}
+
+// TestRedisBrokerControlPubSubProbeRecoversDetachedReplica: the control-loop
+// variant of the detached-replica scenario. With SubscribeOnReplica the
+// control connection also lives on a replica; detaching that replica silently
+// starves the node of all control traffic — other nodes' pings and commands —
+// while the connection stays healthy. The probe must detect the silence and
+// restart the control connection, which lands on the surviving replica.
+// Unlike client channels, the control channel set is fixed, so restart-based
+// recovery is fully self-contained.
+func TestRedisBrokerControlPubSubProbeRecoversDetachedReplica(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in short mode: requires sentinel with replicas")
+	}
+	waitReplicasHealthy(t)
+
+	name := "ctl-probe-recover-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	b, _, controlReceived := newProbeTestSentinelBroker(t, 300*time.Millisecond, name)
+
+	// Sanity: control delivery works through the replica.
+	require.True(t, waitControlDelivery(t, b, controlReceived, 10*time.Second),
+		"initial control message was not delivered via replica subscription")
+
+	// Find the replica holding the control subscription and detach it.
+	subscribedReplica, _ := replicaHoldingSubscription(t, b.controlChannel)
+	detachReplica(t, subscribedReplica)
+	drainControl(controlReceived)
+
+	// Starvation: control publishes succeed, nothing arrives.
+	require.NoError(t, b.PublishControl([]byte("starved"), "", ""))
+	select {
+	case <-controlReceived:
+		t.Fatal("unexpected control delivery right after replica detach")
+	case <-time.After(1 * time.Second):
+	}
+
+	// Recovery via probe restart.
+	require.True(t, waitControlDelivery(t, b, controlReceived, 45*time.Second),
+		"control delivery did not recover after replica detach")
+	timeouts := counterValue(t, b.node.metrics.redisBrokerPubSubErrors.WithLabelValues(name, "control_probe_timeout"))
+	require.GreaterOrEqual(t, timeouts, 1.0, "expected at least one control probe timeout to trigger the restart")
+}
+
+// TestRedisBrokerPubSubProbeShardedIdle verifies the probe steady state in
+// (non-node-grouped) sharded PUB/SUB mode against a real Redis Cluster: each
+// partition loop probes its own hash-tagged shard channel via SPUBLISH, the
+// probe routes to the right cluster node, loops back, and causes neither
+// publications nor restarts.
+func TestRedisBrokerPubSubProbeShardedIdle(t *testing.T) {
+	name := "probe-sharded-idle-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	node := testNode(t)
+	prefix := getUniquePrefix()
+	redisConf := RedisShardConfig{
+		ClusterAddresses: []string{"127.0.0.1:7001", "127.0.0.1:7002", "127.0.0.1:7003"},
+		IOTimeout:        10 * time.Second,
+		ConnectTimeout:   10 * time.Second,
+	}
+	s, err := NewRedisShard(node, redisConf)
+	require.NoError(t, err)
+
+	// Sharded PUB/SUB is a Redis 7+ feature.
+	result := s.client.Do(context.Background(), s.client.B().Spublish().Channel(prefix+"._").Message("").Build())
+	if result.Error() != nil && strings.Contains(result.Error().Error(), "unknown command") {
+		t.Skip("sharded PUB/SUB not supported by this Redis version, skipping test")
+	}
+
+	numPartitions := 4
+	b, err := NewRedisBroker(node, RedisBrokerConfig{
+		Prefix:                     prefix,
+		Name:                       name,
+		Shards:                     []*RedisShard{s},
+		NumShardedPubSubPartitions: numPartitions,
+		PubSubProbeInterval:        150 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	node.SetBroker(b)
+	t.Cleanup(func() {
+		_ = node.Shutdown(context.Background())
+		stopRedisBroker(b)
+	})
+
+	received := make(chan string, 128)
+	handler := &testBrokerEventHandler{
+		HandleControlFunc: func([]byte) error { return nil },
+		HandlePublicationFunc: func(ch string, pub *Publication, sp StreamPosition, delta bool, prevPub *Publication) error {
+			received <- ch
+			return nil
+		},
+	}
+	require.NoError(t, b.RegisterBrokerEventHandler(handler))
+
+	// Observe every partition's shard channel: each partition loop must
+	// probe its own channel.
+	observer, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{"127.0.0.1:7001", "127.0.0.1:7002", "127.0.0.1:7003"},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer observer.Close()
+	var probesSeen sync.Map
+	observerCtx, observerCancel := context.WithCancel(context.Background())
+	defer observerCancel()
+	for partIdx := 0; partIdx < numPartitions; partIdx++ {
+		shardCh := string(b.pubSubShardChannelID(partIdx, 0, true))
+		go func(shardCh string) {
+			_ = observer.Receive(observerCtx, observer.B().Ssubscribe().Channel(shardCh).Build(), func(msg rueidis.PubSubMessage) {
+				if msg.Message == pubSubProbeMessage {
+					probesSeen.Store(shardCh, struct{}{})
+				}
+			})
+		}(shardCh)
+	}
+
+	require.Eventually(t, func() bool {
+		count := 0
+		probesSeen.Range(func(_, _ any) bool { count++; return true })
+		return count == numPartitions
+	}, 10*time.Second, 100*time.Millisecond, "every partition loop must probe its own shard channel")
+
+	select {
+	case ch := <-received:
+		t.Fatalf("unexpected publication on %s: probes must be consumed by the PUB/SUB loop", ch)
+	default:
+	}
+	timeouts := counterValue(t, b.node.metrics.brokerPubSub.errors.WithLabelValues(name, "probe_timeout"))
+	require.Equal(t, 0.0, timeouts, "healthy idle sharded connections must not fail liveness checks")
+
+	// Real sharded delivery still works.
+	channel := "probe-sharded-ch"
+	require.NoError(t, b.Subscribe(channel))
+	_, err = b.Publish(channel, []byte("after-idle"), PublishOptions{})
+	require.NoError(t, err)
+	select {
+	case <-received:
+	case <-time.After(5 * time.Second):
+		t.Fatal("sharded publication not delivered after idle probing period")
+	}
+}
+
+// TestRedisMapBrokerPubSubProbeIdle verifies the probe steady state for the
+// map broker, which shares runPubSubLoop with RedisBroker but has its own
+// config, metrics and shard channel naming.
+func TestRedisMapBrokerPubSubProbeIdle(t *testing.T) {
+	name := "map-probe-idle-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	node := testNode(t)
+
+	received := make(chan string, 128)
+	handler := &testBrokerEventHandler{
+		HandlePublicationFunc: func(ch string, pub *Publication, sp StreamPosition, delta bool, prevPub *Publication) error {
+			received <- ch
+			return nil
+		},
+	}
+	prefix := getUniquePrefix()
+	e := redisMapBrokerFactory{}.makeCustom(t, node, handler, func(c *RedisMapBrokerConfig) {
+		c.Prefix = prefix
+		c.Name = name
+		c.PubSubProbeInterval = 150 * time.Millisecond
+	})
+
+	shardChannel := e.pubSubShardChannelID(0, 0, false)
+	probeSeen := make(chan struct{}, 16)
+	observer, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:       []string{"127.0.0.1:6379"},
+		DisableCache:      true,
+		ForceSingleClient: true,
+	})
+	require.NoError(t, err)
+	defer observer.Close()
+	observerCtx, observerCancel := context.WithCancel(context.Background())
+	defer observerCancel()
+	go func() {
+		_ = observer.Receive(observerCtx, observer.B().Subscribe().Channel(shardChannel).Build(), func(msg rueidis.PubSubMessage) {
+			if msg.Message == pubSubProbeMessage {
+				select {
+				case probeSeen <- struct{}{}:
+				default:
+				}
+			}
+		})
+	}()
+
+	select {
+	case <-probeSeen:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no liveness probe observed on the map broker shard channel while idle")
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	select {
+	case ch := <-received:
+		t.Fatalf("unexpected publication on %s: probes must be consumed by the PUB/SUB loop", ch)
+	default:
+	}
+	timeouts := counterValue(t, node.metrics.mapBrokerPubSub.errors.WithLabelValues(name, "probe_timeout"))
+	require.Equal(t, 0.0, timeouts, "healthy idle map broker connection must not fail liveness checks")
+
+	// Real map delivery still works.
+	channel := "map-probe-ch"
+	require.NoError(t, e.Subscribe(channel))
+	_, err = e.Publish(context.Background(), channel, "key1", MapPublishOptions{})
+	require.NoError(t, err)
+	select {
+	case <-received:
+	case <-time.After(5 * time.Second):
+		t.Fatal("map publication not delivered after idle probing period")
+	}
+}
+

--- a/redis_pubsub_shared.go
+++ b/redis_pubsub_shared.go
@@ -59,6 +59,10 @@ type pubSubCallbacks struct {
 	messageChannelID func(ch string) string
 	// shardForChannel returns the RedisShard for a given channel (for filtering during resubscribe).
 	shardForChannel func(ch string) *RedisShard
+	// extraResubscribeChannels returns broker-level channel subscriptions that
+	// must survive PUB/SUB reconnects but are not tracked in the Hub (shared
+	// poll key channels). May be nil.
+	extraResubscribeChannels func() []string
 }
 
 func getPubSubStartLogFields(s *RedisShard, logFields map[string]any) map[string]any {
@@ -234,6 +238,11 @@ func runPubSubLoop(
 	}
 
 	channels := node.Hub().Channels()
+	if cb.extraResubscribeChannels != nil {
+		// Broker-level subscriptions not tracked in the Hub (shared poll key
+		// channels) go through the same per-shard/partition filters below.
+		channels = append(channels, cb.extraResubscribeChannels()...)
+	}
 
 	var wg sync.WaitGroup
 	started := time.Now()

--- a/redis_pubsub_shared.go
+++ b/redis_pubsub_shared.go
@@ -18,7 +18,25 @@ const (
 	// defaultPubSubProbeInterval is the default idle interval after which a
 	// PUB/SUB connection gets a liveness probe.
 	defaultPubSubProbeInterval = 30 * time.Second
+
+	// minPubSubProbeInterval is the floor for a configured probe interval.
+	// Probing below this makes no sense: the interval is also the deadline
+	// for the probe round trip, and shorter values turn ordinary Redis
+	// latency into connection restarts.
+	minPubSubProbeInterval = 100 * time.Millisecond
 )
+
+// normalizePubSubProbeInterval normalizes a configured probe interval: zero
+// means default, negative disables probing, positive is clamped to the floor.
+func normalizePubSubProbeInterval(configured time.Duration) time.Duration {
+	if configured == 0 {
+		return defaultPubSubProbeInterval
+	}
+	if configured > 0 && configured < minPubSubProbeInterval {
+		return minPubSubProbeInterval
+	}
+	return configured
+}
 
 // pubSubProbeMessage is the payload of PUB/SUB liveness probes. Probes are
 // recognized by the channel they arrive on (the shard service channel), not
@@ -30,7 +48,12 @@ const pubSubProbeMessage = "probe"
 // shard client (the master), even when the PUB/SUB loop subscribes on a
 // replica — in that mode a delivered probe additionally verifies the
 // replication link.
-func publishPubSubProbe(shard *RedisShard, node *Node, psm redisPubSubMetrics, name, shardChannel string, useShardedPubSub bool, timeout time.Duration, logFields map[string]any) {
+//
+// Returns true when Redis accepted the PUBLISH. Only a probe that was really
+// sent can prove anything about the receive path — see the probe branch of
+// runPubSubLoop. The timeout callers pass is the probe interval itself: an
+// attempt that takes longer than that is superseded by the next one anyway.
+func publishPubSubProbe(shard *RedisShard, node *Node, psm redisPubSubMetrics, name, shardChannel string, useShardedPubSub bool, timeout time.Duration, logFields map[string]any) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	var cmd rueidis.Completed
@@ -40,12 +63,47 @@ func publishPubSubProbe(shard *RedisShard, node *Node, psm redisPubSubMetrics, n
 		cmd = shard.client.B().Publish().Channel(shardChannel).Message(pubSubProbeMessage).Build()
 	}
 	if err := shard.client.Do(ctx, cmd).Error(); err != nil {
-		// A failed publish becomes a failed probe on the next tick. Still
-		// worth logging separately: it means the publish path is broken too,
-		// so restarting the PUB/SUB connection alone may not help.
 		psm.incErrors(name, "probe_publish")
 		node.logger.log(newErrorLogEntry(err, "error publishing PUB/SUB probe", logFields))
+		return false
 	}
+	return true
+}
+
+// pubSubProbeState is the part of the liveness probing state that must
+// survive a loop restart. It is created once per PUB/SUB loop identity by the
+// broker starting the loop, and is only ever touched by that single loop
+// goroutine (runForever runs one loop instance at a time), so it needs no
+// synchronization.
+type pubSubProbeState struct {
+	// consecutiveRestarts counts loop restarts caused by failed liveness
+	// probes since the last time the connection delivered something. Reset
+	// as soon as any message arrives.
+	consecutiveRestarts int
+}
+
+// pubSubProbeRestartBackoff spaces out repeated probe-triggered restarts.
+//
+// Restarting only helps if the new connection lands on a node that actually
+// delivers. When it does not — the underlying client keeps resolving to the
+// same wedged node — unbounded restarts would resubscribe every channel of
+// this node every couple of intervals, which is expensive precisely when
+// Redis is least able to take it. The first restart is immediate (the common
+// case, where reconnecting fixes it), each further one doubles the wait, and
+// the wait is capped at ten intervals.
+func pubSubProbeRestartBackoff(interval time.Duration, consecutiveRestarts int) time.Duration {
+	if consecutiveRestarts <= 1 {
+		return 0
+	}
+	maxBackoff := 10 * interval
+	backoff := interval
+	for i := 2; i < consecutiveRestarts; i++ {
+		backoff *= 2
+		if backoff >= maxBackoff {
+			return maxBackoff
+		}
+	}
+	return backoff
 }
 
 // pubSubCallbacks carries the type-varying behavior as function pointers.
@@ -98,6 +156,7 @@ func runPubSubLoop(
 	psm redisPubSubMetrics,
 	subscribeOnReplica bool,
 	probeInterval time.Duration,
+	probeState *pubSubProbeState,
 	numProcessors, numResubscribeShards, numSubscribeShards, numPartitions int,
 	logFields map[string]any,
 	eventHandler BrokerEventHandler,
@@ -349,9 +408,9 @@ func runPubSubLoop(
 	// The probe ticker breaks that: when nothing has been received for a
 	// full interval, publish a small probe to the shard service channel
 	// through the regular publish path and expect it back on this
-	// connection. If a probe was sent and a whole further interval passed
-	// without receiving ANYTHING (not even the probe), the connection is
-	// considered stale and the loop restarts, re-resolving the topology.
+	// connection. If a probe was really sent and a whole further interval
+	// passed without receiving ANYTHING (not even the probe), the connection
+	// is considered stale and the loop restarts, re-resolving the topology.
 	// Under regular traffic the probe never fires, so the steady-state cost
 	// is one atomic load per interval.
 	var probeTickerCh <-chan time.Time
@@ -361,7 +420,10 @@ func runPubSubLoop(
 		probeTickerCh = probeTicker.C
 	}
 	var seenCount uint64
-	var probeOutstanding bool
+	// probeSent is non-nil while a probe attempt is outstanding and becomes
+	// true once Redis has accepted that PUBLISH. Publishing happens off this
+	// goroutine, so the loop learns the outcome through the flag.
+	var probeSent *atomic.Bool
 	for {
 		select {
 		case err = <-wait:
@@ -381,19 +443,50 @@ func runPubSubLoop(
 				// The connection delivered something during the last
 				// interval (possibly a previous probe) — alive.
 				seenCount = cur
-				probeOutstanding = false
+				probeSent = nil
+				probeState.consecutiveRestarts = 0
 				continue
 			}
-			if probeOutstanding {
+			if probeSent != nil && probeSent.Load() {
 				// A probe was published a full interval ago and nothing at
 				// all has been received since — the connection is attached
 				// to a node that does not deliver published traffic.
 				psm.incErrors(name, "probe_timeout")
-				node.logger.log(newLogEntry(LogLevelWarn, "no PUB/SUB message received since liveness probe was sent, restarting PUB/SUB connection", logFields))
+				probeState.consecutiveRestarts++
+				backoff := pubSubProbeRestartBackoff(probeInterval, probeState.consecutiveRestarts)
+				restartLogFields := make(map[string]any, len(logFields)+2)
+				for k, v := range logFields {
+					restartLogFields[k] = v
+				}
+				restartLogFields["consecutive_probe_restarts"] = probeState.consecutiveRestarts
+				restartLogFields["restart_delay"] = backoff.String()
+				node.logger.log(newLogEntry(LogLevelWarn, "no PUB/SUB message received since liveness probe was sent, restarting PUB/SUB connection", restartLogFields))
+				if backoff > 0 {
+					// Keep the connection in place while waiting: it is stale,
+					// not broken, so subscriptions issued meanwhile still
+					// succeed and are restored by the resubscribe on restart.
+					select {
+					case <-time.After(backoff):
+					case <-done:
+					case <-shard.closeCh:
+					}
+				}
 				return
 			}
-			probeOutstanding = true
-			go publishPubSubProbe(shard, node, psm, name, shardChannel, useShardedPubSub, probeInterval, logFields)
+			// Either no probe was outstanding, or the outstanding one never
+			// reached Redis — the publish failed or is still in flight. A
+			// probe that was not sent says nothing about the receive path:
+			// it is the publish path that is broken (a failing over master,
+			// a READONLY pin), and restarting the PUB/SUB connection would
+			// not fix that while resubscribing every channel of this node.
+			// Start a fresh attempt instead.
+			sent := &atomic.Bool{}
+			probeSent = sent
+			go func() {
+				if publishPubSubProbe(shard, node, psm, name, shardChannel, useShardedPubSub, probeInterval, logFields) {
+					sent.Store(true)
+				}
+			}()
 		}
 	}
 }

--- a/redis_pubsub_shared.go
+++ b/redis_pubsub_shared.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/centrifugal/centrifuge/internal/convert"
@@ -13,7 +14,39 @@ import (
 
 const (
 	pubSubProcessorBufferSize = 4096
+
+	// defaultPubSubProbeInterval is the default idle interval after which a
+	// PUB/SUB connection gets a liveness probe.
+	defaultPubSubProbeInterval = 30 * time.Second
 )
+
+// pubSubProbeMessage is the payload of PUB/SUB liveness probes. Probes are
+// recognized by the channel they arrive on (the shard service channel), not
+// by payload — the payload only helps when inspecting traffic by hand.
+const pubSubProbeMessage = "probe"
+
+// publishPubSubProbe publishes a liveness probe to the shard service channel
+// through the regular publish path. The publish always goes through the main
+// shard client (the master), even when the PUB/SUB loop subscribes on a
+// replica — in that mode a delivered probe additionally verifies the
+// replication link.
+func publishPubSubProbe(shard *RedisShard, node *Node, psm redisPubSubMetrics, name, shardChannel string, useShardedPubSub bool, timeout time.Duration, logFields map[string]any) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	var cmd rueidis.Completed
+	if useShardedPubSub {
+		cmd = shard.client.B().Spublish().Channel(shardChannel).Message(pubSubProbeMessage).Build()
+	} else {
+		cmd = shard.client.B().Publish().Channel(shardChannel).Message(pubSubProbeMessage).Build()
+	}
+	if err := shard.client.Do(ctx, cmd).Error(); err != nil {
+		// A failed publish becomes a failed probe on the next tick. Still
+		// worth logging separately: it means the publish path is broken too,
+		// so restarting the PUB/SUB connection alone may not help.
+		psm.incErrors(name, "probe_publish")
+		node.logger.log(newErrorLogEntry(err, "error publishing PUB/SUB probe", logFields))
+	}
+}
 
 // pubSubCallbacks carries the type-varying behavior as function pointers.
 // Both RedisBroker and RedisMapBroker provide their own callbacks.
@@ -60,6 +93,7 @@ func runPubSubLoop(
 	name string,
 	psm redisPubSubMetrics,
 	subscribeOnReplica bool,
+	probeInterval time.Duration,
 	numProcessors, numResubscribeShards, numSubscribeShards, numPartitions int,
 	logFields map[string]any,
 	eventHandler BrokerEventHandler,
@@ -146,8 +180,22 @@ func runPubSubLoop(
 	defer cancel()
 	defer conn.Close()
 
+	// receivedCount counts messages delivered by this connection. It feeds
+	// the liveness probing below: a connection that received anything since
+	// the previous check is alive and is not probed. A counter increment is
+	// the only per-message cost of probing.
+	var receivedCount atomic.Uint64
+
 	wait := conn.SetPubSubHooks(rueidis.PubSubHooks{
 		OnMessage: func(msg rueidis.PubSubMessage) {
+			receivedCount.Add(1)
+			if msg.Channel == shardChannel {
+				// The shard channel is a service channel: nothing publishes
+				// real traffic to it, only liveness probes arrive here. The
+				// probe did its job by updating receivedCount — don't pass it
+				// to message processors.
+				return
+			}
 			select {
 			case processors[index(msg.Channel, numProcessors)] <- msg:
 			case <-done:
@@ -280,15 +328,64 @@ func runPubSubLoop(
 		<-done
 	}()
 
-	select {
-	case err = <-wait:
-		startOnce(err)
-		if err != nil {
-			psm.incErrors(name, "connection")
-			node.logger.log(newErrorLogEntry(err, "pub/sub connection error", logFields))
+	// The loop below parks until the connection errors, the loop is asked to
+	// stop, or the shard closes. A healthy-looking connection is not enough
+	// to park on forever: after a Redis failover the connection may end up
+	// attached to a node that answers keepalive pings and accepts commands
+	// but never receives the published traffic — a demoted master, a node
+	// outside the replication chain, or an unrelated Redis on a reused IP
+	// (see centrifugal/centrifugo#1189). No connection error ever fires in
+	// that state, so subscribers starve silently until process restart.
+	//
+	// The probe ticker breaks that: when nothing has been received for a
+	// full interval, publish a small probe to the shard service channel
+	// through the regular publish path and expect it back on this
+	// connection. If a probe was sent and a whole further interval passed
+	// without receiving ANYTHING (not even the probe), the connection is
+	// considered stale and the loop restarts, re-resolving the topology.
+	// Under regular traffic the probe never fires, so the steady-state cost
+	// is one atomic load per interval.
+	var probeTickerCh <-chan time.Time
+	if probeInterval > 0 {
+		probeTicker := time.NewTicker(probeInterval)
+		defer probeTicker.Stop()
+		probeTickerCh = probeTicker.C
+	}
+	var seenCount uint64
+	var probeOutstanding bool
+	for {
+		select {
+		case err = <-wait:
+			startOnce(err)
+			if err != nil {
+				psm.incErrors(name, "connection")
+				node.logger.log(newErrorLogEntry(err, "pub/sub connection error", logFields))
+			}
+			return
+		case <-done:
+			return
+		case <-shard.closeCh:
+			return
+		case <-probeTickerCh:
+			cur := receivedCount.Load()
+			if cur != seenCount {
+				// The connection delivered something during the last
+				// interval (possibly a previous probe) — alive.
+				seenCount = cur
+				probeOutstanding = false
+				continue
+			}
+			if probeOutstanding {
+				// A probe was published a full interval ago and nothing at
+				// all has been received since — the connection is attached
+				// to a node that does not deliver published traffic.
+				psm.incErrors(name, "probe_timeout")
+				node.logger.log(newLogEntry(LogLevelWarn, "no PUB/SUB message received since liveness probe was sent, restarting PUB/SUB connection", logFields))
+				return
+			}
+			probeOutstanding = true
+			go publishPubSubProbe(shard, node, psm, name, shardChannel, useShardedPubSub, probeInterval, logFields)
 		}
-	case <-done:
-	case <-shard.closeCh:
 	}
 }
 

--- a/shared_poll.go
+++ b/shared_poll.go
@@ -1000,10 +1000,15 @@ func (s *sharedPollChannelState) flipEpochAndCollectClients(hub *keyedHub, newEp
 // the reconnect resubscribes Hub().Channels() and nothing else. The Redis
 // PUB/SUB loops call this (via Node) to restore key channels together with
 // Hub channels after re-establishing a connection.
+//
+// Brokers are matched by interface equality. That is well defined for every
+// built-in broker (all pointer types); a Broker implemented as a
+// non-comparable value type — a struct with a map or slice field, used by
+// value — would panic on the comparison below.
 func (m *SharedPollManager) brokerChannelsSnapshot(b Broker) []string {
-	m.brokerSubMu.Lock()
-	defer m.brokerSubMu.Unlock()
-	var channels []string
+	m.brokerSubMu.RLock()
+	defer m.brokerSubMu.RUnlock()
+	channels := make([]string, 0, len(m.brokerSubChans))
 	for kc, broker := range m.brokerSubChans {
 		if broker == b {
 			channels = append(channels, kc)

--- a/shared_poll.go
+++ b/shared_poll.go
@@ -994,6 +994,24 @@ func (s *sharedPollChannelState) flipEpochAndCollectClients(hub *keyedHub, newEp
 	return hub.collectAllClients()
 }
 
+// brokerChannelsSnapshot returns the key channels currently subscribed at the
+// given broker. Key channels are subscribed at broker level and tracked only
+// here — not in the Hub — so a PUB/SUB reconnect would silently drop them:
+// the reconnect resubscribes Hub().Channels() and nothing else. The Redis
+// PUB/SUB loops call this (via Node) to restore key channels together with
+// Hub channels after re-establishing a connection.
+func (m *SharedPollManager) brokerChannelsSnapshot(b Broker) []string {
+	m.brokerSubMu.Lock()
+	defer m.brokerSubMu.Unlock()
+	var channels []string
+	for kc, broker := range m.brokerSubChans {
+		if broker == b {
+			channels = append(channels, kc)
+		}
+	}
+	return channels
+}
+
 // close stops all refresh workers and waits for them to finish.
 func (m *SharedPollManager) close() {
 	close(m.shutdownCh)


### PR DESCRIPTION
## Problem

A Redis PUB/SUB connection can stay healthy on the TCP level while attached to a node that no longer receives published traffic. After a Sentinel failover the client may end up on a demoted master, a node outside the replication chain, or an unrelated Redis on a reused pod IP. No connection error ever fires in that state: the node answers keepalive pings and accepts commands, publishes keep succeeding — and subscribers starve silently until the process is restarted. Health checks stay green the whole time.

The terminal wait of every PUB/SUB loop only reacts to connection errors, so nothing can recover from this state today.

## Change

Verify delivery instead of trusting connection health.

Every PUB/SUB loop counts received messages (one atomic increment per message — the only hot-path cost). When a connection receives nothing for `PubSubProbeInterval`, the loop publishes a small probe to its service channel through the regular publish path and expects it back on the connection. One more silent interval means the connection does not deliver published traffic: the loop logs a warning, increments a `probe_timeout` error counter and re-establishes the connection, re-resolving topology.

Probe targets carry no real traffic and are consumed by the loop itself, never reaching message handlers:

- broker loops (`RedisBroker`, `RedisMapBroker`) probe their per-shard service channel (`SPUBLISH` in sharded mode, routed by the channel's hash tag);
- the control loop probes a dedicated per-node channel, because the node channel carries real control commands. In a running node this machinery is dormant: node info pings keep the control connection non-idle, so control probes only activate when pings are legitimately absent.

Probes are idle-gated, so under regular message flow none are sent. On a shared service channel any node's probe delivery also proves liveness for every other subscriber of that channel, further reducing probe traffic in multi-node setups.

`PubSubProbeInterval` defaults to 30 seconds (zero value); negative disables probing. Detection worst case is two intervals of silence.

## Shared poll fix (second commit)

Verifying restart behavior surfaced a pre-existing bug: shared poll subscribes per-key channels at broker level and tracks them in its own registry — they are not in the Hub. The PUB/SUB loop resubscribed only `Hub().Channels()` after re-establishing a connection, so every reconnect (connection error, failover, and now probe restart) silently dropped all key channels while shared poll still believed they were subscribed. Key events never arrived again until each key was untracked and re-tracked.

The resubscribe path now has a second source: `SharedPollManager` exposes a snapshot of the key channels subscribed at a given broker and the loop appends them to the Hub list before the existing per-shard/partition filtering.

## Tests

Integration tests reproduce the failure end to end through real Redis states only:

- a replica detached from the master (`REPLICAOF NO ONE` + `SENTINEL RESET`) silently starves the subscriber while publishes succeed; the probe detects it and the restarted loop re-resolves to the surviving replica — covered for both client message and control connections;
- a disabled-probe baseline documents the old behavior: starvation persists while publishes keep returning success;
- idle steady-state tests for standalone, sharded cluster, map broker and control connections prove probes loop back, never surface as publications and never cause false restarts;
- the shared poll test drives the real key subscription path, kills PUB/SUB connections via `CLIENT KILL TYPE pubsub` (the same connection error a Redis restart produces) and requires the key channel to be subscribed and delivering again after reconnect — it fails against the Hub-only resubscribe.

The docker-compose sentinel service gains two replicas for the detached-replica scenarios.
