### PR TITLE
Add WebsocketConfig.ProcessCommandsOffReadLoop to cut per-connection memory

### DIFF
--- a/handler_websocket.go
+++ b/handler_websocket.go
@@ -98,6 +98,34 @@ type WebsocketConfig struct {
 	// must be true, otherwise no connections will be accepted).
 	DisableHTTP1Upgrade bool
 
+	// ProcessCommandsOffReadLoop makes each connection's read loop hand every
+	// frame to a short-lived goroutine and wait for it, instead of processing the
+	// frame itself.
+	//
+	// It exists to keep the read loop's goroutine stack small. Command
+	// processing runs the whole dispatch chain - handlers, publish, broker,
+	// broadcast fan-out - and a goroutine's stack only ever grows to the deepest
+	// call it makes and is not given back while the goroutine lives. A read loop
+	// that has processed one command therefore keeps that peak stack for as long
+	// as the connection is open, even while completely idle. Moving the work to a
+	// goroutine that exits afterwards returns the deep stack to the runtime's
+	// stack cache, where connections reuse it instead of each owning one.
+	//
+	// The trade is one goroutine start and two scheduler handoffs per frame.
+	// That is a latency cost, not a throughput one: it is visible on a
+	// connection that sends a command and waits for the reply with nothing else
+	// going on, and it disappears once many connections are busy at the same
+	// time, where the handoff overlaps with other work. Under that kind of load
+	// per-connection memory is lower as well, because only the connections
+	// actually mid-frame hold a deep stack rather than every one of them.
+	//
+	// Ordering is unaffected: the read loop waits for each frame to finish
+	// before reading the next.
+	//
+	// Off by default. It suits large pools of mostly-idle connections, where it
+	// roughly halves the read loop's stack.
+	ProcessCommandsOffReadLoop bool
+
 	PingPongConfig
 }
 
@@ -276,6 +304,13 @@ func (s *WebsocketHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 			}(time.Now())
 		}
 
+		// Allocated once per connection when enabled, so handing a frame off
+		// costs a goroutine but no allocation. See ProcessCommandsOffReadLoop.
+		var handoff *frameHandoff
+		if s.config.ProcessCommandsOffReadLoop {
+			handoff = newFrameHandoff(c)
+		}
+
 		for {
 			_, r, err := conn.NextReader()
 			if err != nil {
@@ -284,7 +319,12 @@ func (s *WebsocketHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 				}
 				break
 			}
-			proceed := HandleReadFrame(c, r)
+			var proceed bool
+			if handoff != nil {
+				proceed = handoff.handle(r)
+			} else {
+				proceed = HandleReadFrame(c, r)
+			}
 			if !proceed {
 				break
 			}
@@ -310,6 +350,43 @@ func (s *WebsocketHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		// HTTP/2 and above - execute directly, otherwise underlying stream is being closed.
 		handleConn()
 	}
+}
+
+// frameHandoff runs HandleReadFrame on a goroutine other than the one that owns
+// the connection's read loop, one goroutine per frame, and lets the read loop
+// wait for the result.
+//
+// It is a struct with a method rather than a closure so that handing off costs
+// nothing beyond the goroutine itself: the reader and the result channel live
+// here for the lifetime of the connection, and `go h.run()` on an
+// already-heap-allocated receiver allocates no closure per frame.
+//
+// Only the read loop writes r, and it does so before starting run and does not
+// touch it again until run has sent on done, so the two goroutines never race.
+type frameHandoff struct {
+	c    *Client
+	r    io.Reader
+	done chan bool
+}
+
+func newFrameHandoff(c *Client) *frameHandoff {
+	return &frameHandoff{c: c, done: make(chan bool, 1)}
+}
+
+func (h *frameHandoff) run() {
+	h.done <- HandleReadFrame(h.c, h.r)
+}
+
+// handle processes one frame off the read loop and reports whether the
+// connection should keep reading.
+func (h *frameHandoff) handle(r io.Reader) bool {
+	h.r = r
+	go h.run()
+	proceed := <-h.done
+	// Drop the reader: it is only valid until the next NextReader call, and
+	// holding it would keep the frame's buffers reachable while idle.
+	h.r = nil
+	return proceed
 }
 
 // HandleReadFrame is a helper to read Centrifuge commands from frame-based io.Reader and

--- a/handler_websocket_test.go
+++ b/handler_websocket_test.go
@@ -10,7 +10,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"runtime"
+	"runtime/pprof"
 	"strconv"
 	"strings"
 	"sync"
@@ -1713,4 +1715,637 @@ func TestProcessCommandsOffReadLoopInterleavedWithPushes(t *testing.T) {
 		require.Equal(t, uint32(3+i), id, "reply %d out of order", i)
 	}
 	require.Equal(t, numPushes, pushes)
