### PR TITLE
Complete subscribe rollback before waking unsubscribe waiters

### DIFF
--- a/client.go
+++ b/client.go
@@ -3947,10 +3947,11 @@ func (c *Client) removeSubscribePresence(channel string, flags uint16) {
 // ordering (inline, or deferred until after presence/join work so an unsubscribe
 // cannot remove presence before this subscribe added it).
 //
-// On a closed client it drops the reservation, closes its subscribingCh, removes
-// the hub entry registered earlier in the subscribe (ctx.subGen must match), and
-// returns (nil, false); the caller adds any path-specific cleanup (reply/buffer
-// release) and returns its own error. Lock must NOT be held.
+// On a closed client it drops the reservation, removes the hub entry registered
+// earlier in the subscribe (ctx.subGen must match), closes its subscribingCh —
+// in that order, so a woken waiter never observes a half-rolled-back attempt —
+// and returns (nil, false); the caller adds any path-specific cleanup
+// (reply/buffer release) and returns its own error. Lock must NOT be held.
 //
 // The reservation is consumed only if it still carries this attempt's generation
 // (ctx.subGen). A subscribe stalled past the unsubscribe wait timeout can lose
@@ -4021,9 +4022,6 @@ func (c *Client) commitSubscription(channel string, ctx ChannelContext, kind res
 			delete(c.channels, channel)
 		}
 		c.mu.Unlock()
-		if subscribingCh != nil {
-			close(subscribingCh)
-		}
 		// Release the recovery buffer before removing the hub entry. A positioned/
 		// recovering subscribe holds pubBufferMu (LockBufferAndReadBuffered) until
 		// StopBuffering, and removeSubscription takes subShard.mu; the broadcast
@@ -4037,6 +4035,14 @@ func (c *Client) commitSubscription(channel string, ctx ChannelContext, kind res
 			// snapshotted c.channels before this channel entered it — remove the
 			// entry here or it lingers until PresenceTTL.
 			c.removeSubscribePresence(channel, ctx.flags)
+		}
+		// Wake any waiter only after this attempt's rollback is complete (same
+		// ordering as onSubscribeErrorGen). The waiter is typically the unsubscribe
+		// loop inside close(), and close() fires OnDisconnect right after it — so
+		// closing this first would let a caller observe a "fully disconnected"
+		// client while the hub entry we are about to remove is still registered.
+		if subscribingCh != nil {
+			close(subscribingCh)
 		}
 		return nil, false
 	}


### PR DESCRIPTION
Fixes the flaky `TestClientSubscribingChannelsCleanupOnClientClose`:

```
client_test.go:4113:
    Error: "[test1]" should have 0 item(s), but has 1
--- FAIL: TestClientSubscribingChannelsCleanupOnClientClose
```

### Root cause

The closed-client rollback in `commitSubscription` ran in this order:

```
delete(c.channels, ch)  →  close(subscribingCh)  →  StopBuffering  →  removeSubscription(hub)
```

The waiter on `subscribingCh` is the unsubscribe loop inside `close()`. Once woken it finds the channel gone from `c.channels`, returns immediately, and `close()` goes straight on to fire `OnDisconnect` — while the subscribe goroutine has not yet reached `removeSubscription`. Anything synchronizing on `OnDisconnect` can then observe a hub subscription still registered for a fully disconnected client. On a loaded CI runner the subscribe goroutine gets preempted in that window often enough to flake.

`onSubscribeErrorGen` already had the correct ordering (hub removal, then `close(subscribingCh)`); the commit path was the odd one out.

### Fix

Finish the rollback — `StopBuffering` → `removeSubscription` → `removeSubscribePresence` — and close `subscribingCh` last, so a woken waiter never observes a half-rolled-back attempt. None of those calls take `connectMu` or `presenceMu` (both held by the waiting `close()`), so waking later introduces no lock-order risk, and the waiter's 5s gate is untouched.

### Verification

- Inserting a 50ms sleep between `close(subscribingCh)` and `removeSubscription` reproduced the CI failure verbatim (3/20 runs).
- With the fix: 200x `-race` on the cleanup / buffered-publication tests pass; full package `-race` suite passes.