### PR TITLE
Close transport before per-channel cleanup on disconnect

### DIFF
--- a/client.go
+++ b/client.go
@@ -1519,6 +1519,7 @@ func (c *Client) close(disconnect Disconnect) error {
 	// race connectCmd (e.g. the stale-connection timer firing during a slow
 	// connect), so the disconnect logs below must not read it lock-free.
 	user := c.user
+	authenticated := c.authenticated
 	c.status = statusClosed
 
 	c.stopTimer()
@@ -1529,21 +1530,14 @@ func (c *Client) close(disconnect Disconnect) error {
 	}
 	c.mu.Unlock()
 
-	// Unsubscribe from all channels (handles both normal and map subscriptions).
-	for channel := range channels {
-		err := c.unsubscribe(channel, unsubscribeDisconnect, &disconnect)
-		if err != nil {
-			c.node.logger.log(newErrorLogEntry(err, "error unsubscribing client from channel", map[string]any{"channel": channel, "user": user, "client": c.uid, "error": err.Error()}))
-		}
-	}
-
-	// Clean up any in-progress map subscriptions that aren't in channels yet.
-	c.cleanupMapSubscribingAll()
-
-	c.mu.RLock()
-	authenticated := c.authenticated
-	c.mu.RUnlock()
-
+	// Tear the transport down FIRST, before the per-channel cleanup below.
+	// Presence removal and leave publishing (in the unsubscribe loop) are
+	// synchronous PresenceManager/Broker round trips; under load they can be
+	// slow, and if the socket were closed only after them the connection would
+	// linger on the server while a reconnecting client that already gave up
+	// opens a new one - producing several concurrent connections per client
+	// (centrifuge-js #371). None of the cleanup below writes to the transport,
+	// so closing it here is safe and keeps teardown off the Redis-bound path.
 	if authenticated {
 		c.node.removeClient(c)
 	}
@@ -1562,6 +1556,21 @@ func (c *Client) close(disconnect Disconnect) error {
 	_ = c.messageWriter.close(flushRemaining)
 
 	_ = c.transport.Close(disconnect)
+
+	// Transport is closed; do the (potentially slow) channel cleanup now, off
+	// the connection's critical path. This still runs under presenceMu with
+	// c.closing set, so an in-flight presence tick can not resurrect presence
+	// entries after we remove them.
+	// Unsubscribe from all channels (handles both normal and map subscriptions).
+	for channel := range channels {
+		err := c.unsubscribe(channel, unsubscribeDisconnect, &disconnect)
+		if err != nil {
+			c.node.logger.log(newErrorLogEntry(err, "error unsubscribing client from channel", map[string]any{"channel": channel, "user": user, "client": c.uid, "error": err.Error()}))
+		}
+	}
+
+	// Clean up any in-progress map subscriptions that aren't in channels yet.
+	c.cleanupMapSubscribingAll()
 
 	if disconnect.Code != DisconnectConnectionClosed.Code {
 		c.node.logger.log(newLogEntry(LogLevelDebug, "closing client connection", map[string]any{"client": c.uid, "user": user, "reason": disconnect.Reason}))

--- a/client.go
+++ b/client.go
@@ -767,10 +767,27 @@ func (c *Client) writeEncodedPushData(data []byte, ch string, key string, frameT
 	disconnect := c.messageWriter.enqueue(item)
 	if disconnect != nil {
 		// close in goroutine to not block message broadcast.
-		go func() { _ = c.close(*disconnect) }()
+		c.spawnCloseUnlessClosing(*disconnect)
 		return io.EOF
 	}
 	return nil
+}
+
+// spawnCloseUnlessClosing starts close() in a goroutine for a broadcast-path
+// write failure, unless a close is already running. The guard matters because a
+// closing connection stays in the hub's subscription shards until close() gets
+// to the per-channel cleanup - and that cleanup makes PresenceManager/Broker
+// round trips, so under slow Redis the window is long. Every publication landing
+// in it fails to enqueue (the writer is already closed) and would otherwise
+// spawn a goroutine that just blocks on presenceMu until the in-flight close
+// finishes: one goroutine per message per closing connection, worst exactly when
+// Redis is slowest. The in-flight close already performs the teardown, so there
+// is nothing for these to do.
+func (c *Client) spawnCloseUnlessClosing(disconnect Disconnect) {
+	if c.closing.Load() {
+		return
+	}
+	go func() { _ = c.close(disconnect) }()
 }
 
 // publishJoinAndPresence publishes join notification and sets up map presence
@@ -1500,13 +1517,16 @@ func (c *Client) Disconnect(disconnect ...Disconnect) {
 
 func (c *Client) close(disconnect Disconnect) error {
 	c.startWriter(0, 0, 0, 0, false)
-	// Signal an in-flight presence tick to stop before we block on presenceMu:
-	// that tick may be draining many PresenceManager round trips, and close
-	// would otherwise wait for all of them. presenceMu is still taken below, so
-	// the tick can not resurrect presence entries after we remove them.
+	// Signal an in-flight presence tick to stop: that tick may be draining many
+	// PresenceManager round trips, and the cleanup below waits for all of them
+	// on presenceMu.
 	c.closing.Store(true)
-	c.presenceMu.Lock()
-	defer c.presenceMu.Unlock()
+	// presenceMu is deliberately NOT taken here - it is taken further down, once
+	// the transport is closed. Taking it up front would put an in-flight presence
+	// tick's Redis round trip (or, worse, its timeout) in front of the socket
+	// teardown, which is what we are trying to keep the teardown clear of. Only
+	// close() takes both mutexes, so this connectMu -> presenceMu order cannot
+	// invert against anything else.
 	c.connectMu.Lock()
 	defer c.connectMu.Unlock()
 	c.mu.Lock()
@@ -1557,10 +1577,14 @@ func (c *Client) close(disconnect Disconnect) error {
 
 	_ = c.transport.Close(disconnect)
 
-	// Transport is closed; do the (potentially slow) channel cleanup now, off
-	// the connection's critical path. This still runs under presenceMu with
-	// c.closing set, so an in-flight presence tick can not resurrect presence
-	// entries after we remove them.
+	// Transport is closed; do the (potentially slow) channel cleanup now, off the
+	// connection's critical path. Only now do we block on presenceMu: the cleanup
+	// removes presence entries, so it must not overlap an in-flight tick that is
+	// still adding them. c.closing is already set, so that tick stops at its next
+	// per-channel check instead of draining every round trip.
+	c.presenceMu.Lock()
+	defer c.presenceMu.Unlock()
+
 	// Unsubscribe from all channels (handles both normal and map subscriptions).
 	for channel := range channels {
 		err := c.unsubscribe(channel, unsubscribeDisconnect, &disconnect)
@@ -3470,9 +3494,9 @@ func (c *Client) startWriter(batchDelay time.Duration, maxMessagesInFrame int, q
 					}
 					disconnect, ok := disconnectFromError(err)
 					if ok {
-						go func() { _ = c.close(*disconnect) }()
+						c.spawnCloseUnlessClosing(*disconnect)
 					} else {
-						go func() { _ = c.close(DisconnectWriteError) }()
+						c.spawnCloseUnlessClosing(DisconnectWriteError)
 					}
 					return err
 				}
@@ -3540,9 +3564,9 @@ func (c *Client) startWriter(batchDelay time.Duration, maxMessagesInFrame int, q
 					}
 					disconnect, ok := disconnectFromError(err)
 					if ok {
-						go func() { _ = c.close(*disconnect) }()
+						c.spawnCloseUnlessClosing(*disconnect)
 					} else {
-						go func() { _ = c.close(DisconnectWriteError) }()
+						c.spawnCloseUnlessClosing(DisconnectWriteError)
 					}
 					return err
 				}

--- a/client_experimental.go
+++ b/client_experimental.go
@@ -110,7 +110,7 @@ func (c *Client) writeQueueItems(items []queue.Item) error {
 	disconnect := c.messageWriter.enqueueMany(items...)
 	if disconnect != nil {
 		// close in goroutine to not block message broadcast.
-		go func() { _ = c.close(*disconnect) }()
+		c.spawnCloseUnlessClosing(*disconnect)
 		return io.EOF
 	}
 	return nil

--- a/hub_test.go
+++ b/hub_test.go
@@ -265,8 +265,12 @@ func TestHubDisconnect(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("no data in sink")
 	}
-	require.Len(t, n.hub.UserConnections("42"), 0)
-	require.Equal(t, 0, n.hub.NumSubscribers("test_channel"))
+	// close() now tears the transport down (which signals closeCh) before the
+	// per-channel cleanup, so hub subscription state converges shortly after the
+	// close signal rather than strictly before it.
+	require.Eventually(t, func() bool {
+		return len(n.hub.UserConnections("42")) == 0 && n.hub.NumSubscribers("test_channel") == 0
+	}, 2*time.Second, 10*time.Millisecond)
 
 	// Disconnect subscribed user with reconnect.
 	err = n.hub.disconnect("24", DisconnectForceReconnect, "", "", nil, nil)
@@ -276,8 +280,9 @@ func TestHubDisconnect(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("no data in sink")
 	}
-	require.Len(t, n.hub.UserConnections("24"), 0)
-	require.Equal(t, 0, n.hub.NumSubscribers("test_channel_reconnect"))
+	require.Eventually(t, func() bool {
+		return len(n.hub.UserConnections("24")) == 0 && n.hub.NumSubscribers("test_channel_reconnect") == 0
+	}, 2*time.Second, 10*time.Millisecond)
 
 	wg.Wait()
 

--- a/regression_test.go
+++ b/regression_test.go
@@ -4483,3 +4483,262 @@ func TestMapCommit_InstallsOverOccupiedChannelSlot(t *testing.T) {
 	delete(client.channels, ch)
 	client.mu.Unlock()
 }
+
+// ===========================================================================
+// client_close_teardown_test.go
+// ===========================================================================
+
+// gatedPresenceManager tracks which (channel, clientID) pairs are present and
+// lets a test block exactly one AddPresence or RemovePresence call to hold the
+// connection's close path open at a chosen point.
+type gatedPresenceManager struct {
+	mu      sync.Mutex
+	present map[string]map[string]bool
+
+	// Armed by the test via addArmed/removeArmed. The first call after arming
+	// reports itself on <op>Entered and then blocks until <op>Release is closed.
+	addArmed      atomic.Bool
+	addEntered    chan string
+	addRelease    chan struct{}
+	removeArmed   atomic.Bool
+	removeEntered chan string
+	removeRelease chan struct{}
+}
+
+func newGatedPresenceManager() *gatedPresenceManager {
+	return &gatedPresenceManager{
+		present:       map[string]map[string]bool{},
+		addEntered:    make(chan string, 1),
+		addRelease:    make(chan struct{}),
+		removeEntered: make(chan string, 1),
+		removeRelease: make(chan struct{}),
+	}
+}
+
+func (m *gatedPresenceManager) Presence(ch string) (map[string]*ClientInfo, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	res := map[string]*ClientInfo{}
+	for clientID := range m.present[ch] {
+		res[clientID] = &ClientInfo{ClientID: clientID}
+	}
+	return res, nil
+}
+
+func (m *gatedPresenceManager) PresenceStats(_ string) (PresenceStats, error) {
+	return PresenceStats{}, nil
+}
+
+func (m *gatedPresenceManager) AddPresence(ch string, clientID string, _ *ClientInfo) error {
+	if m.addArmed.CompareAndSwap(true, false) {
+		m.addEntered <- ch
+		<-m.addRelease
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.present[ch] == nil {
+		m.present[ch] = map[string]bool{}
+	}
+	m.present[ch][clientID] = true
+	return nil
+}
+
+func (m *gatedPresenceManager) RemovePresence(ch string, clientID string, _ string) error {
+	if m.removeArmed.CompareAndSwap(true, false) {
+		m.removeEntered <- ch
+		<-m.removeRelease
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.present[ch], clientID)
+	if len(m.present[ch]) == 0 {
+		delete(m.present, ch)
+	}
+	return nil
+}
+
+func (m *gatedPresenceManager) numPresent() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := 0
+	for _, clients := range m.present {
+		n += len(clients)
+	}
+	return n
+}
+
+// countGoroutinesRunning returns how many goroutine stacks currently contain
+// needle.
+func countGoroutinesRunning(needle string) int {
+	buf := make([]byte, 1<<20)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return strings.Count(string(buf[:n]), needle)
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+}
+
+const clientCloseStackFrame = "centrifuge.(*Client).close("
+
+// TestClose_BroadcastDuringCleanupSpawnsNoExtraCloses guards the broadcast path
+// against a goroutine storm while a connection is closing.
+//
+// close() tears the transport (and the writer) down before running the
+// per-channel cleanup, so that a slow PresenceManager can not hold the socket
+// open. But the connection stays registered in the hub's subscription shards
+// until the cleanup loop reaches each channel, so publications keep being routed
+// to it in the meantime. Every one of them fails to enqueue on the closed writer,
+// and writeEncodedPushData used to answer that by spawning `go c.close(...)` -
+// one goroutine per message, each of which only blocks until the in-flight close
+// finishes. The storm is worst exactly when Redis is slow, which is when the
+// cleanup is slow.
+func TestClose_BroadcastDuringCleanupSpawnsNoExtraCloses(t *testing.T) {
+	const chA, chB = "close_cleanup_a", "close_cleanup_b"
+	const numPublications = 300
+
+	pm := newGatedPresenceManager()
+	node := defaultNodeNoHandlers()
+	defer func() { _ = node.Shutdown(context.Background()) }()
+	node.SetPresenceManager(pm)
+	node.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
+			cb(SubscribeReply{Options: SubscribeOptions{EmitPresence: true}}, nil)
+		})
+	})
+
+	client := newTestConnectedClientV2(t, node, "42")
+	subscribeClientV2(t, client, chA)
+	subscribeClientV2(t, client, chB)
+	require.Equal(t, 2, pm.numPresent())
+
+	// Block the first RemovePresence of the cleanup loop. The loop walks channels
+	// in map order, so we learn which one it took and publish into the other -
+	// that one is still in c.channels and still in the hub, i.e. still a live
+	// broadcast target with a dead writer.
+	pm.removeArmed.Store(true)
+
+	closeDone := make(chan struct{})
+	go func() {
+		_ = client.close(DisconnectConnectionClosed)
+		close(closeDone)
+	}()
+
+	var gatedChannel string
+	select {
+	case gatedChannel = <-pm.removeEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("cleanup loop never reached RemovePresence")
+	}
+	openChannel := chA
+	if gatedChannel == chA {
+		openChannel = chB
+	}
+
+	// Precondition: the closing connection is still a broadcast target on the
+	// channel the cleanup has not reached yet. Without this the test would pass
+	// trivially.
+	require.Equal(t, 1, node.hub.NumSubscribers(openChannel),
+		"connection must still be subscribed while cleanup is in flight")
+
+	before := countGoroutinesRunning(clientCloseStackFrame)
+	for i := 0; i < numPublications; i++ {
+		_, err := node.Publish(openChannel, []byte(`{"n":`+strconv.Itoa(i)+`}`))
+		require.NoError(t, err)
+	}
+	// Give any goroutine the broadcast path spawned time to be scheduled and show
+	// up in the stack dump.
+	time.Sleep(100 * time.Millisecond)
+	during := countGoroutinesRunning(clientCloseStackFrame)
+
+	// `before` is 1: the close() we started above, parked in RemovePresence.
+	require.LessOrEqual(t, during, before+1,
+		"broadcasts to a closing connection must not spawn a close goroutine per message "+
+			"(before=%d during=%d after %d publications)", before, during, numPublications)
+
+	close(pm.removeRelease)
+	select {
+	case <-closeDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("close did not finish")
+	}
+
+	require.Zero(t, pm.numPresent(), "cleanup must still remove presence for every channel")
+	require.Zero(t, node.hub.NumSubscribers(chA))
+	require.Zero(t, node.hub.NumSubscribers(chB))
+	require.Empty(t, node.hub.UserConnections("42"))
+}
+
+// TestClose_TransportTeardownNotGatedByInFlightPresenceTick guards the socket
+// teardown against an in-flight presence tick.
+//
+// The tick holds presenceMu across its PresenceManager round trips. close() also
+// needs presenceMu - the cleanup removes presence entries and must not overlap a
+// tick that is still adding them - but it only needs it for that cleanup. Taking
+// it up front put a whole Redis round trip (or its timeout) in front of
+// transport.Close, so a hung PresenceManager kept the socket, the hub entry and
+// the inflight-connections gauge alive for the duration - the same lingering
+// connection this ordering exists to prevent.
+func TestClose_TransportTeardownNotGatedByInFlightPresenceTick(t *testing.T) {
+	const channel = "close_tick_channel"
+
+	pm := newGatedPresenceManager()
+	node, err := New(Config{
+		LogLevel:                     LogLevelError,
+		LogHandler:                   func(entry LogEntry) {},
+		ClientPresenceUpdateInterval: 50 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	node.SetPresenceManager(pm)
+	node.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
+			cb(SubscribeReply{Options: SubscribeOptions{EmitPresence: true}}, nil)
+		})
+	})
+	require.NoError(t, node.Run())
+	defer func() { _ = node.Shutdown(context.Background()) }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	transport := newTestTransport(cancel)
+	client := newTestSubscribedClientWithTransport(t, ctx, node, transport, "42", channel)
+
+	// Arm only now: the subscribe above already paid one AddPresence.
+	pm.addArmed.Store(true)
+	select {
+	case <-pm.addEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("presence tick never reached AddPresence")
+	}
+	// The tick is parked inside AddPresence holding presenceMu.
+
+	closeDone := make(chan struct{})
+	go func() {
+		_ = client.close(DisconnectConnectionClosed)
+		close(closeDone)
+	}()
+
+	select {
+	case <-transport.closeCh:
+	case <-time.After(2 * time.Second):
+		close(pm.addRelease)
+		t.Fatal("transport was not closed while a presence tick was in flight")
+	}
+	require.Empty(t, node.hub.UserConnections("42"),
+		"connection must leave the hub without waiting for the presence tick")
+
+	// close() is now parked on presenceMu waiting for the tick, as it must be:
+	// releasing the tick lets it finish adding presence, and only then does the
+	// cleanup remove it.
+	close(pm.addRelease)
+	select {
+	case <-closeDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("close did not finish")
+	}
+
+	require.Zero(t, pm.numPresent(),
+		"presence added by the in-flight tick must still be removed by the cleanup")
+	require.Zero(t, node.hub.NumSubscribers(channel))
+}