+}
+
+// What a connection costs while it is doing nothing is what caps connection
+// density. These benchmarks hold b.N *real* WebSocket connections open, put
+// each through a realistic command sequence, let them go idle, and then report
+// what each one still occupies.
+//
+// The number this file exists to measure is stack-B/conn. A goroutine's stack
+// grows to the deepest call it ever makes and is not handed back while the
+// goroutine lives, so a read loop that has processed a single publish keeps the
+// stack that the whole dispatch-and-fan-out chain needed, for the entire life
+// of the connection. That is what WebsocketConfig.ProcessCommandsOffReadLoop
+// targets, and the Inline/OffReadLoop pairs below are its A/B.
+//
+// Both ends of every connection live in this process, so heap-B/conn covers the
+// client half too and is only meaningful relative to another run of this same
+// benchmark. stack-B/conn is not affected the same way: the client half has no
+// goroutine of its own here - the benchmark goroutine drives it - so
+// essentially all of it is server-side read loops.
+//
+// Set CENTRIFUGE_BENCH_HEAP_PROFILE to a path to also write an inuse_space
+// profile with every connection live.
+
+// settle blocks until the goroutine count stops moving, so a measurement
+// baseline is not taken while previous work is still unwinding.
+func settle(b *testing.B) {
+	b.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	last := -1
+	stable := 0
+	for time.Now().Before(deadline) {
+		runtime.GC()
+		n := runtime.NumGoroutine()
+		if n == last {
+			if stable++; stable >= 3 {
+				return
+			}
+		} else {
+			stable = 0
+			last = n
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	b.Log("goroutine count did not settle; footprint baseline may be noisy")
+}
+
+type wsFootprintParams struct {
+	ws             WebsocketConfig
+	writeDelay     time.Duration
+	writeWithTimer bool
+	// commandsPerConn is how many publishes each connection issues before going
+	// idle. It must be at least one: a connection that never sends a command
+	// never drives the dispatch chain, its read loop stack never grows, and the
+	// benchmark would report an identical footprint for both variants while
+	// measuring nothing at all.
+	commandsPerConn int
+}
+
+// benchWsRoundTrip sends one command and reads until the matching reply comes
+// back, skipping the pushes a self-subscribed publish generates. Returning only
+// on the matching id keeps the connection in lockstep, so a command that
+// silently failed surfaces as a failure rather than as a faster benchmark.
+func benchWsRoundTrip(b *testing.B, conn *websocket.Conn, cmd *protocol.Command) {
+	b.Helper()
+	raw, err := json.Marshal(cmd)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err = conn.WriteMessage(websocket.TextMessage, raw); err != nil {
+		b.Fatal(err)
+	}
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		_, data, rErr := conn.ReadMessage()
+		if rErr != nil {
+			b.Fatal(rErr)
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			if line == "" {
+				continue
+			}
+			var reply struct {
+				ID    uint32          `json:"id"`
+				Error json.RawMessage `json:"error"`
+			}
+			if err = json.Unmarshal([]byte(line), &reply); err != nil {
+				b.Fatalf("decoding reply %q: %v", line, err)
+			}
+			if len(reply.Error) > 0 {
+				b.Fatalf("command %d failed: %s", cmd.Id, reply.Error)
+			}
+			if reply.ID == cmd.Id {
+				return
+			}
+		}
+	}
+	b.Fatalf("no reply for command %d", cmd.Id)
+}
+
+// benchWsExerciseConn subscribes the connection and has it publish, so the read
+// loop runs the full dispatch chain - handler, broker, fan-out back to this
+// same connection - and its stack reaches the depth a real connection reaches.
+func benchWsExerciseConn(b *testing.B, conn *websocket.Conn, channel string, publishes int) {
+	b.Helper()
+	benchWsRoundTrip(b, conn, &protocol.Command{
+		Id:        2,
+		Subscribe: &protocol.SubscribeRequest{Channel: channel},
+	})
+	for i := 0; i < publishes; i++ {
+		benchWsRoundTrip(b, conn, &protocol.Command{
+			Id: uint32(3 + i),
+			Publish: &protocol.PublishRequest{
+				Channel: channel,
+				Data:    []byte(`{"input":"hello world, this is a benchmark payload"}`),
+			},
+		})
+	}
+}
+
+func benchWsConnFootprint(b *testing.B, p wsFootprintParams) {
+	if p.commandsPerConn < 1 {
+		b.Fatal("commandsPerConn must be >= 1, otherwise the read loop stack never grows")
+	}
+
+	n, err := New(Config{LogLevel: LogLevelError})
+	if err != nil {
+		b.Fatal(err)
+	}
+	n.OnConnecting(func(_ context.Context, _ ConnectEvent) (ConnectReply, error) {
+		return ConnectReply{
+			Credentials:    &Credentials{UserID: "bench"},
+			WriteDelay:     p.writeDelay,
+			WriteWithTimer: p.writeWithTimer,
+		}, nil
+	})
+	n.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
+			cb(SubscribeReply{}, nil)
+		})
+		client.OnPublish(func(e PublishEvent, cb PublishCallback) {
+			cb(PublishReply{}, nil)
+		})
+	})
+	if err = n.Run(); err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = n.Shutdown(context.Background()) }()
+
+	// These clients answer replies and then go quiet, so a server ping firing
+	// mid-run would disconnect connections already established and the footprint
+	// would be measured over a shrinking population.
+	ws := p.ws
+	ws.PingPongConfig = PingPongConfig{PingInterval: time.Hour, PongTimeout: time.Minute}
+
+	mux := http.NewServeMux()
+	mux.Handle("/connection/websocket", NewWebsocketHandler(n, ws))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	url := "ws" + server.URL[4:]
+
+	// Warm up before taking the baseline. A node allocates several MB lazily on
+	// first use - Prometheus label combinations, summary quantile streams, broker
+	// maps - and that is fixed cost, not per-connection cost. Left inside the
+	// measured window it lands in heap-B/conn divided by b.N, which at a few
+	// hundred connections is larger than the per-connection heap itself and
+	// swamps it with noise. Running a few connections through the full command
+	// path first forces those allocations to happen before the baseline.
+	for i := 0; i < 8; i++ {
+		warm := newRealConnJSONConnect(b, url, false)
+		benchWsExerciseConn(b, warm, fmt.Sprintf("warmup%d", i), p.commandsPerConn)
+		_ = warm.Close()
+	}
+
+	// Connections torn down by warmup, or by an earlier benchmark in this
+	// process, are still unwinding and would otherwise be charged to the
+	// baseline.
+	settle(b)
+
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+	goroutinesBefore := runtime.NumGoroutine()
+
+	b.ResetTimer()
+	conns := make([]*websocket.Conn, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		conn := newRealConnJSONConnect(b, url, false)
+		benchWsExerciseConn(b, conn, fmt.Sprintf("bench%d", i), p.commandsPerConn)
+		conns = append(conns, conn)
+	}
+	b.StopTimer()
+
+	// Every connection must still be registered. Without this the benchmark
+	// divides by b.N while the server has quietly dropped a share of them,
+	// reporting a footprint well below the real one.
+	if got := n.hub.NumClients(); got != b.N {
+		b.Fatalf("server holds %d connections, want %d: some were dropped during the run", got, b.N)
+	}
+
+	// Go shrinks an oversized goroutine stack by at most half per GC cycle, so a
+	// single collection reports the peak the read loop reached rather than what
+	// an idle connection settles at. Several cycles give the steady state, which
+	// is what a mostly-idle fleet actually costs.
+	for i := 0; i < 8; i++ {
+		runtime.GC()
+	}
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	goroutinesAfter := runtime.NumGoroutine()
+
+	// MemStats counters are unsigned and the heap can legitimately end smaller
+	// than it started, so subtract as signed - an unsigned wrap here renders as
+	// a nonsense 3.6e16 rather than as an obvious error.
+	stackDelta := int64(after.StackInuse) - int64(before.StackInuse)
+	heapDelta := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+	goroutineDelta := goroutinesAfter - goroutinesBefore
+
+	// Each connection must have left exactly its read loop behind. Anything else
+	// means the baseline was taken while unrelated goroutines were still
+	// unwinding, which silently skews every metric here - run one variant per
+	// process if this trips.
+	if perConn := float64(goroutineDelta) / float64(b.N); perConn < 0.95 || perConn > 1.05 {
+		b.Fatalf("%.3f goroutines/conn, want ~1.0: measurement baseline is polluted", perConn)
+	}
+
+	b.ReportMetric(float64(stackDelta)/float64(b.N), "stack-B/conn")
+	b.ReportMetric(float64(heapDelta)/float64(b.N), "heap-B/conn")
+	b.ReportMetric(float64(goroutineDelta)/float64(b.N), "goroutines/conn")
+
+	if path := os.Getenv("CENTRIFUGE_BENCH_HEAP_PROFILE"); path != "" {
+		f, ferr := os.Create(path)
+		if ferr != nil {
+			b.Fatal(ferr)
+		}
+		if perr := pprof.Lookup("heap").WriteTo(f, 0); perr != nil {
+			b.Fatal(perr)
+		}
+		_ = f.Close()
+	}
+
+	runtime.KeepAlive(conns)
+	for _, c := range conns {
+		_ = c.Close()
+	}
+}
+
+// The A/B pair. Both use the timer-driven writer, so the writer goroutine is
+// already gone and the only per-connection goroutine left is the read loop -
+// exactly what ProcessCommandsOffReadLoop acts on.
+
+func BenchmarkWsFootprint_Inline(b *testing.B) {
+	benchWsConnFootprint(b, wsFootprintParams{
+		ws: WebsocketConfig{ReadBufferSize: 512, UseWriteBufferPool: true},
+		// Only needs to be non-zero to put the writer in timer mode, which is what
+		// removes the writer goroutine. Kept small because every command round
+		// trip waits for it and each connection makes five of them.
+		writeDelay:      time.Millisecond,
+		writeWithTimer:  true,
+		commandsPerConn: 3,
+	})
+}
+
+func BenchmarkWsFootprint_OffReadLoop(b *testing.B) {
+	benchWsConnFootprint(b, wsFootprintParams{
+		ws: WebsocketConfig{
+			ReadBufferSize: 512, UseWriteBufferPool: true,
+			ProcessCommandsOffReadLoop: true,
+		},
+		// Only needs to be non-zero to put the writer in timer mode, which is what
+		// removes the writer goroutine. Kept small because every command round
+		// trip waits for it and each connection makes five of them.
+		writeDelay:      time.Millisecond,
+		writeWithTimer:  true,
+		commandsPerConn: 3,
+	})
+}
+
+// The same pair with stock buffer settings and the goroutine writer, to confirm
+// the stack effect is independent of the other tuning.
+
+func BenchmarkWsFootprint_DefaultBuffers_Inline(b *testing.B) {
+	benchWsConnFootprint(b, wsFootprintParams{commandsPerConn: 3})
+}
+
+func BenchmarkWsFootprint_DefaultBuffers_OffReadLoop(b *testing.B) {
+	benchWsConnFootprint(b, wsFootprintParams{
+		ws:              WebsocketConfig{ProcessCommandsOffReadLoop: true},
+		commandsPerConn: 3,
+	})
+}
+
+// --- The cost side ---------------------------------------------------------
+//
+// ProcessCommandsOffReadLoop buys stack by spending a goroutine spawn and two
+// scheduler handoffs per frame. These measure that price on a connection that
+// is doing nothing but sending commands - the worst case for the option, and
+// the opposite of the fleet it is meant to help.
+
+func benchWsCommandThroughput(b *testing.B, offReadLoop bool) {
+	const channel = "bench"
+	n, err := New(Config{LogLevel: LogLevelError})
+	if err != nil {
+		b.Fatal(err)
+	}
+	n.OnConnecting(func(_ context.Context, _ ConnectEvent) (ConnectReply, error) {
+		return ConnectReply{Credentials: &Credentials{UserID: "bench"}}, nil
+	})
+	n.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) { cb(SubscribeReply{}, nil) })
+		client.OnPublish(func(e PublishEvent, cb PublishCallback) { cb(PublishReply{}, nil) })
+	})
+	if err = n.Run(); err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = n.Shutdown(context.Background()) }()
+
+	mux := http.NewServeMux()
+	mux.Handle("/connection/websocket", NewWebsocketHandler(n, WebsocketConfig{
+		PingPongConfig:             PingPongConfig{PingInterval: time.Hour, PongTimeout: time.Minute},
+		ProcessCommandsOffReadLoop: offReadLoop,
+	}))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	conn := newRealConnJSONConnect(b, "ws"+server.URL[4:], false)
+	defer func() { _ = conn.Close() }()
+	benchWsRoundTrip(b, conn, &protocol.Command{
+		Id: 2, Subscribe: &protocol.SubscribeRequest{Channel: channel},
+	})
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		benchWsRoundTrip(b, conn, &protocol.Command{
+			Id: uint32(3 + i),
+			Publish: &protocol.PublishRequest{
+				Channel: channel,
+				Data:    []byte(`{"input":"hello world, this is a benchmark payload"}`),
+			},
+		})
+	}
+	b.StopTimer()
+
+}
+
+func BenchmarkWsCommandThroughput_Inline(b *testing.B) {
+	benchWsCommandThroughput(b, false)
+}
+
+func BenchmarkWsCommandThroughput_OffReadLoop(b *testing.B) {
+	benchWsCommandThroughput(b, true)
+}
+
+// --- Where does the read goroutine's stack high-water mark come from? -------
+//
+// The read goroutine settles at 4KB rather than Go's 2KB minimum, and Go only
+// doubles a stack when a call chain does not fit. Whether that doubling happens
+// during connection setup, or later while actually parsing a frame, decides
+// whether restructuring setup out of the read loop's frame could get it back to
+// 2KB. These two probes separate the cases.
+//
+// StackProbe_UpgradedOnly holds connections that completed the WebSocket
+// handshake and nothing else. Setup has run in full and the goroutine is parked
+// in the read path, but no frame has ever been parsed.
+//
+// StackProbe_Exercised is the same connection after real commands.
+//
+// Equal numbers mean setup or the idle read path sets the mark, and moving work
+// out of the loop cannot help. A lower number for UpgradedOnly means frame
+// parsing is what grows the stack.
+
+func benchWsStackProbe(b *testing.B, sendCommands bool) {
+	n, err := New(Config{
+		LogLevel: LogLevelError,
+		// A connection that never authenticates is closed as stale by default,
+		// which is exactly what the UpgradedOnly probe holds open on purpose.
+		ClientStaleCloseDelay: time.Hour,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	n.OnConnecting(func(_ context.Context, _ ConnectEvent) (ConnectReply, error) {
+		return ConnectReply{
+			Credentials:    &Credentials{UserID: "bench"},
+			WriteDelay:     time.Millisecond,
+			WriteWithTimer: true,
+		}, nil
+	})
+	n.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) { cb(SubscribeReply{}, nil) })
+		client.OnPublish(func(e PublishEvent, cb PublishCallback) { cb(PublishReply{}, nil) })
+	})
+	if err = n.Run(); err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = n.Shutdown(context.Background()) }()
+
+	mux := http.NewServeMux()
+	mux.Handle("/connection/websocket", NewWebsocketHandler(n, WebsocketConfig{
+		PingPongConfig:             PingPongConfig{PingInterval: time.Hour, PongTimeout: time.Minute},
+		ReadBufferSize:             512,
+		UseWriteBufferPool:         true,
+		ProcessCommandsOffReadLoop: true,
+	}))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	url := "ws" + server.URL[4:] + "/connection/websocket"
+
+	dial := func() *websocket.Conn {
+		d := &websocket.Dialer{}
+		conn, resp, _, dErr := d.Dial(url, nil)
+		if dErr != nil {
+			b.Fatal(dErr)
+		}
+		_ = resp.Body.Close()
+		return conn
+	}
+
+	for i := 0; i < 8; i++ {
+		warm := newRealConnJSONConnect(b, "ws"+server.URL[4:], false)
+		benchWsExerciseConn(b, warm, fmt.Sprintf("warmup%d", i), 3)
+		_ = warm.Close()
+	}
+	settle(b)
+
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+	goroutinesBefore := runtime.NumGoroutine()
+
+	b.ResetTimer()
+	conns := make([]*websocket.Conn, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		var conn *websocket.Conn
+		if sendCommands {
+			conn = newRealConnJSONConnect(b, "ws"+server.URL[4:], false)
+			benchWsExerciseConn(b, conn, fmt.Sprintf("bench%d", i), 3)
+		} else {
+			conn = dial()
+		}
+		conns = append(conns, conn)
+	}
+	b.StopTimer()
+
+	// The same guards the footprint benchmark carries. Stack per connection is a
+	// division by b.N, so a run that quietly lost connections reports a smaller
+	// stack and looks like a result. Only connections that have authenticated
+	// appear in the hub, so the upgraded-only probe is held to the goroutine
+	// count below instead.
+	if sendCommands {
+		if got := n.hub.NumClients(); got != b.N {
+			b.Fatalf("server holds %d connections, want %d: some were dropped during the run", got, b.N)
+		}
+	}
+
+	for i := 0; i < 8; i++ {
+		runtime.GC()
+	}
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	goroutineDelta := runtime.NumGoroutine() - goroutinesBefore
+
+	if perConn := float64(goroutineDelta) / float64(b.N); perConn < 0.95 || perConn > 1.05 {
+		b.Fatalf("%.3f goroutines/conn, want ~1.0: the measurement is not one read goroutine per connection", perConn)
+	}
+
+	b.ReportMetric(float64(int64(after.StackInuse)-int64(before.StackInuse))/float64(b.N), "stack-B/conn")
+	b.ReportMetric(float64(goroutineDelta)/float64(b.N), "goroutines/conn")
+
+	runtime.KeepAlive(conns)
+	for _, c := range conns {
+		_ = c.Close()
+	}
+}
+
+func BenchmarkWsStackProbe_UpgradedOnly(b *testing.B) { benchWsStackProbe(b, false) }
+func BenchmarkWsStackProbe_Exercised(b *testing.B)    { benchWsStackProbe(b, true) }
+
+// --- Footprint while connections are actually busy --------------------------
+//
+// The footprint benchmarks above measure idle connections, which is the case
+// ProcessCommandsOffReadLoop is designed for. This measures the opposite case,
+// because the option is expected to lose there and the size of the loss decides
+// whether it is safe to recommend for a busy deployment.
+//
+// Inline, a busy connection is one goroutine grown to its peak. Offloaded, it is
+// the read goroutine parked at its own size plus a processing goroutine that
+// grows from Go's 2KB minimum every single frame. While a frame is in flight
+// both are live, so peak stack can be higher than doing nothing at all.
+//
+// Stack is sampled during the load rather than after it, since the whole point
+// is what is resident while frames are in flight. ReadMemStats stops the world
+// briefly, so it is sampled at a modest interval and both variants pay it
+// equally.
+
+func benchWsUnderLoad(b *testing.B, offReadLoop bool) {
+	const numConns = 100
+	const channel = "load"
+
+	n, err := New(Config{LogLevel: LogLevelError})
+	if err != nil {
+		b.Fatal(err)
+	}
+	n.OnConnecting(func(_ context.Context, _ ConnectEvent) (ConnectReply, error) {
+		return ConnectReply{Credentials: &Credentials{UserID: "bench"}}, nil
+	})
+	n.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) { cb(SubscribeReply{}, nil) })
+		client.OnPublish(func(e PublishEvent, cb PublishCallback) { cb(PublishReply{}, nil) })
+	})
+	if err = n.Run(); err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = n.Shutdown(context.Background()) }()
+
+	mux := http.NewServeMux()
+	mux.Handle("/connection/websocket", NewWebsocketHandler(n, WebsocketConfig{
+		PingPongConfig:             PingPongConfig{PingInterval: time.Hour, PongTimeout: time.Minute},
+		ReadBufferSize:             512,
+		UseWriteBufferPool:         true,
+		ProcessCommandsOffReadLoop: offReadLoop,
+	}))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	url := "ws" + server.URL[4:]
+
+	conns := make([]*websocket.Conn, 0, numConns)
+	for i := 0; i < numConns; i++ {
+		conn := newRealConnJSONConnect(b, url, false)
+		benchWsRoundTrip(b, conn, &protocol.Command{
+			Id: 2, Subscribe: &protocol.SubscribeRequest{Channel: channel},
+		})
+		conns = append(conns, conn)
+	}
+	defer func() {
+		for _, c := range conns {
+			_ = c.Close()
+		}
+	}()
+	settle(b)
+
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	// Every connection sends continuously for the whole window, so the load is
+	// sustained rather than bursty and the samples describe a steady state.
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	payload := []byte(`{"input":"hello world, this is a benchmark payload"}`)
+	for ci, conn := range conns {
+		wg.Add(1)
+		go func(ci int, conn *websocket.Conn) {
+			defer wg.Done()
+			id := 3
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				cmd, _ := json.Marshal(&protocol.Command{
+					Id:      uint32(id),
+					Publish: &protocol.PublishRequest{Channel: channel, Data: payload},
+				})
+				if err := conn.WriteMessage(websocket.TextMessage, cmd); err != nil {
+					return
+				}
+				// A publish into a channel this connection is subscribed to
+				// produces a reply *and* a push. Reading only one of them leaves
+				// the other queued, the server's write queue grows past its limit
+				// and it disconnects the client - which looks like the benchmark
+				// measuring something rather than breaking.
+				if !readUntilReplyID(conn, uint32(id)) {
+					return
+				}
+				id++
+			}
+		}(ci, conn)
+	}
+
+	b.ResetTimer()
+
+	var peakStack, sumStack int64
+	var peakGoroutines, samples int
+	for i := 0; i < b.N; i++ {
+		var m runtime.MemStats
+		runtime.ReadMemStats(&m)
+		s := int64(m.StackInuse) - int64(before.StackInuse)
+		if s > peakStack {
+			peakStack = s
+		}
+		sumStack += s
+		if g := runtime.NumGoroutine(); g > peakGoroutines {
+			peakGoroutines = g
+		}
+		samples++
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	close(stop)
+	wg.Wait()
+	b.StopTimer()
+
+	if got := n.hub.NumClients(); got != numConns {
+		b.Fatalf("server holds %d connections, want %d: load dropped connections", got, numConns)
+	}
+
+	b.ReportMetric(float64(peakStack)/numConns, "peak-stack-B/conn")
+	b.ReportMetric(float64(sumStack)/float64(samples)/numConns, "mean-stack-B/conn")
+	b.ReportMetric(float64(peakGoroutines)/numConns, "peak-goroutines/conn")
+}
+
+func BenchmarkWsUnderLoad_Inline(b *testing.B)      { benchWsUnderLoad(b, false) }
+func BenchmarkWsUnderLoad_OffReadLoop(b *testing.B) { benchWsUnderLoad(b, true) }
+
+// readUntilReplyID drains messages until the reply with the given id arrives,
+// discarding pushes. Reports false if the connection failed.
+func readUntilReplyID(conn *websocket.Conn, want uint32) bool {
+	for {
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			return false
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			if line == "" {
+				continue
+			}
+			var reply struct {
+				ID uint32 `json:"id"`
+			}
+			if json.Unmarshal([]byte(line), &reply) == nil && reply.ID == want {
+				return true
+			}
+		}
+	}
 }

