### PR TITLE
Fix nil pointer panic when delta publication fails JSON encoding

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -992,7 +992,13 @@ func getDeltaPub(prevPub *Publication, fullPub *protocol.Publication, key prepar
 	return deltaPub
 }
 
-func getDeltaData(sub subInfo, key preparedKey, channel string, deltaPub *protocol.Publication, channelSubID int64, jsonEncodeErr *encodeError) ([]byte, error) {
+// jsonEncodeErr is a **encodeError, not *encodeError, deliberately: the caller
+// holds a nil *encodeError and needs it REPLACED on failure. Taking it by value
+// meant this function dereferenced nil (panicking the whole broadcast) and,
+// had it not panicked, would have written to the pointee rather than the
+// caller's variable — so the caller's `jsonEncodeErr != nil` check could never
+// fire. Matches how the non-delta paths do `jsonEncodeErr = &encodeError{...}`.
+func getDeltaData(sub subInfo, key preparedKey, channel string, deltaPub *protocol.Publication, channelSubID int64, jsonEncodeErr **encodeError) ([]byte, error) {
 	var deltaData []byte
 	if key.ProtocolType == protocol.TypeJSON {
 		if sub.client.transport.Unidirectional() {
@@ -1007,7 +1013,7 @@ func getDeltaData(sub subInfo, key preparedKey, channel string, deltaPub *protoc
 			deltaData, err = protocol.DefaultJsonPushEncoder.Encode(push)
 			putPush(push)
 			if err != nil {
-				*jsonEncodeErr = encodeError{client: sub.client.ID(), user: sub.client.UserID(), error: err}
+				*jsonEncodeErr = &encodeError{client: sub.client.ID(), user: sub.client.UserID(), error: err}
 			}
 		} else {
 			push := getPush()
@@ -1024,7 +1030,7 @@ func getDeltaData(sub subInfo, key preparedKey, channel string, deltaPub *protoc
 			putReply(reply)
 			putPush(push)
 			if err != nil {
-				*jsonEncodeErr = encodeError{client: sub.client.ID(), user: sub.client.UserID(), error: err}
+				*jsonEncodeErr = &encodeError{client: sub.client.ID(), user: sub.client.UserID(), error: err}
 			}
 		}
 	} else if key.ProtocolType == protocol.TypeProtobuf {
@@ -1152,11 +1158,11 @@ func (s *subShard) broadcastPublication(
 			var localDeltaData []byte
 			if key.DeltaType != deltaTypeNone {
 				var err error
-				brokerDeltaData, err = getDeltaData(sub, key, channel, brokerDeltaPub, channelSubID, jsonEncodeErr)
+				brokerDeltaData, err = getDeltaData(sub, key, channel, brokerDeltaPub, channelSubID, &jsonEncodeErr)
 				if err != nil {
 					return err
 				}
-				localDeltaData, err = getDeltaData(sub, key, channel, localDeltaPub, channelSubID, jsonEncodeErr)
+				localDeltaData, err = getDeltaData(sub, key, channel, localDeltaPub, channelSubID, &jsonEncodeErr)
 				if err != nil {
 					return err
 				}

--- a/hub_test.go
+++ b/hub_test.go
@@ -818,6 +818,64 @@ func TestHubBroadcastPublicationDeltaAtMostOnceNoOffset(t *testing.T) {
 	}
 }
 
+// TestHubBroadcastDeltaInvalidJSONDisconnectsClient covers two defects on the
+// delta broadcast path.
+//
+// broadcastPublication declares `var jsonEncodeErr *encodeError` (nil) and
+// passed it BY VALUE to getDeltaData, which on a JSON encode failure did
+// `*jsonEncodeErr = encodeError{...}`:
+//
+//  1. that dereferences nil, panicking the broadcasting goroutine — in a real
+//     node this is the PUB/SUB consumer, so the panic is process-fatal; and
+//  2. even without the panic it wrote to the pointee rather than rebinding the
+//     caller's variable, so the caller's `jsonEncodeErr != nil` check could
+//     never fire and the offending client would never be disconnected.
+//
+// Reaching it needs a JSON encode failure on the delta path. Publication.Data
+// is always json.Escape'd for JSON+Fossil so it cannot be the trigger, but
+// ClientInfo.ConnInfo is embedded raw and the encoder validates the whole
+// assembled document (isValidJSON), so invalid ConnInfo fails the encode.
+//
+// The non-delta paths correctly do `jsonEncodeErr = &encodeError{...}` and
+// already disconnected such clients; this asserts delta behaves the same.
+func TestHubBroadcastDeltaInvalidJSONDisconnectsClient(t *testing.T) {
+	t.Parallel()
+	n := deltaTestNode()
+	defer func() { _ = n.Shutdown(context.Background()) }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	transport := newTestTransport(cancel)
+	transport.setProtocolType(ProtocolTypeJSON)
+	const channel = "test-delta-invalid-json"
+	client := newTestSubscribedClientWithTransportDelta(
+		t, ctx, n, transport, "user-delta", channel, DeltaTypeFossil)
+	require.NotNil(t, client)
+
+	pub := &Publication{
+		Data:   []byte(`{"input":"hello"}`),
+		Offset: 1,
+		Info:   &ClientInfo{ClientID: "cid", UserID: "user-delta", ConnInfo: []byte(`{"broken":`)},
+	}
+	prevPub := &Publication{Data: []byte(`{"input":"hell"}`)}
+
+	require.NotPanics(t, func() {
+		_ = n.hub.broadcastPublication(
+			channel, StreamPosition{Offset: 1, Epoch: "test"},
+			pub, prevPub, prevPub, ChannelBatchConfig{},
+		)
+	}, "broadcast must not panic when a delta publication fails JSON encoding")
+
+	// The encode error must reach the caller, which disconnects the client —
+	// this is what silently never happened when the pointer was passed by value.
+	select {
+	case <-transport.closeCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("client was not disconnected: the delta JSON encode error did not propagate to broadcastPublication")
+	}
+	require.Equal(t, DisconnectInappropriateProtocol.Code, transport.disconnect.Code)
+}
+
 func TestHubBroadcastJoin(t *testing.T) {
 	t.Parallel()
 	tcs := []struct {


### PR DESCRIPTION
## The bug

`getDeltaData` takes `jsonEncodeErr` as `*encodeError` and writes through it:

```go
*jsonEncodeErr = encodeError{client: ..., user: ..., error: err}
```

But `broadcastPublication` passes its own `var jsonEncodeErr *encodeError`, which is **nil**. A JSON encode failure on the delta path therefore dereferences nil and panics the broadcasting goroutine. Nothing in the library calls `recover()`, so the panic reaches the broker PUB/SUB consumer and **terminates the process**.

There is a second, quieter defect in the same call. Writing to the pointee rather than rebinding the caller's variable means the caller's `jsonEncodeErr != nil` check could never fire — so even without the panic, the offending client would never be disconnected and would silently receive nothing from then on.

## When it triggers

All three must hold at once:

1. a subscriber on the channel has Fossil delta active (`getDeltaData` is only called under `key.DeltaType != deltaTypeNone`);
2. that subscriber's protocol is JSON (only the JSON branch writes through the pointer; the Protobuf branch returns `err` correctly);
3. the encode actually fails.

For (3): `Publication.Data` **cannot** be the trigger — it is always `json.Escape`'d for JSON+Fossil. But `ClientInfo.ConnInfo` / `ChanInfo` are embedded raw and the encoder validates the whole assembled document via `isValidJSON`, so application-supplied info that is not valid JSON reaches it. Those come from `Credentials.Info` and `SubscribeOptions.ChannelInfo`, and are not validated.

Verified matrix on current master:

| condition | result |
|---|---|
| JSON + delta + bad `Info` | **panic** |
| JSON + delta + bad `Info`, no prevPub | **panic** |
| JSON + delta + bad `Info`, unidirectional | **panic** |
| JSON + delta + bad `Info`, offset 0 | **panic** |
| JSON + delta + bad `Data` | no panic |
| JSON + **no delta** + bad `Info` | no panic |
| **Protobuf** + delta + bad `Info` | no panic |

The asymmetry in the last two rows is the point: identical input is handled gracefully on the non-delta path (that client gets `DisconnectInappropriateProtocol`, node survives), while enabling delta turns it into a whole-node crash.

Worth noting for anyone building `ConnInfo` by interpolating user-controlled data into JSON without escaping — that would make this remotely triggerable.

## The fix

Take `**encodeError`, matching what the non-delta paths already do with `jsonEncodeErr = &encodeError{...}`. Five functional lines in one unexported function with three references in the repo. Both defects go away: the broadcast survives, and the client is disconnected with `DisconnectInappropriateProtocol` exactly as on the non-delta path.

A nil guard would have been shorter but would only mute the panic while leaving the propagation defect — trading a loud crash for silent permanent breakage.

## Testing

`hub_delta_encode_panic_test.go` reproduces through the full `broadcastPublication` path and asserts the client is disconnected, which is what proves the error now propagates. It **fails on master with the nil deref and passes with the fix**.

Full suite, `-race`, `go vet` and `gofmt` all clean.