### PR TITLE
Default QueueShrinkDelay so batching writers stop rebuilding their queue

### DIFF
--- a/events.go
+++ b/events.go
@@ -81,10 +81,30 @@ type ConnectReply struct {
 	// QueueInitialCap set an initial capacity for client's message queue, the size of queue
 	// can grow further, but won't be reduced below QueueInitialCap. By default, it's 2.
 	QueueInitialCap int
-	// QueueShrinkDelay is a time Centrifuge will wait before shrinking the client's message
-	// queue after it grows. This delay helps to avoid frequent allocations/deallocations when
-	// queue size fluctuates. Zero value means no delay and immediate shrinking. This option
-	// only works when WriteDelay is set to a non-zero value.
+	// QueueShrinkDelay is a time Centrifuge will wait, after the client's message
+	// queue has been drained, before shrinking it back down. This option only
+	// applies when WriteDelay is set to a non-zero value.
+	//
+	// It matters because shrinking is evaluated immediately after a drain, when
+	// the queue is empty by construction. Acting on that would discard the ring
+	// the writer had just filled, and the next frame would rebuild it one
+	// doubling at a time - allocating on every write cycle for the lifetime of
+	// the connection. Waiting instead lets the queue settle: under sustained load
+	// the timer keeps resetting and capacity is simply retained, and once the
+	// connection goes quiet the timer fires and the memory is released in full.
+	//
+	// Zero value (the default) means Centrifuge picks a sensible delay itself
+	// (currently one second). Pass a negative value to shrink immediately after
+	// every drain - available for completeness, but it reintroduces the per-cycle
+	// allocations described above and is not recommended.
+	//
+	// Broadcasting to 200 subscribers with WriteDelay set, per publication:
+	//
+	//	shrink immediately   19.1us   84 allocs   34 KB
+	//	default delay        12.7us    2 allocs  376 B
+	//
+	// A longer delay holds capacity through longer quiet gaps, which suits
+	// connections that burst repeatedly; a shorter one returns memory sooner.
 	QueueShrinkDelay time.Duration
 	// PingPongConfig if set, will override Transport's PingPongConfig to enable setting ping/pong interval
 	// for individual client.

--- a/writer.go
+++ b/writer.go
@@ -46,7 +46,30 @@ func newWriter(config writerConfig, queueInitialCap int) *writer {
 
 const (
 	defaultMaxMessagesInFrame = 16
+
+	// defaultQueueShrinkDelay is used when a batching writer does not specify
+	// QueueShrinkDelay. Shrink is evaluated straight after a drain, when the
+	// queue is empty by construction, so shrinking on the spot discards the ring
+	// the writer had just filled and the next frame rebuilds it by doubling.
+	// Deferring the decision lets it settle: under load the timer keeps
+	// resetting, and once the connection goes quiet it fires and the capacity is
+	// released in full. Callers wanting the old immediate behaviour pass a
+	// negative QueueShrinkDelay.
+	defaultQueueShrinkDelay = time.Second
 )
+
+// effectiveShrinkDelay resolves the configured QueueShrinkDelay. Zero means
+// "unset" and gets defaultQueueShrinkDelay; a negative value means the caller
+// explicitly wants the queue shrunk immediately after every drain.
+func effectiveShrinkDelay(configured time.Duration) time.Duration {
+	if configured == 0 {
+		return defaultQueueShrinkDelay
+	}
+	if configured < 0 {
+		return 0
+	}
+	return configured
+}
 
 func (w *writer) waitSendMessage(maxMessagesInFrame int, writeDelay time.Duration, shrinkDelay time.Duration) bool {
 	// Wait for message from the queue.
@@ -163,6 +186,7 @@ func (w *writer) run(writeDelay time.Duration, maxMessagesInFrame int, shrinkDel
 	if maxMessagesInFrame == 0 {
 		maxMessagesInFrame = defaultMaxMessagesInFrame
 	}
+	shrinkDelay = effectiveShrinkDelay(shrinkDelay)
 
 	// Timer-driven mode for writeDelay > 0 and useWriteTimer: non-blocking, triggered by enqueue.
 	if writeDelay > 0 && useWriteTimer {

--- a/writer_test.go
+++ b/writer_test.go
@@ -2,6 +2,7 @@ package centrifuge
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"os"
 	"sync/atomic"
@@ -579,4 +580,54 @@ func TestWriter_ScheduleFlushLocked_AlreadyScheduled(t *testing.T) {
 	w.scheduleFlushLocked()
 	w.scheduleFlushImmediateLocked()
 	w.mu.Unlock()
+}
+
+func TestEffectiveShrinkDelay(t *testing.T) {
+	// Zero means "unset" and gets the default: shrinking straight after a drain
+	// discards the ring the writer just filled, which is never what a caller
+	// wants. A negative value is the explicit opt-in to that behaviour.
+	require.Equal(t, defaultQueueShrinkDelay, effectiveShrinkDelay(0))
+	require.Equal(t, time.Duration(0), effectiveShrinkDelay(-1))
+	require.Equal(t, time.Duration(0), effectiveShrinkDelay(-time.Second))
+	require.Equal(t, 5*time.Second, effectiveShrinkDelay(5*time.Second))
+}
+
+// TestQueueReclaimsCapacityWhenIdle pins the property the shrink delay exists
+// for: a batching connection holds its ring while it is busy, and gives it back
+// once it goes quiet. Without the deferral the ring would instead be discarded
+// after every single frame and rebuilt by doubling.
+func TestQueueReclaimsCapacityWhenIdle(t *testing.T) {
+	const ch = "reclaim"
+	n, err := New(Config{LogLevel: LogLevelError, LogHandler: func(LogEntry) {}})
+	require.NoError(t, err)
+	n.OnConnecting(func(ctx context.Context, e ConnectEvent) (ConnectReply, error) {
+		// QueueShrinkDelay deliberately left unset - the case this covers.
+		return ConnectReply{WriteDelay: 100 * time.Microsecond, MaxMessagesInFrame: 16}, nil
+	})
+	n.OnConnect(func(c *Client) {
+		c.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) { cb(SubscribeReply{}, nil) })
+	})
+	require.NoError(t, n.Run())
+	defer func() { _ = n.Shutdown(context.Background()) }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tr := newTestTransport(func() {})
+	tr.sink = nil
+	c := newTestConnectedClientWithTransport(t, ctx, n, tr, "u1")
+	subscribeClientV2(t, c, ch)
+
+	sp := StreamPosition{Epoch: "test"}
+	for i := 0; i < 512; i++ {
+		require.NoError(t, n.hub.broadcastPublication(
+			ch, sp, &Publication{Data: []byte(`{"a":1}`)}, nil, nil, ChannelBatchConfig{}))
+	}
+	time.Sleep(300 * time.Millisecond)
+	require.Greater(t, c.messageWriter.messages.Cap(), 2,
+		"a busy connection should hold its ring rather than rebuild it every frame")
+
+	require.Eventually(t, func() bool {
+		return c.messageWriter.messages.Cap() <= 2
+	}, defaultQueueShrinkDelay+3*time.Second, 100*time.Millisecond,
+		"ring must be reclaimed once the connection goes quiet")
 }


### PR DESCRIPTION
> Stacked on #598 — base is `perf/broadcast-fanout-allocations`, so the diff here is just this change. GitHub retargets to `master` once #598 merges.

A connection with `WriteDelay` enabled and `QueueShrinkDelay` left at its zero value allocated on **every write cycle** — 84 allocs and 34 KB per publication broadcast to 200 subscribers.

## Root cause

The shrink decision is taken from `FinishCollect` **immediately after a drain**, when the queue is empty by construction:

```go
n := -1
k := len(q.nodes) / 2
for {
    if k >= q.initCap && q.cnt <= k { n = k } else { break }
    k /= 2
}
```

With `cnt == 0` that always walks the whole way down to `QueueInitialCap` (2). Each cycle discarded the ring the writer had just filled, and the next frame rebuilt it one doubling at a time (2 → 4 → 8 → 16). **The policy was reading utilisation at the trough of a sawtooth**, where for a batching writer it is always zero.

`QueueShrinkDelay` already solves this — a non-zero delay defers the decision, and under sustained load the timer keeps resetting so the queue settles at its working set. The problem was purely that its **zero value meant "shrink immediately"**, making the default the pathological setting for exactly the users who enable `WriteDelay`. Both are PRO options and the coupling was only discoverable by reading both doc comments.

## Change

Treat zero as *unset* and apply `DefaultQueueShrinkDelay` (1s). A negative value now selects immediate shrinking — kept for completeness, though it only reintroduces the churn. The no-`WriteDelay` path never reaches `FinishCollect` and is untouched.

## Results

Broadcast to 200 subscribers, `benchstat` n=8, measured from clean git worktrees at the base commit and the branch tip:

| | base | this branch | |
|---|---|---|---|
| `WriteDelay`, shrink unset | 19.07µs / 84 allocs / 34.3 KB | 12.68µs / 2 allocs / 376 B | **−33.5% time (p=0.010), −97.6% allocs, −98.9% bytes** |
| `WriteDelay`, delay tuned | 12.84µs / 2 allocs | 12.73µs / 2 allocs | no regression where already set |
| no `WriteDelay` (default) | 32.44µs / 3 allocs / ring 2 | 32.27µs / 3 allocs / ring 2 | unchanged |

## Against master

The table above is measured against this PR's base (#598). For the full picture, the same benchmark against `master` as shipped — same user-facing config on both sides, `benchstat` n=10, all p=0.000:

| config | | ns/op | allocs/op | B/op | ring/conn |
|---|---|---|---|---|---|
| **no `WriteDelay`** | master | 35.76µs | 196.5 | 13,350 | 2 |
| | this branch | **32.07µs** | **3** | **692** | **2** |
| **`WriteDelay` on** | master | 24.22µs | 97.5 | 29,374 | 2 |
| | this branch | **12.97µs** | **2** | **375** | 32 busy → 2 idle |

The no-`WriteDelay` improvement is #598's doing (one allocation per subscriber from `RemoveMany`); this PR contributes the `WriteDelay` row. Ring size is unchanged on the default path and returns to 2 on the batching path once the connection goes quiet.

## Why not a capacity floor

A shrink floor was the first thing I tried, and it performed marginally better (−38% vs −33%). It is not in this PR because **a floor never gives the memory back**: a connection that bursts once during handshake — subscribes, recovery, initial state — and then goes quiet would hold the floor for its entire life. Measured at ~900 B per connection, on the PRO path *and* the default path, since the floor applied to both.

Deferring instead means capacity is held only while the connection is actually busy, and released in full when it goes idle. `TestQueueReclaimsCapacityWhenIdle` pins that a connection which bursts 512 publications returns to 2 entries once quiet. Peak usage is identical either way — the ring has to hold the queued messages regardless — so this costs nothing at the high-water mark and nothing at rest.

## API note

This changes the meaning of `QueueShrinkDelay`'s zero value from "shrink immediately" to "use the default". The default itself is internal, not an exported constant. Anyone who explicitly wants the old behaviour passes a negative value, following the same convention as `PingInterval`. Since immediate shrinking has no benefit other than reintroducing the allocation churn, the previous zero-value behaviour is unlikely to have been chosen deliberately by anyone.

## Tests

`TestEffectiveShrinkDelay` covers the resolution (zero → default, negative → immediate, positive → as given). `TestQueueReclaimsCapacityWhenIdle` covers both halves of the property: a busy connection holds its ring, and a quiet one gives it back.

Full suite, `-race`, `go vet` and `gofmt` all clean.