--- a/handler_websocket_test.go
+++ b/handler_websocket_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -1422,4 +1423,294 @@ func TestWebsocketHandlerCompressedHeadroom(t *testing.T) {
 	require.Error(t, err) // invalid command -> disconnect, but...
 	require.Falsef(t, websocket.IsCloseError(err, websocket.CloseMessageTooBig),
 		"frame within decompressed limit must not be rejected as too big, got %v", err)
+}
+
+// Tests for WebsocketConfig.ProcessCommandsOffReadLoop. The option moves frame
+// processing to a goroutine per frame, so the properties worth pinning are that
+// the connection still processes commands strictly in order and that the extra
+// goroutines really do go away.
+
+// newOffReadLoopServer starts a node and websocket handler. writeWithTimer
+// removes the per-connection writer goroutine, which lets a goroutine-count
+// assertion be about the read loop alone.
+func newOffReadLoopServer(t *testing.T, offReadLoop bool, writeWithTimer bool) (*Node, string) {
+	t.Helper()
+	n, err := New(Config{LogLevel: LogLevelError})
+	require.NoError(t, err)
+	n.OnConnecting(func(_ context.Context, _ ConnectEvent) (ConnectReply, error) {
+		reply := ConnectReply{Credentials: &Credentials{UserID: "test"}}
+		if writeWithTimer {
+			reply.WriteDelay = time.Millisecond
+			reply.WriteWithTimer = true
+		}
+		return reply, nil
+	})
+	n.OnConnect(func(client *Client) {
+		client.OnRPC(func(e RPCEvent, cb RPCCallback) {
+			// Echo the request back so the reply can be tied to its command.
+			cb(RPCReply{Data: e.Data}, nil)
+		})
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
+			cb(SubscribeReply{}, nil)
+		})
+	})
+	require.NoError(t, n.Run())
+
+	mux := http.NewServeMux()
+	mux.Handle("/connection/websocket", NewWebsocketHandler(n, WebsocketConfig{
+		PingPongConfig:             PingPongConfig{PingInterval: time.Hour, PongTimeout: time.Minute},
+		ProcessCommandsOffReadLoop: offReadLoop,
+	}))
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { _ = n.Shutdown(context.Background()) })
+	return n, "ws" + server.URL[4:]
+}
+
+func dialAndConnect(t *testing.T, url string) *websocket.Conn {
+	t.Helper()
+	dialer := &websocket.Dialer{}
+	conn, resp, _, err := dialer.Dial(url+"/connection/websocket", nil)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	cmd, err := json.Marshal(&protocol.Command{Id: 1, Connect: &protocol.ConnectRequest{}})
+	require.NoError(t, err)
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, cmd))
+	_, _, err = conn.ReadMessage()
+	require.NoError(t, err)
+	return conn
+}
+
+// readReplyIDs reads until it has collected want reply ids, in arrival order.
+func readReplyIDs(t *testing.T, conn *websocket.Conn, want int) []uint32 {
+	t.Helper()
+	ids := make([]uint32, 0, want)
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(20*time.Second)))
+	for len(ids) < want {
+		_, data, err := conn.ReadMessage()
+		require.NoError(t, err)
+		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			if line == "" {
+				continue
+			}
+			var reply struct {
+				ID uint32 `json:"id"`
+				// Checked, not just collected: a command that was rejected still
+				// produces a reply carrying its id, so ignoring the error field
+				// lets a test sail past a subscribe that never took effect.
+				Error json.RawMessage `json:"error"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(line), &reply))
+			require.Empty(t, reply.Error, "command %d failed", reply.ID)
+			if reply.ID != 0 {
+				ids = append(ids, reply.ID)
+			}
+		}
+	}
+	return ids
+}
+
+// TestProcessCommandsOffReadLoopPreservesOrder pipelines commands without
+// waiting for replies. Handing each frame to its own goroutine must not let
+// frames overtake one another: the read loop waits for each before reading the
+// next, and these replies must come back in the order the commands were sent.
+func TestProcessCommandsOffReadLoopPreservesOrder(t *testing.T) {
+	t.Parallel()
+	for _, offReadLoop := range []bool{false, true} {
+		offReadLoop := offReadLoop
+		name := "inline"
+		if offReadLoop {
+			name = "off_read_loop"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, url := newOffReadLoopServer(t, offReadLoop, false)
+			conn := dialAndConnect(t, url)
+			defer func() { _ = conn.Close() }()
+
+			const numCommands = 200
+			for i := 0; i < numCommands; i++ {
+				cmd, err := json.Marshal(&protocol.Command{
+					Id:  uint32(2 + i),
+					Rpc: &protocol.RPCRequest{Method: "echo", Data: []byte(`{}`)},
+				})
+				require.NoError(t, err)
+				require.NoError(t, conn.WriteMessage(websocket.TextMessage, cmd))
+			}
+
+			ids := readReplyIDs(t, conn, numCommands)
+			require.Len(t, ids, numCommands)
+			for i, id := range ids {
+				require.Equal(t, uint32(2+i), id, "reply %d out of order", i)
+			}
+		})
+	}
+}
+
+// TestProcessCommandsOffReadLoopMultipleCommandsPerFrame puts several commands
+// in one frame, which the stream decoder splits. The whole frame is handled by
+// a single handoff, so this checks the batching path is unaffected.
+func TestProcessCommandsOffReadLoopMultipleCommandsPerFrame(t *testing.T) {
+	t.Parallel()
+	_, url := newOffReadLoopServer(t, true, false)
+	conn := dialAndConnect(t, url)
+	defer func() { _ = conn.Close() }()
+
+	const perFrame = 10
+	var frame strings.Builder
+	for i := 0; i < perFrame; i++ {
+		cmd, err := json.Marshal(&protocol.Command{
+			Id:  uint32(2 + i),
+			Rpc: &protocol.RPCRequest{Method: "echo", Data: []byte(`{}`)},
+		})
+		require.NoError(t, err)
+		frame.Write(cmd)
+		frame.WriteString("\n")
+	}
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(frame.String())))
+
+	ids := readReplyIDs(t, conn, perFrame)
+	require.Len(t, ids, perFrame)
+	for i, id := range ids {
+		require.Equal(t, uint32(2+i), id)
+	}
+}
+
+// TestProcessCommandsOffReadLoopNoGoroutineLeak checks the per-frame goroutines
+// are transient and that closing the connections releases the read loops. A
+// leak here would turn the option from a stack saving into a goroutine leak.
+func TestProcessCommandsOffReadLoopNoGoroutineLeak(t *testing.T) {
+	// The timer-driven writer leaves the read loop as the only lasting
+	// per-connection goroutine, so the count below is a direct statement about
+	// the per-frame handoff goroutines being transient.
+	_, url := newOffReadLoopServer(t, true, true)
+
+	settleGoroutines := func() int {
+		last, stable := -1, 0
+		for i := 0; i < 200; i++ {
+			runtime.GC()
+			n := runtime.NumGoroutine()
+			if n == last {
+				if stable++; stable >= 3 {
+					return n
+				}
+			} else {
+				stable, last = 0, n
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		return runtime.NumGoroutine()
+	}
+
+	before := settleGoroutines()
+
+	const numConns = 20
+	conns := make([]*websocket.Conn, 0, numConns)
+	for i := 0; i < numConns; i++ {
+		conn := dialAndConnect(t, url)
+		for j := 0; j < 5; j++ {
+			cmd, err := json.Marshal(&protocol.Command{
+				Id:  uint32(2 + j),
+				Rpc: &protocol.RPCRequest{Method: "echo", Data: []byte(`{}`)},
+			})
+			require.NoError(t, err)
+			require.NoError(t, conn.WriteMessage(websocket.TextMessage, cmd))
+		}
+		readReplyIDs(t, conn, 5)
+		conns = append(conns, conn)
+	}
+
+	// While connected, each connection should hold its read loop and nothing
+	// more: the per-frame goroutines have all exited by now.
+	live := settleGoroutines()
+	require.LessOrEqual(t, live-before, numConns+5,
+		"expected about one goroutine per connection (the read loop), got %d extra for %d connections",
+		live-before, numConns)
+
+	for _, c := range conns {
+		_ = c.Close()
+	}
+	after := settleGoroutines()
+	require.LessOrEqual(t, after-before, 5, "goroutines leaked after disconnect: %d extra", after-before)
+}
+
+// TestProcessCommandsOffReadLoopInterleavedWithPushes is the messiest realistic
+// shape: a client pipelining commands while the server pushes into a channel it
+// is subscribed to. Replies and pushes are produced by different goroutines and
+// interleave in the connection's write queue, while command processing itself
+// has moved to a goroutine per frame.
+//
+// Replies must still come back in command order, every command must be
+// answered, and no push may be lost. Run with -race this also exercises the
+// handoff's synchronisation against the broadcast path.
+func TestProcessCommandsOffReadLoopInterleavedWithPushes(t *testing.T) {
+	t.Parallel()
+	n, url := newOffReadLoopServer(t, true, false)
+	conn := dialAndConnect(t, url)
+	defer func() { _ = conn.Close() }()
+
+	const channel = "interleave"
+	sub, err := json.Marshal(&protocol.Command{
+		Id: 2, Subscribe: &protocol.SubscribeRequest{Channel: channel},
+	})
+	require.NoError(t, err)
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, sub))
+	require.Equal(t, []uint32{2}, readReplyIDs(t, conn, 1))
+
+	const numCommands = 150
+	const numPushes = 150
+
+	// Push from the server while the client pipelines commands, so the two
+	// streams are produced concurrently rather than in phases.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numPushes; i++ {
+			_, pErr := n.Publish(channel, []byte(`{"push":1}`))
+			require.NoError(t, pErr)
+		}
+	}()
+
+	for i := 0; i < numCommands; i++ {
+		cmd, mErr := json.Marshal(&protocol.Command{
+			Id:  uint32(3 + i),
+			Rpc: &protocol.RPCRequest{Method: "echo", Data: []byte(`{}`)},
+		})
+		require.NoError(t, mErr)
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage, cmd))
+	}
+	wg.Wait()
+
+	// Collect until every reply and every push has arrived.
+	var replyIDs []uint32
+	pushes := 0
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(30*time.Second)))
+	for len(replyIDs) < numCommands || pushes < numPushes {
+		_, data, rErr := conn.ReadMessage()
+		require.NoError(t, rErr, "got %d/%d replies and %d/%d pushes",
+			len(replyIDs), numCommands, pushes, numPushes)
+		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			if line == "" {
+				continue
+			}
+			var msg struct {
+				ID   uint32          `json:"id"`
+				Push json.RawMessage `json:"push"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(line), &msg))
+			switch {
+			case msg.ID != 0:
+				replyIDs = append(replyIDs, msg.ID)
+			case len(msg.Push) > 0:
+				pushes++
+			}
+		}
+	}
+
+	require.Len(t, replyIDs, numCommands)
+	for i, id := range replyIDs {
+		require.Equal(t, uint32(3+i), id, "reply %d out of order", i)
+	}
+	require.Equal(t, numPushes, pushes)
 }

