### PR TITLE
Remove per-drain allocation from the broadcast fan-out path

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -754,6 +754,13 @@ type subInfo struct {
 	tagsFilter       *tagsFilter
 	serverTagsFilter *tagsFilter
 	isMap            bool // true for map subscriptions.
+	// protoType and unidirectional mirror the client's transport. Both are fixed
+	// for the connection's lifetime, but reading them goes through two interface
+	// dispatches — a cost paid once per subscriber per broadcast. Snapshotting
+	// them at addSub time turns the broadcast loop's per-subscriber protocol
+	// dispatch into plain field loads. Set by addSub, not by callers.
+	protoType      protocol.Type
+	unidirectional bool
 	// subGen identifies this specific subscription of the client to the channel.
 	// A resubscribe gets a fresh subGen, so a stale unsubscribe (carrying an older
 	// subGen it read from c.channels) will not remove a newer subscription's hub
@@ -796,6 +803,11 @@ func newSubShard(logger *logger, metrics *metrics, maxTimeLagMilli int64, shardI
 // addSub adds connection into clientHub subscriptions registry.
 // Returns (chanID, isFirst, error) where isFirst is true if this is the first subscriber.
 func (s *subShard) addSub(ch string, sub subInfo) (int64, bool, error) {
+	// Snapshot the transport's immutable protocol properties so the broadcast
+	// loop reads fields instead of making interface calls per subscriber.
+	sub.protoType = sub.client.transport.Protocol().toProto()
+	sub.unidirectional = sub.client.transport.Unidirectional()
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -1090,7 +1102,18 @@ func (s *subShard) broadcastPublication(
 	if fullPub.Offset == 1 && sp.Epoch != "" {
 		fullPub.Epoch = sp.Epoch
 	}
-	preparedDataByKey := make(map[preparedKey]preparedData)
+	// Encoded payloads are shared by all subscribers with the same
+	// protocol/delta/useID/filtered combination. Nearly every channel has just
+	// one such combination, so a single-entry front cache serves every
+	// subscriber after the first and the map — whose key hashing showed up as a
+	// per-subscriber cost, preparedKey holding a string — is only built when a
+	// channel really does mix combinations.
+	var (
+		lastKey           preparedKey
+		lastData          preparedData
+		haveLast          bool
+		preparedDataByKey map[preparedKey]preparedData
+	)
 
 	var filteredPub *protocol.Publication
 
@@ -1134,13 +1157,21 @@ func (s *subShard) broadcastPublication(
 		}
 
 		key := preparedKey{
-			ProtocolType:   sub.client.Transport().Protocol().toProto(),
-			Unidirectional: sub.client.transport.Unidirectional(),
+			ProtocolType:   sub.protoType,
+			Unidirectional: sub.unidirectional,
 			DeltaType:      sub.deltaType,
 			UseID:          useChannelID,
 			WasFiltered:    wasFiltered,
 		}
-		prepValue, prepDataFound := preparedDataByKey[key]
+		var (
+			prepValue     preparedData
+			prepDataFound bool
+		)
+		if haveLast && lastKey == key {
+			prepValue, prepDataFound = lastData, true
+		} else if preparedDataByKey != nil {
+			prepValue, prepDataFound = preparedDataByKey[key]
+		}
 		if !prepDataFound {
 			var brokerDeltaPub *protocol.Publication
 			if fullPub.Offset > 0 {
@@ -1280,9 +1311,20 @@ func (s *subShard) broadcastPublication(
 				}
 				prepValue.filteredPub = filteredPub
 			}
-			preparedDataByKey[key] = prepValue
+			// Promote to the front cache. Only once a second distinct key shows up
+			// is the map created, seeded with the entry the front cache is about to
+			// evict, so an alternating pattern still hits the map rather than
+			// re-encoding.
+			if haveLast {
+				if preparedDataByKey == nil {
+					preparedDataByKey = make(map[preparedKey]preparedData, 4)
+				}
+				preparedDataByKey[lastKey] = lastData
+				preparedDataByKey[key] = prepValue
+			}
+			lastKey, lastData, haveLast = key, prepValue, true
 		}
-		if sub.client.transport.Protocol() == ProtocolTypeJSON {
+		if sub.protoType == protocol.TypeJSON {
 			if jsonEncodeErr != nil {
 				go func(c *Client) { c.Disconnect(DisconnectInappropriateProtocol) }(sub.client)
 				continue
@@ -1327,18 +1369,32 @@ func (s *subShard) broadcastJoin(channel string, join *protocol.Join, batchConfi
 	// Get subID for this channel if it exists
 	channelSubID, hasSubID := s.chanIDs[channel]
 
-	preparedDataByKey := make(map[preparedKey][]byte)
+	// See broadcastPublication: single-entry front cache, map only on mixed keys.
+	var (
+		lastKey           preparedKey
+		lastData          []byte
+		haveLast          bool
+		preparedDataByKey map[preparedKey][]byte
+	)
 
 	for _, sub := range channelSubscribers {
 		useChannelID := sub.useID && hasSubID
 		key := preparedKey{
-			ProtocolType:   sub.client.Transport().Protocol().toProto(),
-			Unidirectional: sub.client.transport.Unidirectional(),
+			ProtocolType:   sub.protoType,
+			Unidirectional: sub.unidirectional,
 			DeltaType:      deltaTypeNone, // Join messages don't use delta
 			UseID:          useChannelID,
 		}
 
-		prepValue, prepDataFound := preparedDataByKey[key]
+		var (
+			prepValue     []byte
+			prepDataFound bool
+		)
+		if haveLast && lastKey == key {
+			prepValue, prepDataFound = lastData, true
+		} else if preparedDataByKey != nil {
+			prepValue, prepDataFound = preparedDataByKey[key]
+		}
 		if !prepDataFound {
 			var data []byte
 
@@ -1390,11 +1446,18 @@ func (s *subShard) broadcastJoin(channel string, join *protocol.Join, batchConfi
 				}
 			}
 
-			preparedDataByKey[key] = data
 			prepValue = data
+			if haveLast {
+				if preparedDataByKey == nil {
+					preparedDataByKey = make(map[preparedKey][]byte, 4)
+				}
+				preparedDataByKey[lastKey] = lastData
+				preparedDataByKey[key] = data
+			}
+			lastKey, lastData, haveLast = key, data, true
 		}
 
-		if sub.client.transport.Protocol() == ProtocolTypeJSON && jsonEncodeErr != nil {
+		if sub.protoType == protocol.TypeJSON && jsonEncodeErr != nil {
 			go func(c *Client) { c.Disconnect(DisconnectInappropriateProtocol) }(sub.client)
 			continue
 		}
@@ -1431,18 +1494,32 @@ func (s *subShard) broadcastLeave(channel string, leave *protocol.Leave, batchCo
 	// Get subID for this channel if it exists
 	channelSubID, hasSubID := s.chanIDs[channel]
 
-	preparedDataByKey := make(map[preparedKey][]byte)
+	// See broadcastPublication: single-entry front cache, map only on mixed keys.
+	var (
+		lastKey           preparedKey
+		lastData          []byte
+		haveLast          bool
+		preparedDataByKey map[preparedKey][]byte
+	)
 
 	for _, sub := range channelSubscribers {
 		useChannelID := sub.useID && hasSubID
 		key := preparedKey{
-			ProtocolType:   sub.client.Transport().Protocol().toProto(),
-			Unidirectional: sub.client.transport.Unidirectional(),
+			ProtocolType:   sub.protoType,
+			Unidirectional: sub.unidirectional,
 			DeltaType:      deltaTypeNone, // Leave messages don't use delta
 			UseID:          useChannelID,
 		}
 
-		prepValue, prepDataFound := preparedDataByKey[key]
+		var (
+			prepValue     []byte
+			prepDataFound bool
+		)
+		if haveLast && lastKey == key {
+			prepValue, prepDataFound = lastData, true
+		} else if preparedDataByKey != nil {
+			prepValue, prepDataFound = preparedDataByKey[key]
+		}
 		if !prepDataFound {
 			var data []byte
 
@@ -1494,11 +1571,18 @@ func (s *subShard) broadcastLeave(channel string, leave *protocol.Leave, batchCo
 				}
 			}
 
-			preparedDataByKey[key] = data
 			prepValue = data
+			if haveLast {
+				if preparedDataByKey == nil {
+					preparedDataByKey = make(map[preparedKey][]byte, 4)
+				}
+				preparedDataByKey[lastKey] = lastData
+				preparedDataByKey[key] = data
+			}
+			lastKey, lastData, haveLast = key, data, true
 		}
 
-		if sub.client.transport.Protocol() == ProtocolTypeJSON && jsonEncodeErr != nil {
+		if sub.protoType == protocol.TypeJSON && jsonEncodeErr != nil {
 			go func(c *Client) { c.Disconnect(DisconnectInappropriateProtocol) }(sub.client)
 			continue
 		}

--- a/hub_broadcast_bench_test.go
+++ b/hub_broadcast_bench_test.go
@@ -1,0 +1,158 @@
+package centrifuge
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// drain blocks until every client's writer queue is empty.
+//
+// Fan-out cost is not paid only by the broadcasting goroutine: each subscriber's
+// writer goroutine dequeues and encodes on its own. b.ReportAllocs accounts for
+// allocations process-wide, so waiting for the queues to empty before the timer
+// stops keeps the writers' work attributed to the run that caused it. Bounded so
+// a wedged writer fails the benchmark instead of hanging it.
+func drain(clients []*Client) {
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		pending := false
+		for _, c := range clients {
+			if c.messageWriter.messages.Len() > 0 {
+				pending = true
+				break
+			}
+		}
+		if !pending {
+			return
+		}
+		time.Sleep(50 * time.Microsecond)
+	}
+}
+
+// benchSubscribedClients connects numSubs clients subscribed to ch. Transports
+// have a nil sink so writer goroutines drain without blocking on a reader.
+func benchSubscribedClients(b *testing.B, n *Node, numSubs int, ch string, proto func(i int) ProtocolType) []*Client {
+	b.Helper()
+	clients := make([]*Client, 0, numSubs)
+	for i := 0; i < numSubs; i++ {
+		transport := newTestTransport(func() {})
+		transport.setProtocolType(proto(i))
+		transport.sink = nil
+		ctx, cancel := context.WithCancel(context.Background())
+		b.Cleanup(cancel)
+		c := newTestConnectedClientWithTransport(b, ctx, n, transport, "user"+strconv.Itoa(i))
+		subscribeClientV2(b, c, ch)
+		clients = append(clients, c)
+	}
+	return clients
+}
+
+func allJSON(int) ProtocolType { return ProtocolTypeJSON }
+
+func benchBroadcast(b *testing.B, numSubs int, withOffset bool) {
+	const ch = "bench"
+	n := defaultTestNodeBenchmark(b)
+	defer func() { _ = n.Shutdown(context.Background()) }()
+	clients := benchSubscribedClients(b, n, numSubs, ch, allJSON)
+
+	data := []byte(`{"input":"hello world, this is a benchmark publication payload"}`)
+	sp := StreamPosition{Epoch: "test"}
+	var offset uint64
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if withOffset {
+			offset++
+		}
+		pub := &Publication{Data: data, Offset: offset, Time: time.Now().UnixMilli()}
+		if err := n.hub.broadcastPublication(ch, sp, pub, nil, nil, ChannelBatchConfig{}); err != nil {
+			b.Fatal(err)
+		}
+	}
+	drain(clients)
+	b.StopTimer()
+}
+
+func BenchmarkHubBroadcast_1Sub(b *testing.B)     { benchBroadcast(b, 1, false) }
+func BenchmarkHubBroadcast_100Subs(b *testing.B)  { benchBroadcast(b, 100, false) }
+func BenchmarkHubBroadcast_1000Subs(b *testing.B) { benchBroadcast(b, 1000, false) }
+
+func BenchmarkHubBroadcastOffset_1Sub(b *testing.B)     { benchBroadcast(b, 1, true) }
+func BenchmarkHubBroadcastOffset_100Subs(b *testing.B)  { benchBroadcast(b, 100, true) }
+func BenchmarkHubBroadcastOffset_1000Subs(b *testing.B) { benchBroadcast(b, 1000, true) }
+
+// BenchmarkHubBroadcastManyChannels broadcasts across many channels
+// concurrently — the shape that exposes per-broadcast (rather than
+// per-subscriber) costs such as metric label lookups and prepared-data map
+// allocation.
+func BenchmarkHubBroadcastManyChannels(b *testing.B) {
+	const numChannels = 64
+	const subsPerChannel = 10
+	n := defaultTestNodeBenchmark(b)
+	defer func() { _ = n.Shutdown(context.Background()) }()
+
+	channels := make([]string, numChannels)
+	clients := make([]*Client, 0, numChannels*subsPerChannel)
+	for i := 0; i < numChannels; i++ {
+		channels[i] = "bench" + strconv.Itoa(i)
+		for j := 0; j < subsPerChannel; j++ {
+			transport := newTestTransport(func() {})
+			transport.sink = nil
+			ctx, cancel := context.WithCancel(context.Background())
+			b.Cleanup(cancel)
+			c := newTestConnectedClientWithTransport(b, ctx, n, transport, "u"+strconv.Itoa(i)+"_"+strconv.Itoa(j))
+			subscribeClientV2(b, c, channels[i])
+			clients = append(clients, c)
+		}
+	}
+
+	data := []byte(`{"input":"hello world, this is a benchmark publication payload"}`)
+	sp := StreamPosition{Epoch: "test"}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			ch := channels[i%numChannels]
+			i++
+			pub := &Publication{Data: data, Time: time.Now().UnixMilli()}
+			if err := n.hub.broadcastPublication(ch, sp, pub, nil, nil, ChannelBatchConfig{}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	drain(clients)
+	b.StopTimer()
+}
+
+// BenchmarkHubBroadcastMixedProtocol has both JSON and Protobuf subscribers on
+// one channel, so the prepared-payload cache must hold more than one entry.
+func BenchmarkHubBroadcastMixedProtocol(b *testing.B) {
+	const ch = "bench"
+	n := defaultTestNodeBenchmark(b)
+	defer func() { _ = n.Shutdown(context.Background()) }()
+	clients := benchSubscribedClients(b, n, 1000, ch, func(i int) ProtocolType {
+		if i%2 == 0 {
+			return ProtocolTypeProtobuf
+		}
+		return ProtocolTypeJSON
+	})
+
+	data := []byte(`{"input":"hello world, this is a benchmark publication payload"}`)
+	sp := StreamPosition{Epoch: "test"}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		pub := &Publication{Data: data, Time: time.Now().UnixMilli()}
+		if err := n.hub.broadcastPublication(ch, sp, pub, nil, nil, ChannelBatchConfig{}); err != nil {
+			b.Fatal(err)
+		}
+	}
+	drain(clients)
+	b.StopTimer()
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -266,6 +266,44 @@ func (q *Queue) RemoveMany(maxItems int) ([]Item, bool) {
 	return messages, true
 }
 
+// RemoveManyIntoShrink is RemoveManyInto plus the immediate shrink that
+// RemoveMany performs, both in one critical section. It exists so the
+// no-write-delay writer path can drop RemoveMany's per-drain slice allocation
+// without either changing shrink timing or taking mu a second time via
+// FinishCollect — this mutex is contended by every broadcast producer, so an
+// extra acquisition per drain is not free.
+func (q *Queue) RemoveManyIntoShrink(buf []Item, maxItems int) (int, bool) {
+	q.mu.Lock()
+
+	if q.cnt == 0 {
+		q.mu.Unlock()
+		return 0, false
+	}
+
+	var count int
+	if maxItems == -1 || q.cnt < maxItems {
+		count = q.cnt
+	} else {
+		count = maxItems
+	}
+	if count > len(buf) {
+		count = len(buf)
+	}
+
+	for i := 0; i < count; i++ {
+		buf[i] = q.nodes[q.head]
+		q.nodes[q.head] = Item{}
+		q.head = (q.head + 1) % len(q.nodes)
+		q.cnt--
+		q.size -= len(buf[i].Data)
+	}
+
+	q.doShrinkLocked()
+
+	q.mu.Unlock()
+	return count, true
+}
+
 // Cap returns the capacity (without allocations)
 func (q *Queue) Cap() int {
 	q.mu.RLock()

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -842,3 +842,57 @@ func TestQueueFinishCollectAfterCloseRemovesNothing(t *testing.T) {
 		t.Fatal("queue must remain closed")
 	}
 }
+
+// TestQueueRemoveManyIntoShrinkMatchesRemoveMany pins the equivalence the
+// writer's no-write-delay path depends on: draining via RemoveManyIntoShrink
+// must leave the queue in the same observable state (length, size, capacity)
+// as the RemoveMany call it replaced, so swapping them cannot change when a
+// grown queue shrinks back.
+func TestQueueRemoveManyIntoShrinkMatchesRemoveMany(t *testing.T) {
+	fill := func(q *Queue, n int) {
+		for i := 0; i < n; i++ {
+			require.True(t, q.Add(Item{Data: []byte("message-payload"), Channel: "ch"}))
+		}
+	}
+
+	for _, tc := range []struct{ initCap, added, drain int }{
+		{2, 1, 16}, {2, 64, 16}, {2, 64, -1}, {8, 100, 16}, {8, 9, -1}, {4, 4, 4},
+	} {
+		qa, qb := New(tc.initCap), New(tc.initCap)
+		fill(qa, tc.added)
+		fill(qb, tc.added)
+
+		removed, okA := qa.RemoveMany(tc.drain)
+
+		bufSize := tc.drain
+		if bufSize < 0 {
+			bufSize = qb.Len()
+		}
+		buf := make([]Item, bufSize)
+		n, okB := qb.RemoveManyIntoShrink(buf, tc.drain)
+
+		require.Equal(t, okA, okB, "ok mismatch for %+v", tc)
+		require.Equal(t, len(removed), n, "count mismatch for %+v", tc)
+		require.Equal(t, qa.Len(), qb.Len(), "length mismatch for %+v", tc)
+		require.Equal(t, qa.Size(), qb.Size(), "size mismatch for %+v", tc)
+		require.Equal(t, qa.Cap(), qb.Cap(), "capacity (shrink) mismatch for %+v", tc)
+
+		// Drained items must be intact and in FIFO order.
+		for i := 0; i < n; i++ {
+			require.Equal(t, removed[i].Data, buf[i].Data, "payload mismatch for %+v", tc)
+		}
+
+		// Both must remain usable afterwards.
+		fill(qa, 3)
+		fill(qb, 3)
+		require.Equal(t, qa.Len(), qb.Len(), "post-refill length mismatch for %+v", tc)
+	}
+}
+
+func TestQueueRemoveManyIntoShrinkEmpty(t *testing.T) {
+	q := New(2)
+	buf := make([]Item, 4)
+	n, ok := q.RemoveManyIntoShrink(buf, 4)
+	require.False(t, ok)
+	require.Equal(t, 0, n)
+}

--- a/metrics.go
+++ b/metrics.go
@@ -186,6 +186,7 @@ type metrics struct {
 	mapBrokerPublishSuppressedCache sync.Map
 	mapBrokerRemoveSuppressedCache  sync.Map
 	pubSubLagCache                 sync.Map
+	broadcastDurationCache         sync.Map
 	sharedPollHandlerCache         sync.Map
 	sharedPollResultCache          sync.Map
 	sharedPollChannelCache         sync.Map
@@ -1152,12 +1153,26 @@ func (m *metrics) observePubSubDeliveryLag(lagTimeMilli int64, ch string) {
 	observer.(prometheus.Observer).Observe(float64(lagTimeMilli) / 1000)
 }
 
+type broadcastDurationLabels struct {
+	Type             string
+	ChannelNamespace string
+}
+
 func (m *metrics) observeBroadcastDuration(started time.Time, ch string) {
-	if m.config.GetChannelNamespaceLabel != nil {
-		m.broadcastDurationHistogram.WithLabelValues("publication", m.getChannelNamespaceLabel(ch)).Observe(time.Since(started).Seconds())
-		return
+	// Runs once per broadcast, so resolve the histogram child once per label set
+	// and cache it — WithLabelValues hashes the label values on every call. The
+	// cache key must carry BOTH labels the vector declares: keying on the
+	// namespace alone would hand back the wrong child the moment a second call
+	// site passes a different type.
+	const broadcastType = "publication"
+	channelNamespace := m.getChannelNamespaceLabel(ch)
+	labels := broadcastDurationLabels{Type: broadcastType, ChannelNamespace: channelNamespace}
+	observer, ok := m.broadcastDurationCache.Load(labels)
+	if !ok {
+		observer = m.broadcastDurationHistogram.WithLabelValues(broadcastType, channelNamespace)
+		m.broadcastDurationCache.Store(labels, observer)
 	}
-	m.broadcastDurationHistogram.WithLabelValues("publication", m.getChannelNamespaceLabel(ch)).Observe(time.Since(started).Seconds())
+	observer.(prometheus.Observer).Observe(time.Since(started).Seconds())
 }
 
 func (m *metrics) observePingPongDuration(duration time.Duration, transport string) {

--- a/writer.go
+++ b/writer.go
@@ -109,21 +109,45 @@ func (w *writer) waitSendMessage(maxMessagesInFrame int, writeDelay time.Duratio
 		return true
 	}
 
-	// No batching - use RemoveMany which handles shrinking automatically.
+	// No batching. Drain into a pooled buffer rather than letting the queue
+	// allocate a fresh []Item per drain (RemoveMany does), which on the
+	// broadcast path is an allocation per drain per connection. Shrink stays
+	// inline in the same critical section, so timing and lock traffic match
+	// RemoveMany exactly: shrinkDelay is deliberately NOT consulted here —
+	// QueueShrinkDelay is documented to apply only when WriteDelay > 0, and
+	// routing this path through FinishCollect would both start honouring it and
+	// arm/Reset a timer on every drain.
 	w.mu.Lock()
-	defer w.mu.Unlock()
 
-	items, ok := w.messages.RemoveMany(maxMessagesInFrame)
+	bufSize := maxMessagesInFrame
+	if bufSize < 0 { // Unlimited, just use current length.
+		bufSize = w.messages.Len()
+		if bufSize == 0 {
+			w.mu.Unlock()
+			return !w.messages.Closed()
+		}
+	}
+
+	itemBuf := getItemBuf(bufSize)
+	buf := itemBuf.B
+
+	n, ok := w.messages.RemoveManyIntoShrink(buf, bufSize)
 	if !ok {
+		putItemBuf(itemBuf)
+		w.mu.Unlock()
 		return !w.messages.Closed()
 	}
 
+	items := buf[:n]
 	var writeErr error
-	if len(items) == 1 {
+	if n == 1 {
 		writeErr = w.config.WriteFn(items[0])
 	} else {
 		writeErr = w.config.WriteManyFn(items...)
 	}
+
+	putItemBuf(itemBuf)
+	w.mu.Unlock()
 
 	if writeErr != nil {
 		// Write failed, transport must close itself, here we just return from routine.


### PR DESCRIPTION
## What was happening

Profiling a 1000-subscriber broadcast showed **one allocation per drain per connection**, all from a single line — `make([]Item, 0, count)` in `queue.RemoveMany`, reached from `writer.waitSendMessage` when `writeDelay == 0`. The `writeDelay > 0` path already drained into a pooled buffer (`getItemBuf` + `RemoveManyInto`); the default path did not.

The encoded payloads were already shared between subscribers. It was the small per-connection "here's your batch" slice that was rebuilt every time.

## Changes

**1. Pooled drain on the default writer path.** Draining now goes through a new `queue.RemoveManyIntoShrink`, which removes *and* shrinks in one critical section. Two details this preserves that a `FinishCollect`-based version would not:

- `QueueShrinkDelay` stays inert when `WriteDelay == 0`, as documented. Routing through `FinishCollect` would have silently started honouring it and armed a `time.Timer` on every drain.
- The queue mutex — contended by *every* broadcast producer — is still taken once per drain rather than twice.

A test pins equivalence against `RemoveMany` across cap/fill/drain combinations, comparing length, size, **capacity** and FIFO order.

**2. Prepared-payload lookup.** `broadcastPublication`/`Join`/`Leave` looked the payload up in a map keyed by a struct holding a string — hashed once per subscriber — and allocated that map per broadcast. Nearly every channel has one protocol/delta/useID/filtered combination, so a one-entry front cache serves every subscriber after the first, and the map is built lazily only when a channel genuinely mixes combinations. `subInfo` also snapshots the transport's protocol type and unidirectional flag at `addSub` time; both are fixed for the connection's lifetime but cost two interface dispatches per subscriber per broadcast.

**3. Metric label cache.** `observeBroadcastDuration` was the only metric helper resolving its histogram child on every call. Now cached by label set like its siblings — keyed on **both** declared labels, so a future second call site cannot silently get the wrong child. Its duplicated `if/else` branches were identical and are dropped.

## Results

Interleaved A/B on separately compiled binaries, `benchstat` n=6, all **p=0.002**:

| benchmark | allocs/op | B/op |
|---|---|---|
| `Broadcast_1000Subs` | 1000 → **9.5** (-99.1%) | -95.3% |
| `BroadcastOffset_1000Subs` | 1001 → **4.5** (-99.6%) | -98.8% |
| `BroadcastMixedProtocol` | 1001 → **5.5** (-99.5%) | -96.5% |
| `Broadcast_100Subs` | 95 → **3.5** (-96.3%) | -89.3% |
| `ManyChannels` | 9 → 6 (-33.3%) | -28.9% |
| **geomean** | **-93.9%** | **-86.8%** |

`Broadcast_1Sub` is unchanged at 2 allocs/op — with one subscriber the writer drains one item per batch either way, so there is nothing for pooling to save. The win is proportional to *delivered* messages (subscribers × rate), which is the expected shape.

Roughly 64 bytes and one allocation per delivered message removed, so a node delivering 1M msg/s sheds on the order of 64 MB/s of garbage. The practical benefit is GC pressure: fewer cycles, and fewer assists charged to the *writer* goroutine, which sits directly on the delivery path.

**Applies to deployments leaving `WriteDelay` at its default.** Those setting `WriteDelay > 0` were already on the pooled path and get only changes 2 and 3.

## On timing

**No latency or CPU claim is made.** Wall-clock geomean moved favourably across every run, but no individual benchmark reached significance over repeated measurement, with run-to-run variance far exceeding the effect. One earlier run showed a significant CPU improvement on `ManyChannels`; it did not reproduce, so it is not claimed here.

The benchmarks added here also use a no-op transport, so the consumer is free — a known way to distort lock and wakeup behaviour. Allocation counts are exact and unaffected by that; the timing columns should not be read as a result. Settling the CPU question properly needs a bounded fixed-rate run on real hardware.

## Testing

Full suite, `-race`, `go vet` (darwin/linux/windows) and `gofmt` all clean. New benchmarks are in `hub_broadcast_bench_test.go` with no build tags.