### PR TITLE
Strengthen redis_cluster_slot hash-tag edge case tests

### DIFF
--- a/redis_cluster_slot_test.go
+++ b/redis_cluster_slot_test.go
@@ -37,25 +37,36 @@ func TestRedisSlot_KnownValues(t *testing.T) {
 
 func TestRedisSlot_HashTagEdgeCases(t *testing.T) {
 	t.Parallel()
-	// Empty hash tag {}: no valid tag, hash full key.
-	slotFull := redisSlot("abc{}")
-	slotABC := redisSlot("abc{}")
-	if slotFull != slotABC {
-		t.Errorf("empty hash tag should hash full key")
+	// Expected values match Redis CLUSTER KEYSLOT. Redis looks for the first
+	// "{", then for the first "}" after it: if either is missing, or the tag
+	// between them is empty, the whole key is hashed.
+	tests := []struct {
+		name string
+		key  string
+		slot uint16
+	}{
+		{"empty hash tag hashes full key", "abc{}", 16021},
+		{"no closing brace hashes full key", "{abc", 444},
+		{"closing brace before opening one hashes full key", "a}{b", 11640},
+		{"first hash tag wins", "{a}x{b}", 15495},
+		{"tag is found after a leading closing brace", "}{a}", 15495},
+		{"empty first tag hashes full key even if a later tag is valid", "{}{a}", 13650},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redisSlot(tt.key); got != tt.slot {
+				t.Errorf("redisSlot(%q) = %d, want %d", tt.key, got, tt.slot)
+			}
+		})
 	}
 
-	// Only first valid {} is used.
-	slot1 := redisSlot("{a}x{b}")
-	slot2 := redisSlot("{a}")
-	if slot1 != slot2 {
-		t.Errorf("should use first hash tag: got %d and %d", slot1, slot2)
-	}
-
-	// No closing brace: hash full key.
-	slotNoBrace := redisSlot("{abc")
-	slotPlain := redisSlot("{abc")
-	if slotNoBrace != slotPlain {
-		t.Errorf("no closing brace should hash full key")
+	// Guard against the whole key accidentally being reduced to the brace-less
+	// remainder: hashing "abc{}" or "{abc" must not give the same slot as "abc".
+	plain := redisSlot("abc")
+	for _, key := range []string{"abc{}", "{abc"} {
+		if got := redisSlot(key); got == plain {
+			t.Errorf("redisSlot(%q) = %d, must differ from redisSlot(\"abc\")", key, got)
+		}
 	}
 }
 


### PR DESCRIPTION
The prior TestRedisSlot_HashTagEdgeCases only compared redisSlot() against itself (e.g. redisSlot("abc{}") == redisSlot("abc{}")), so it could not fail regardless of the implementation. Replace it with a table of absolute expected slots, independently derived and cross-checked against CLUSTER KEYSLOT on a real Redis cluster, plus three edge cases the file did not cover: a closing brace preceding the opening one, a tag found after a leading closing brace, and an empty first tag with a valid tag later in the key.