--- a/handler_websocket_test.go
+++ b/handler_websocket_test.go
@@ -1449,7 +1449,14 @@ func newOffReadLoopServer(t *testing.T, offReadLoop bool, writeWithTimer bool) (
 	})
 	n.OnConnect(func(client *Client) {
 		client.OnRPC(func(e RPCEvent, cb RPCCallback) {
-			// Echo the request back so the reply can be tied to its command.
+			// "disconnect" lets a test close the connection from inside command
+			// processing, which under the handoff runs on a different goroutine
+			// than the read loop. Anything else echoes, so the reply can be tied
+			// to its command.
+			if e.Method == "disconnect" {
+				client.Disconnect(DisconnectForceNoReconnect)
+				return
+			}
 			cb(RPCReply{Data: e.Data}, nil)
 		})
 		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
@@ -1715,6 +1722,91 @@ func TestProcessCommandsOffReadLoopInterleavedWithPushes(t *testing.T) {
 		require.Equal(t, uint32(3+i), id, "reply %d out of order", i)
 	}
 	require.Equal(t, numPushes, pushes)
+}
+
+// TestProcessCommandsOffReadLoopServerDisconnect covers teardown started by the
+// server rather than by the peer. The read loop is parked waiting for the
+// handoff or for the next frame, so what has to hold is that closing the
+// transport still unblocks it and drains the connection.
+func TestProcessCommandsOffReadLoopServerDisconnect(t *testing.T) {
+	t.Parallel()
+	for _, offReadLoop := range []bool{false, true} {
+		offReadLoop := offReadLoop
+		name := "inline"
+		if offReadLoop {
+			name = "off_read_loop"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			n, url := newOffReadLoopServer(t, offReadLoop, false)
+			conn := dialAndConnect(t, url)
+			defer func() { _ = conn.Close() }()
+
+			cmd, err := json.Marshal(&protocol.Command{
+				Id: 2, Rpc: &protocol.RPCRequest{Method: "echo", Data: []byte(`{}`)},
+			})
+			require.NoError(t, err)
+			require.NoError(t, conn.WriteMessage(websocket.TextMessage, cmd))
+			require.Equal(t, []uint32{2}, readReplyIDs(t, conn, 1))
+			require.Equal(t, 1, n.Hub().NumClients())
+
+			for _, c := range n.Hub().Connections() {
+				c.Disconnect(DisconnectForceNoReconnect)
+			}
+
+			require.Eventually(t, func() bool { return n.Hub().NumClients() == 0 },
+				10*time.Second, 20*time.Millisecond,
+				"server-side disconnect did not complete")
+
+			// And the peer must actually see the connection end.
+			require.NoError(t, conn.SetReadDeadline(time.Now().Add(10*time.Second)))
+			for {
+				if _, _, rErr := conn.ReadMessage(); rErr != nil {
+					break
+				}
+			}
+		})
+	}
+}
+
+// TestProcessCommandsOffReadLoopDisconnectDuringCommand closes the connection
+// from inside command processing. That is the one case the handoff genuinely
+// changes: the close runs on the handoff goroutine while the read loop sits in
+// the channel receive waiting for that same frame to finish. Teardown must still
+// complete, and must not deadlock against the close handshake the read loop is
+// the one to drain.
+func TestProcessCommandsOffReadLoopDisconnectDuringCommand(t *testing.T) {
+	t.Parallel()
+	for _, offReadLoop := range []bool{false, true} {
+		offReadLoop := offReadLoop
+		name := "inline"
+		if offReadLoop {
+			name = "off_read_loop"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			n, url := newOffReadLoopServer(t, offReadLoop, false)
+			conn := dialAndConnect(t, url)
+			defer func() { _ = conn.Close() }()
+
+			cmd, err := json.Marshal(&protocol.Command{
+				Id: 2, Rpc: &protocol.RPCRequest{Method: "disconnect", Data: []byte(`{}`)},
+			})
+			require.NoError(t, err)
+			require.NoError(t, conn.WriteMessage(websocket.TextMessage, cmd))
+
+			require.Eventually(t, func() bool { return n.Hub().NumClients() == 0 },
+				15*time.Second, 20*time.Millisecond,
+				"disconnect issued from command processing did not complete")
+
+			require.NoError(t, conn.SetReadDeadline(time.Now().Add(10*time.Second)))
+			for {
+				if _, _, rErr := conn.ReadMessage(); rErr != nil {
+					break
+				}
+			}
+		})
+	}
 }
 
 // What a connection costs while it is doing nothing is what caps connection


