### PR TITLE
Treat a negative EmulationConfig.MaxRequestBodySize as unset

### DIFF
--- a/emulation.go
+++ b/emulation.go
@@ -52,7 +52,7 @@ func (s *EmulationHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	maxBytesSize := s.config.MaxRequestBodySize
-	if maxBytesSize == 0 {
+	if maxBytesSize <= 0 {
 		maxBytesSize = 64 * 1024
 	}
 	r.Body = http.MaxBytesReader(rw, r.Body, int64(maxBytesSize))

--- a/emulation_test.go
+++ b/emulation_test.go
@@ -97,6 +97,47 @@ func TestEmulationHandler_RequestTooLarge(t *testing.T) {
 	_ = resp.Body.Close()
 }
 
+func TestEmulationHandler_NegativeMaxRequestBodySizeUsesDefault(t *testing.T) {
+	t.Parallel()
+	n, _ := New(Config{})
+	require.NoError(t, n.Run())
+	defer func() { _ = n.Shutdown(context.Background()) }()
+	mux := http.NewServeMux()
+	mux.Handle("/emulation", NewEmulationHandler(n, EmulationConfig{
+		MaxRequestBodySize: -1,
+	}))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	url := server.URL + "/emulation"
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	command := &protocol.Command{
+		Id:      1,
+		Connect: &protocol.ConnectRequest{},
+	}
+	jsonData, err := json.Marshal(command)
+	require.NoError(t, err)
+
+	emuRequest := &protocol.EmulationRequest{
+		Node:    "unknown",
+		Session: "unknown",
+		Data:    jsonData,
+	}
+	jsonEmuRequest, err := json.Marshal(emuRequest)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(jsonEmuRequest))
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	// A negative config value must fall back to the default limit, not be
+	// coerced to zero (which would reject every non-empty request).
+	require.NotEqual(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+}
+
 func TestEmulationHandler_NodeNotFound(t *testing.T) {
 	t.Parallel()
 	n, _ := New(Config{})


### PR DESCRIPTION
## Summary

`EmulationHandler.ServeHTTP` only fell back to the 64KB default `MaxRequestBodySize` when the configured value was exactly `0`:

```go
maxBytesSize := s.config.MaxRequestBodySize
if maxBytesSize == 0 {
    maxBytesSize = 64 * 1024
}
r.Body = http.MaxBytesReader(rw, r.Body, int64(maxBytesSize))
```

A negative value (e.g. from a miscomputed config) is not caught by that check, and is passed straight to `http.MaxBytesReader`, whose stdlib implementation clamps any negative limit to `0`. The effective limit becomes zero bytes, so every non-empty emulation request is rejected with `413 Request Entity Too Large`, rather than falling back to a sane default.

The sibling `MaxRequestBodySize` handling in `handler_sse.go` and `handler_http_stream.go` already guards with `<= 0` (added in #612, which hardened the stream command decoder against bad size limits), so this brings `emulation.go` in line with the same pattern.

## Test plan

Added `TestEmulationHandler_NegativeMaxRequestBodySizeUsesDefault` in `emulation_test.go`: it configures `EmulationConfig{MaxRequestBodySize: -1}`, posts a small valid emulation request, and asserts the response is not `413`.

- Confirmed it fails against the old code (every request gets `413` regardless of size).
- Confirmed it passes with the `<= 0` fix.
- Kept the test permanently: it exercises a real edge case in the exported `EmulationConfig` type, isn't covered by the existing `TestEmulationHandler_RequestTooLarge` test (which uses a small positive limit to verify legitimate rejection), and doesn't reach into internals.

Ran:
- `go build ./...`
- `go vet ./...`
- `golangci-lint run ./...` (0 issues)
- `go test ./ -run TestEmulationHandler -race -v` (all pass)