### PR TITLE
Trim two per-publication costs on the hot path, unbreak the websocket benchmarks

### DIFF
--- a/client.go
+++ b/client.go
@@ -2563,17 +2563,16 @@ func (c *Client) handlePublish(req *protocol.PublishRequest, cmd *protocol.Comma
 		}
 
 		if reply.Result == nil {
-			publishOpts := []PublishOption{
-				WithHistory(reply.Options.HistorySize, reply.Options.HistoryTTL, reply.Options.HistoryMetaTTL),
-				WithClientInfo(reply.Options.ClientInfo),
-			}
-			if reply.Options.Key != "" {
-				publishOpts = append(publishOpts, WithKey(reply.Options.Key))
-			}
-			_, err := c.node.Publish(
-				event.Channel, event.Data,
-				publishOpts...,
-			)
+			// Forward exactly the options the closure-based form used to set -
+			// history, client info and key - and nothing else, so the rest of
+			// PublishReply.Options stays as unforwarded as it has always been.
+			_, err := c.node.publishWithOptions(event.Channel, event.Data, PublishOptions{
+				HistorySize:    reply.Options.HistorySize,
+				HistoryTTL:     reply.Options.HistoryTTL,
+				HistoryMetaTTL: reply.Options.HistoryMetaTTL,
+				ClientInfo:     reply.Options.ClientInfo,
+				Key:            reply.Options.Key,
+			})
 			if err != nil {
 				c.logWriteInternalErrorFlush(channel, protocol.FrameTypePublish, cmd, err, "error publish", started, rw)
 				return

--- a/client.go
+++ b/client.go
@@ -4673,7 +4673,7 @@ func (c *Client) handleAsyncUnsubscribe(ch string, unsub Unsubscribe) {
 
 func (c *Client) writePublicationUpdatePosition(
 	ch string, pub *protocol.Publication, prep preparedData, sp StreamPosition, maxLagExceeded bool,
-	batchConfig ChannelBatchConfig,
+	batchConfig ChannelBatchConfig, nowUnix int64,
 ) error {
 	c.mu.Lock()
 	channelContext, ok := c.channels[ch]
@@ -4774,7 +4774,10 @@ func (c *Client) writePublicationUpdatePosition(
 		c.mu.Unlock()
 		return nil
 	}
-	channelContext.positionCheckTime = time.Now().Unix()
+	if nowUnix == 0 {
+		nowUnix = time.Now().Unix()
+	}
+	channelContext.positionCheckTime = nowUnix
 	channelContext.streamPosition.Offset = pub.Offset
 	c.channels[ch] = channelContext
 	c.mu.Unlock()
@@ -4812,10 +4815,15 @@ func (c *Client) writePublicationNoDelta(ch string, pub *protocol.Publication, d
 		ch, pub, preparedData{
 			fullData: data, brokerDeltaData: nil, localDeltaData: nil, deltaSub: false, wasFiltered: false,
 		},
-		sp, false, batchConfig)
+		sp, false, batchConfig, 0)
 }
 
-func (c *Client) writePublication(ch string, pub *protocol.Publication, prep preparedData, sp StreamPosition, maxLagExceeded bool, batchConfig ChannelBatchConfig) error {
+// writePublication delivers one publication to this connection. nowUnix is the
+// wall clock the caller already read, in Unix seconds; a fan-out reads it once
+// per publication and passes it to every subscriber rather than having each of
+// them read the clock again for a value that only has second granularity. Pass
+// 0 when the caller has no clock reading at hand.
+func (c *Client) writePublication(ch string, pub *protocol.Publication, prep preparedData, sp StreamPosition, maxLagExceeded bool, batchConfig ChannelBatchConfig, nowUnix int64) error {
 	if pub.Offset == 0 {
 		if hasFlag(c.transport.DisabledPushFlags(), PushFlagPublication) {
 			return nil
@@ -4864,7 +4872,7 @@ func (c *Client) writePublication(ch string, pub *protocol.Publication, prep pre
 		syncPub = prep.filteredPub
 	}
 	c.pubSubSync.SyncPublication(ch, syncPub, func() {
-		_ = c.writePublicationUpdatePosition(ch, pub, prep, sp, maxLagExceeded, batchConfig)
+		_ = c.writePublicationUpdatePosition(ch, pub, prep, sp, maxLagExceeded, batchConfig, nowUnix)
 	})
 	return nil
 }

--- a/client_keyed.go
+++ b/client_keyed.go
@@ -958,5 +958,5 @@ func (c *Client) keyedWriteRemoval(channel string, key string, pub *protocol.Pub
 	if c.node.config.GetChannelBatchConfig != nil {
 		batchConfig = c.node.config.GetChannelBatchConfig(channel)
 	}
-	_ = c.writePublication(channel, pub, preparedData{fullData: data}, StreamPosition{}, false, batchConfig)
+	_ = c.writePublication(channel, pub, preparedData{fullData: data}, StreamPosition{}, false, batchConfig, 0)
 }

--- a/handler_websocket_test.go
+++ b/handler_websocket_test.go
@@ -794,6 +794,9 @@ func BenchmarkWsPubSub(b *testing.B) {
 
 	mux := http.NewServeMux()
 	mux.Handle("/connection/websocket", testAuthMiddleware(NewWebsocketHandler(n, WebsocketConfig{
+		// These clients never answer a server ping, so let no ping fire: otherwise a
+		// run lasting longer than the ping interval loses its connections mid-measurement.
+		PingPongConfig:  PingPongConfig{PingInterval: time.Hour, PongTimeout: time.Minute},
 		WriteBufferSize: 0,
 		ReadBufferSize:  0,
 	})))
@@ -917,6 +920,9 @@ func BenchmarkWsBroadcastCompressionCache(b *testing.B) {
 
 			mux := http.NewServeMux()
 			mux.Handle("/connection/websocket", testAuthMiddleware(NewWebsocketHandler(n, WebsocketConfig{
+				// These clients never answer a server ping, so let no ping fire: otherwise a
+				// run lasting longer than the ping interval loses its connections mid-measurement.
+				PingPongConfig:                      PingPongConfig{PingInterval: time.Hour, PongTimeout: time.Minute},
 				Compression:                         true,
 				CompressionPreparedMessageCacheSize: bm.cacheSizeMB * 1024 * 1024,
 			})))
@@ -967,6 +973,9 @@ func BenchmarkWsCommandReplyV2(b *testing.B) {
 
 	mux := http.NewServeMux()
 	mux.Handle("/connection/websocket", testAuthMiddleware(NewWebsocketHandler(n, WebsocketConfig{
+		// These clients never answer a server ping, so let no ping fire: otherwise a
+		// run lasting longer than the ping interval loses its connections mid-measurement.
+		PingPongConfig:  PingPongConfig{PingInterval: time.Hour, PongTimeout: time.Minute},
 		WriteBufferSize: 0,
 		ReadBufferSize:  0,
 	})))
@@ -1044,6 +1053,9 @@ func BenchmarkWsCommandReplyV2Multiple(b *testing.B) {
 
 	mux := http.NewServeMux()
 	mux.Handle("/connection/websocket", testAuthMiddleware(NewWebsocketHandler(n, WebsocketConfig{
+		// These clients never answer a server ping, so let no ping fire: otherwise a
+		// run lasting longer than the ping interval loses its connections mid-measurement.
+		PingPongConfig:  PingPongConfig{PingInterval: time.Hour, PongTimeout: time.Minute},
 		WriteBufferSize: 0,
 		ReadBufferSize:  0,
 	})))
@@ -1149,6 +1161,9 @@ func BenchmarkWsCommandReplyV2MultipleParallel(b *testing.B) {
 
 	mux := http.NewServeMux()
 	mux.Handle("/connection/websocket", testAuthMiddleware(NewWebsocketHandler(n, WebsocketConfig{
+		// These clients never answer a server ping, so let no ping fire: otherwise a
+		// run lasting longer than the ping interval loses its connections mid-measurement.
+		PingPongConfig:  PingPongConfig{PingInterval: time.Hour, PongTimeout: time.Minute},
 		WriteBufferSize: 0,
 		ReadBufferSize:  0,
 	})))

--- a/hub.go
+++ b/hub.go
@@ -1092,6 +1092,12 @@ func (s *subShard) broadcastPublication(
 	// about insufficient state in the stream.
 	var maxLagExceeded bool
 	now := time.Now()
+	// Positioning bookkeeping stamps each subscriber's channel context with the
+	// current time in whole seconds. Read the clock once here and hand it to
+	// every subscriber: a fan-out is far shorter than the second of resolution
+	// that stamp carries, so re-reading it per subscriber buys no accuracy and
+	// costs one clock read per delivered message.
+	nowUnix := now.Unix()
 	if pubTime > 0 {
 		timeLagMilli := now.UnixMilli() - pubTime
 		if s.maxTimeLagMilli > 0 && timeLagMilli > s.maxTimeLagMilli {
@@ -1339,7 +1345,7 @@ func (s *subShard) broadcastPublication(
 
 		// Even filtered publications need to reach writePublication for offset tracking,
 		// but they will be marked as filtered so the client can skip them without adding to the queue.
-		_ = sub.client.writePublication(channel, fullPub, prepValue, sp, maxLagExceeded, batchConfig)
+		_ = sub.client.writePublication(channel, fullPub, prepValue, sp, maxLagExceeded, batchConfig, nowUnix)
 	}
 	if jsonEncodeErr != nil && s.logger.enabled(LogLevelWarn) {
 		// Log that we had clients with inappropriate protocol, and point to the first such client.

--- a/node.go
+++ b/node.go
@@ -905,8 +905,17 @@ func (n *Node) publish(ch string, data []byte, opts ...PublishOption) (PublishRe
 	for _, opt := range opts {
 		opt(pubOpts)
 	}
+	return n.publishWithOptions(ch, data, *pubOpts)
+}
+
+// publishWithOptions is the publish path once options are resolved. Callers
+// that already hold a PublishOptions - the client publish command handler gets
+// one straight out of PublishReply - go here directly instead of wrapping each
+// field in a PublishOption closure only for Node.publish to unwrap it again.
+// Every one of those closures is a heap allocation on a per-publication path.
+func (n *Node) publishWithOptions(ch string, data []byte, pubOpts PublishOptions) (PublishResult, error) {
 	n.metrics.incMessagesSent("publication", ch)
-	result, err := n.getBroker(ch).Publish(ch, data, *pubOpts)
+	result, err := n.getBroker(ch).Publish(ch, data, pubOpts)
 	if err != nil {
 		return PublishResult{}, err
 	}


### PR DESCRIPTION
Three independent changes found while profiling the fan-out and publish paths. The first two are behaviour-preserving refactors of hot-path plumbing; the third fixes benchmarks that could not complete.

## 1. Reuse the broadcast timestamp for per-subscriber position bookkeeping

`writePublicationUpdatePosition` stamped `channelContext.positionCheckTime` from its own `time.Now()` call — one clock read per subscriber per publication, for a value only ever stored and compared in whole seconds against a check delay measured in tens of them.

`subShard.broadcastPublication` already reads the clock once at the top, so that reading is threaded down to every subscriber. A fan-out completes in far less than the second of resolution the stamp carries, so the stored value is unchanged. Callers with no clock reading at hand pass `0` and the callee reads it itself.

Profiling a 1000-subscriber positioning fan-out put `time.Now` at **8.4% of total CPU**, all of it from this one function. Measured with base and patched binaries interleaved: **-16.4% on the broadcasting goroutine (p=0.000)** and **-3.9% process CPU per delivered message (p=0.035)**.

## 2. Skip the PublishOption closures on the client publish path

`Client.handlePublish` built a `[]PublishOption` holding `WithHistory`, `WithClientInfo` and sometimes `WithKey`, and handed them to `Node.Publish` — which immediately unwrapped them into a `PublishOptions` and discarded them. `PublishReply.Options` *is* a `PublishOptions`, so the closures existed only to be undone: four heap allocations per publication for a pure round trip.

The resolved path is split out as `Node.publishWithOptions` and the handler calls it directly. `Node.publish` still applies the options and delegates, so **`Node.Publish`, the `PublishOption` type and every `With*` constructor are untouched — no API change**.

The handler forwards the same explicit subset of fields it always has (history, client info, key). Passing `reply.Options` wholesale would compile and be faster still, but would silently start honouring `Tags`, `UseDelta`, `IdempotencyKey` and `Version` on a path that has never applied them.

Measured on the inbound publish command, interleaved: **14 -> 10 allocs/op, -19% B/op, -7.0% wall (p=0.002), -5.4% CPU (p=0.003)**.

## 3. Stop server pings from killing the websocket benchmarks mid-run

`BenchmarkWsPubSub`, the three `BenchmarkWsCommandReplyV2` variants and `BenchmarkWsBroadcastCompressionCache` each hold real websocket connections open across the measured loop, but their clients only read — they never answer an application-level ping. With the default 25s interval, any run long enough to reach it lost its connections and failed with `websocket: close 3012: no pong`.

At `-benchtime 1s`, four of eight sub-benchmarks failed and the parallel one failed every time; all pass now. The ping is pushed past any plausible run length in those five handlers. Tests in the file are short-lived and are left alone.

## Verification

- Full package test suite passes; `go build ./...` and `go vet ./...` clean.
- `gofmt -l` reports the same pre-existing files as `master` — none introduced here.
- Every A/B above compares two prebuilt test binaries run alternately. Running all of one side then all of the other gave the *opposite* sign on change 1 (a "significant" +6.6% regression) purely from ordering bias on a machine with ±15% run-to-run noise.

## Caveats

- All measurements are from a macOS laptop with both connection ends in one process. The directions are profile-attributed and solid; the magnitudes are not a substitute for a Linux run at scale.
- `time.Now` is a libc call on macOS and a vDSO call on Linux, so change 1's share will be smaller there.
- These are single-digit-percent wins. The large levers found in the same profiling session are configuration, not code: write batching (`WriteDelay`) is worth ~7-8x CPU per delivered message, and `UseWriteBufferPool` plus a smaller `ReadBufferSize` cut per-connection heap by ~34% and goroutines by half. Both default to off. Happy to open a separate discussion on defaults.
- The benchmarks used to produce these numbers are deliberately not included here.