### PR DESCRIPTION
Adds an opt-in option that keeps a connection's read loop goroutine stack small,
cutting per-connection memory for deployments holding many mostly-idle
connections. Off by default; with it off the read path is unchanged apart from
one nil check per frame.

## Why

A goroutine's stack grows to the deepest call it ever makes and is not given
back while the goroutine lives. A websocket read loop processes commands inline,
so the whole dispatch chain — handler, broker, broadcast fan-out — runs on it.
That has to happen only **once**, even just the initial `connect`, for the read
goroutine to reach 8KB and hold it for the connection's entire life, however
idle it becomes afterwards.

A probe included here confirms where that comes from: connections that completed
the handshake and sent nothing measure the same 4KB read loop stack as
connections that ran real commands, so the growth is in setup and cannot be
reclaimed by restructuring the loop.

## What it does

When enabled, the read loop hands each frame to a goroutine that exits when the
frame is done. The deep stack returns to the runtime's stack cache and is reused
by whichever connection needs it next, instead of being pinned to one that
spends its life waiting. Ordering is unchanged — the loop waits for each frame
before reading the next.

## Measured

200,000 real websocket connections on a 16 vCPU / 30GB Linux box, idle after
connect, mean of two runs:

| | read loop stack | RSS/conn |
|---|---|---|
| off | 8.2 KB | 22.4 KB |
| on | **4.1 KB** | **18.4 KB** |