### PR DESCRIPTION
## Problem

Reported in centrifugal/centrifuge-js#371: under Redis load a client that times out and reconnects ends up with several concurrent connections on the server ("3–4 connections per client").

On connection close, `Client.close` runs the per-channel cleanup — `RemovePresence` and the leave `PUBLISH`, both synchronous Redis round trips — **before** it closes the transport. Under slow Redis this gates the socket teardown behind that cleanup, so the old connection lingers on the server while the reconnecting client (which already gave up) opens a new one. For a client-initiated close the WebSocket close-frame reply is prompt; what lingers is the final TCP teardown and server-side resource release.

(The broker pub/sub `Unsubscribe` is not on this path — it is already deferred to `subDissolver`.)

## Change

Reorder `close()` so `removeClient`, the disconnect push, writer close and `transport.Close` run first, then the per-channel unsubscribe/presence/leave cleanup. Safe because:

- Nothing in the disconnect-path cleanup writes to the transport (`sendUnsubscribe` frames are only used by the explicit `Unsubscribe` API).
- The cleanup still runs under `presenceMu` with `c.closing` set, so the presence-tick coordination is unaffected.
- `OnUnsubscribe` still fires before `OnDisconnect`.

## Behavior change (worth noting)

On the disconnect path, `OnUnsubscribe` and `OnDisconnect` now fire **after** the transport is closed (`OnDisconnect` already did; `OnUnsubscribe` now does too), and the client is removed from the hub before `OnUnsubscribe`. Their relative order is unchanged. Sending to the *disconnecting* client from a disconnect-triggered `OnUnsubscribe` is no longer possible (it was already impossible from `OnDisconnect`); the explicit-unsubscribe path is unchanged.

Because the transport is torn down before the cleanup loop, hub subscription state (`NumSubscribers`) now converges shortly *after* the transport-close signal rather than strictly before it. `TestHubDisconnect` is updated to wait for convergence (via `require.Eventually`) rather than asserting it synchronously on the close signal.

## Verification

Full package test suite passes (including `TestHubDisconnect`). Measured separately with a local reproducer (slow/latency-injected presence manager + a reconnect-churn storm): peak concurrent server sockets on the port drop from **~13** (CLOSE_WAIT accumulating during each removal) to **~2** after the reorder.
