### PR TITLE
Stop server pings from killing the websocket benchmarks mid-run

### DIFF
--- a/handler_websocket_test.go
+++ b/handler_websocket_test.go
@@ -794,6 +794,9 @@ func BenchmarkWsPubSub(b *testing.B) {
 
 	mux := http.NewServeMux()
 	mux.Handle("/connection/websocket", testAuthMiddleware(NewWebsocketHandler(n, WebsocketConfig{
+		// These clients never answer a server ping, so let no ping fire: otherwise a
+		// run lasting longer than the ping interval loses its connections mid-measurement.
+		PingPongConfig:  PingPongConfig{PingInterval: time.Hour, PongTimeout: time.Minute},
 		WriteBufferSize: 0,
 		ReadBufferSize:  0,
 	})))
@@ -917,6 +920,9 @@ func BenchmarkWsBroadcastCompressionCache(b *testing.B) {
 
 			mux := http.NewServeMux()
 			mux.Handle("/connection/websocket", testAuthMiddleware(NewWebsocketHandler(n, WebsocketConfig{
+				// These clients never answer a server ping, so let no ping fire: otherwise a
+				// run lasting longer than the ping interval loses its connections mid-measurement.
+				PingPongConfig:                      PingPongConfig{PingInterval: time.Hour, PongTimeout: time.Minute},
 				Compression:                         true,
 				CompressionPreparedMessageCacheSize: bm.cacheSizeMB * 1024 * 1024,
 			})))
@@ -967,6 +973,9 @@ func BenchmarkWsCommandReplyV2(b *testing.B) {
 
 	mux := http.NewServeMux()
 	mux.Handle("/connection/websocket", testAuthMiddleware(NewWebsocketHandler(n, WebsocketConfig{
+		// These clients never answer a server ping, so let no ping fire: otherwise a
+		// run lasting longer than the ping interval loses its connections mid-measurement.
+		PingPongConfig:  PingPongConfig{PingInterval: time.Hour, PongTimeout: time.Minute},
 		WriteBufferSize: 0,
 		ReadBufferSize:  0,
 	})))
@@ -1044,6 +1053,9 @@ func BenchmarkWsCommandReplyV2Multiple(b *testing.B) {
 
 	mux := http.NewServeMux()
 	mux.Handle("/connection/websocket", testAuthMiddleware(NewWebsocketHandler(n, WebsocketConfig{
+		// These clients never answer a server ping, so let no ping fire: otherwise a
+		// run lasting longer than the ping interval loses its connections mid-measurement.
+		PingPongConfig:  PingPongConfig{PingInterval: time.Hour, PongTimeout: time.Minute},
 		WriteBufferSize: 0,
 		ReadBufferSize:  0,
 	})))
@@ -1149,6 +1161,9 @@ func BenchmarkWsCommandReplyV2MultipleParallel(b *testing.B) {
 
 	mux := http.NewServeMux()
 	mux.Handle("/connection/websocket", testAuthMiddleware(NewWebsocketHandler(n, WebsocketConfig{
+		// These clients never answer a server ping, so let no ping fire: otherwise a
+		// run lasting longer than the ping interval loses its connections mid-measurement.
+		PingPongConfig:  PingPongConfig{PingInterval: time.Hour, PongTimeout: time.Minute},
 		WriteBufferSize: 0,
 		ReadBufferSize:  0,
 	})))


### PR DESCRIPTION
`BenchmarkWsPubSub`, the three `BenchmarkWsCommandReplyV2` variants and `BenchmarkWsBroadcastCompressionCache` each open real websocket connections and hold them for the whole measured loop, but their clients only ever read — they never answer an application-level ping.

The default ping interval is 25s, so any run long enough to reach it had its connections closed underneath it and failed with `websocket: close 3012: no pong`. At `-benchtime 1s` four of the eight sub-benchmarks failed, and the parallel one failed every time.

This pushes the ping past any plausible run length in those five handlers. Tests in the file are short-lived and are left alone.

## Before

```
BenchmarkWsCommandReplyV2/JSON-10   --- FAIL: BenchmarkWsCommandReplyV2/JSON-10
    handler_websocket_test.go:1026: websocket: close 3012: no pong
BenchmarkWsCommandReplyV2MultipleParallel/PB-10   --- FAIL
    handler_websocket_test.go:1235: websocket: close 3012: no pong
```

## After

All eight sub-benchmarks complete at `-benchtime 1s`, plus `BenchmarkWsBroadcastCompressionCache`.

`go build ./...` and `go vet ./...` clean; `gofmt -l` reports the same pre-existing files as `master`. Test-only change.