Interleaved A/B of the in-repo footprint benchmark, six rounds, separate
processes: **stack-B/conn 8.032 KiB → 3.993 KiB, −50.3% (p=0.002)**, variance
±0%, heap +1.07%, goroutine count unchanged.

The cost is latency, not throughput: about +29% on the round trip of a single
otherwise-idle connection, and **nothing measurable** once many connections are
busy at once, where per-connection memory is also 28% lower than inline.

`BenchmarkWsCommandThroughput_*` reproduces the latency figure and
`BenchmarkWsUnderLoad_*` the memory one. The CPU half of the load comparison was
measured with a `getrusage`-based metric that is not included here, so that
particular claim is not reproducible from this branch — the memory and latency
numbers are.

## Correctness

Tests cover pipelined ordering, several commands per frame, replies interleaved
with concurrent server pushes, goroutine cleanup after disconnect, a server-side
disconnect, and a disconnect issued from inside command processing. Full suite
and `-race` pass on Linux and macOS.

The synchronisation is worth a reviewer's attention and is straightforward: the
`go` statement orders `h.r = r` against the goroutine's start, and the channel
send/receive orders the parser state — including gorilla's `Conn` read state,
since the spawned goroutine performs the frame body's socket reads — between
consecutive frames.

## Scope

WebSocket only. The SSE, HTTP-stream and emulation callers of `HandleReadFrame`
run on short-lived request goroutines whose stacks are released when the request
ends, so a handoff there would be pure cost.

## Contents

Two files.

- `handler_websocket.go` — the option and `frameHandoff` (+79 lines, 29 of them
  non-comment)
- `handler_websocket_test.go` — correctness tests and benchmarks, added to the
  existing file

The correctness tests cover pipelined ordering, several commands per frame,
replies interleaved with concurrent server pushes, goroutine cleanup after
disconnect, a server-side disconnect, and a disconnect issued from inside
command processing. The last is the case the handoff genuinely changes: the
close runs on the handoff goroutine while the read loop waits for that same
frame, so it is the shape that could deadlock against the close handshake. Each
of those runs against both settings, so a divergence shows up rather than just
an absence of failure.

The benchmarks report `stack-B/conn`, `heap-B/conn` and `goroutines/conn` for
idle and busy connections, plus a probe attributing the read loop's stack to
setup rather than to frame parsing. They carry guards that each caught a wrong
answer while this was written: a connection that sends no command never grows its
stack, so both variants would report the same footprint; server pings can close
connections mid-run and report a footprint below the real one; a polluted
baseline shows up as a goroutines/conn that is not ~1.0; and a node lazily
allocates several MB on first use, which divided by b.N swamps the
per-connection heap.

