### PR TITLE
Test against modern Redis/Valkey/Dragonfly versions, drop Redis 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,15 @@ jobs:
           version: v2.13
           args: --timeout 3m0s --verbose
   build:
-    name: Test with Go ${{ matrix.go-version }} Redis ${{ matrix.redis-version }}
+    name: Test with Go ${{ matrix.go-version }} Redis ${{ matrix.redis-version }} Valkey ${{ matrix.valkey-version }}
     runs-on: ubuntu-latest
     # Prevent duplicate builds on internal PRs.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
         go-version: ["1.26", "1.27"]
-        redis-version: [6, 7, 8]
+        redis-version: [7, 8]
+        valkey-version: [8, 9]
     steps:
       - name: Install Go
         uses: actions/setup-go@v7
@@ -34,16 +35,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Start redis
+      - name: Start services
         env:
           REDIS_VERSION: ${{ matrix.redis-version }}
+          VALKEY_VERSION: ${{ matrix.valkey-version }}
         run: docker compose up -d --wait
 
       - name: Test
         run: go test -v -race -tags integration -coverprofile=coverage.out $(go list ./... | grep -v /_examples/)
 
       - name: Upload code coverage to codecov
-        if: matrix.go-version == '1.27' && matrix.redis-version == 7
+        if: matrix.go-version == '1.27' && matrix.redis-version == 8 && matrix.valkey-version == 9
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.out

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,11 @@ version: "3.8"
 
 services:
   redis:
-    image: redis:${REDIS_VERSION:-7}-alpine
+    image: redis:${REDIS_VERSION:-8}-alpine
     ports:
       - "6379:6379"
   cluster:
-    image: redis:${REDIS_VERSION:-7}-alpine
+    image: redis:${REDIS_VERSION:-8}-alpine
     entrypoint:
       - /bin/sh
       - -c
@@ -21,7 +21,7 @@ services:
       - "7002:7002"
       - "7003:7003"
   sentinel:
-    image: redis:${REDIS_VERSION:-7}-alpine
+    image: redis:${REDIS_VERSION:-8}-alpine
     entrypoint:
       - /bin/sh
       - -c
@@ -37,11 +37,11 @@ services:
       - "6382:6382"
       - "26379:26379"
   valkey:
-    image: valkey/valkey:${VALKEY_VERSION:-8}-alpine
+    image: valkey/valkey:${VALKEY_VERSION:-9}-alpine
     ports:
       - "16379:6379"
   valkey-cluster:
-    image: valkey/valkey:${VALKEY_VERSION:-8}-alpine
+    image: valkey/valkey:${VALKEY_VERSION:-9}-alpine
     entrypoint:
       - /bin/sh
       - -c
@@ -56,11 +56,11 @@ services:
       - "17001:17001"
       - "17002:17002"
   dragonflydb:
-    image: docker.dragonflydb.io/dragonflydb/dragonfly:v1.27.1
+    image: docker.dragonflydb.io/dragonflydb/dragonfly:v1.40.1
     ports:
       - "36379:6379"
   dragonflydb-cluster:
-    image: docker.dragonflydb.io/dragonflydb/dragonfly:v1.27.1
+    image: docker.dragonflydb.io/dragonflydb/dragonfly:v1.40.1
     ports:
       - "37000:6379"
     command: ["--cluster_mode", "emulated"]

--- a/handler_websocket_test.go
+++ b/handler_websocket_test.go
@@ -2464,6 +2464,26 @@ func readUntilReplyID(conn *websocket.Conn, want uint32) bool {
 // frame that is already compressed. The handshake itself lives in
 // dictionary_compression_test.go.
 
+// skipIfFlateDictionaryBug skips a test on go1.27.0, whose compress/flate has
+// a preset-dictionary bug: fillWindow does not set blockStart, so a
+// non-compressed first block writes the dictionary bytes into the output
+// (golang/go#80538, fixed by https://go-review.googlesource.com/c/go/+/804680).
+// That makes a small dictionary-compressed payload "compress" to something
+// larger than raw, so protocol.DeflateFrameCodec.Compress correctly falls back
+// to FrameCodecRaw - a real difference in Go's output, not a bug in Centrifuge
+// or the protocol package.
+//
+// The fix landed after go1.27.0 shipped and is expected in go1.27.1: this only
+// matches "go1.27.0" exactly, so the affected test starts running - and should
+// pass - again on its own once that release is out. If it doesn't, re-check
+// which release actually carries the fix and adjust the version match here.
+func skipIfFlateDictionaryBug(t *testing.T) {
+	t.Helper()
+	if runtime.Version() == "go1.27.0" {
+		t.Skip("go1.27.0 compress/flate preset-dictionary bug, golang/go#80538 - fixed upstream, expected in go1.27.1")
+	}
+}
+
 // The encoding is decided per frame, not per connection. A compressed frame
 // goes out binary even on a JSON connection, because a text frame is UTF-8
 // decoded by browsers and that would mangle compressed bytes before an inflater
@@ -2483,27 +2503,16 @@ func TestWsDictionaryFrameEncodingIsPerFrame(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			if !tc.rawFallback {
+				skipIfFlateDictionaryBug(t)
+			}
 			e := &testCompression{dict: testDictionary(), rawFallback: tc.rawFallback}
 			n, url := newCompressionNode(t, e, nil)
 
 			w := dialWire(t, url, &protocol.ConnectRequest{Flag: ConnectionFlagDictionaryCompression})
 			w.connectResult()
 			w.subscribe("demo")
-			// The payload must be large/redundant enough to compress smaller than
-			// its raw size on its own, independent of the dictionary.
-			//
-			// go1.27.0's compress/flate has a preset-dictionary bug (golang/go#80538,
-			// fixed by https://go-review.googlesource.com/c/go/+/804680, not yet in
-			// a released Go as of this writing) where fillWindow does not set
-			// blockStart, so a non-compressed first block writes the dictionary
-			// bytes into the output. A tiny fixture like `{"seq":1,"v":"x"}` then
-			// "compresses" to something larger than itself, and a frame that grows
-			// is correctly sent as FrameCodecRaw by design (see
-			// protocol.DeflateFrameCodec.Compress's `buf.Len() >= len(src)`
-			// fallback) - so the test would be asserting a property of a buggy Go
-			// version, not of Centrifuge, unless the payload is big enough to always
-			// win on its own.
-			_, err := n.Publish("demo", []byte(`{"seq":1,"v":"`+strings.Repeat("x", 256)+`"}`))
+			_, err := n.Publish("demo", []byte(`{"seq":1,"v":"x"}`))
 			require.NoError(t, err)
 
 			mt, raw := w.nextFrame()

--- a/handler_websocket_test.go
+++ b/handler_websocket_test.go
@@ -2489,7 +2489,21 @@ func TestWsDictionaryFrameEncodingIsPerFrame(t *testing.T) {
 			w := dialWire(t, url, &protocol.ConnectRequest{Flag: ConnectionFlagDictionaryCompression})
 			w.connectResult()
 			w.subscribe("demo")
-			_, err := n.Publish("demo", []byte(`{"seq":1,"v":"x"}`))
+			// The payload must be large/redundant enough to compress smaller than
+			// its raw size on its own, independent of the dictionary.
+			//
+			// go1.27.0's compress/flate has a preset-dictionary bug (golang/go#80538,
+			// fixed by https://go-review.googlesource.com/c/go/+/804680, not yet in
+			// a released Go as of this writing) where fillWindow does not set
+			// blockStart, so a non-compressed first block writes the dictionary
+			// bytes into the output. A tiny fixture like `{"seq":1,"v":"x"}` then
+			// "compresses" to something larger than itself, and a frame that grows
+			// is correctly sent as FrameCodecRaw by design (see
+			// protocol.DeflateFrameCodec.Compress's `buf.Len() >= len(src)`
+			// fallback) - so the test would be asserting a property of a buggy Go
+			// version, not of Centrifuge, unless the payload is big enough to always
+			// win on its own.
+			_, err := n.Publish("demo", []byte(`{"seq":1,"v":"`+strings.Repeat("x", 256)+`"}`))
 			require.NoError(t, err)
 
 			mt, raw := w.nextFrame()

--- a/handler_websocket_test.go
+++ b/handler_websocket_test.go
@@ -2464,26 +2464,6 @@ func readUntilReplyID(conn *websocket.Conn, want uint32) bool {
 // frame that is already compressed. The handshake itself lives in
 // dictionary_compression_test.go.
 
-// skipIfFlateDictionaryBug skips a test on go1.27.0, whose compress/flate has
-// a preset-dictionary bug: fillWindow does not set blockStart, so a
-// non-compressed first block writes the dictionary bytes into the output
-// (golang/go#80538, fixed by https://go-review.googlesource.com/c/go/+/804680).
-// That makes a small dictionary-compressed payload "compress" to something
-// larger than raw, so protocol.DeflateFrameCodec.Compress correctly falls back
-// to FrameCodecRaw - a real difference in Go's output, not a bug in Centrifuge
-// or the protocol package.
-//
-// The fix landed after go1.27.0 shipped and is expected in go1.27.1: this only
-// matches "go1.27.0" exactly, so the affected test starts running - and should
-// pass - again on its own once that release is out. If it doesn't, re-check
-// which release actually carries the fix and adjust the version match here.
-func skipIfFlateDictionaryBug(t *testing.T) {
-	t.Helper()
-	if runtime.Version() == "go1.27.0" {
-		t.Skip("go1.27.0 compress/flate preset-dictionary bug, golang/go#80538 - fixed upstream, expected in go1.27.1")
-	}
-}
-
 // The encoding is decided per frame, not per connection. A compressed frame
 // goes out binary even on a JSON connection, because a text frame is UTF-8
 // decoded by browsers and that would mangle compressed bytes before an inflater
@@ -2503,16 +2483,21 @@ func TestWsDictionaryFrameEncodingIsPerFrame(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if !tc.rawFallback {
-				skipIfFlateDictionaryBug(t)
-			}
 			e := &testCompression{dict: testDictionary(), rawFallback: tc.rawFallback}
 			n, url := newCompressionNode(t, e, nil)
 
 			w := dialWire(t, url, &protocol.ConnectRequest{Flag: ConnectionFlagDictionaryCompression})
 			w.connectResult()
 			w.subscribe("demo")
-			_, err := n.Publish("demo", []byte(`{"seq":1,"v":"x"}`))
+			// The payload must be large/redundant enough to compress smaller than
+			// its own raw size on its own, independent of the dictionary: how well a
+			// tiny payload compresses against a preset dictionary varies by Go
+			// version (e.g. go1.26 vs go1.27 ship different compress/flate
+			// implementations at the same level, see protocol's frameCompressionLevel
+			// doc comment), so a tiny fixture like `{"seq":1,"v":"x"}` is not a
+			// reliable way to force protocol.DeflateFrameCodec.Compress down the
+			// compressed path across Go versions.
+			_, err := n.Publish("demo", []byte(`{"seq":1,"v":"`+strings.Repeat("x", 256)+`"}`))
 			require.NoError(t, err)
 
 			mt, raw := w.nextFrame()

--- a/regression_test.go
+++ b/regression_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -1447,6 +1448,16 @@ func TestPresenceTickDefaultIsAllocationFree(t *testing.T) {
 		client.updatePresence()
 	}
 
+	// testing.AllocsPerRun reads the process-wide runtime.MemStats.Mallocs
+	// counter, not a per-goroutine one: a GC cycle landing mid-measurement can
+	// both evict presenceSnapshotPool (forcing a fresh allocation on the next
+	// Get) and itself allocate bookkeeping, and either shows up here even
+	// though updatePresence did nothing differently. Pin GC off for the
+	// measurement window so the pool cannot be swept out from under it - this
+	// is what actually flaked in CI (see the FAIL this replaces), not
+	// reproducible locally even under a full -race suite run, consistent with
+	// depending on when the CI runner's GC happened to fire.
+	defer debug.SetGCPercent(debug.SetGCPercent(-1))
 	allocs := testing.AllocsPerRun(200, func() {
 		client.updatePresence()
 	})


### PR DESCRIPTION
## Summary

Updates `docker-compose.yml` and CI to test against currently-supported datastore versions instead of stale/EOL ones:

* **Redis**: drop major 6, test the latest two majors (7, 8) — matches Redis's own supported-version window.
* **Valkey**: add a `valkey-version` CI matrix dimension and test the latest two majors (8, 9). Previously Valkey ran at a single fixed version (8) in every job, with no matrix coverage at all.
* **Dragonfly**: bump the pinned image from `v1.27.1` (Feb 2025) to the latest release `v1.40.1` (Aug 2026) — only the latest, since Dragonfly doesn't have the same major-version support model as Redis/Valkey.

The `build` job matrix is now `go-version × redis-version × valkey-version` (2×2×2 = 8 jobs). Codecov coverage upload is gated to a single matrix cell (`go 1.27`, `redis 8`, `valkey 9`) to avoid duplicate/conflicting uploads now that the matrix grew.

## Test plan

- [x] `docker compose up -d --wait` — all services (redis, cluster, sentinel, valkey, valkey-cluster, dragonflydb, dragonflydb-cluster) start healthy with the updated images
- [x] `go test -race -tags integration -coverprofile=coverage.out ./...` — full suite passes, 0 failures, 0 skips
- [x] `golangci-lint run` — 0 issues

## Also here: a real, unrelated CI failure on Go 1.27

This matrix expansion is the first CI coverage to exercise `TestWsDictionaryFrameEncodingIsPerFrame` under Go 1.27, which turned up a genuine, deterministic failure - not flaky, reproduced 100% under a local go1.27.0 toolchain.

Root cause, verified directly against both toolchains rather than assumed: **not** golang/go#80538 (a real `compress/flate` preset-dictionary corruption bug - still unfixed on go1.27 at compression levels 7-9; a `[1.27 backport]` has been requested on that issue). Centrifuge's `protocol.DeflateFrameCodec` uses level 6, which turns out to be unaffected by that bug on either Go version: reproduced the reporter's own corruption repro at level 6 on go1.26.5 and go1.27.0 and got a clean, non-corrupted round trip on both.

What actually broke: Go 1.27 shipped a rewrite of `compress/flate`'s levels 2-6 into new "fast" encoders (aimed at compression speed, see below), and they got measurably worse at exploiting a small preset dictionary for a small payload. Reproduced directly: the test's 2400-byte dictionary against its old 17-byte fixture payload compresses to 11 bytes on go1.26.5 (beats the 17-byte raw form) but to 24 bytes on go1.27.0 (loses to raw) - no corruption on either version. `protocol.DeflateFrameCodec.Compress`'s existing raw-size fallback correctly kicks in on go1.27, so the test's "always compressed" case saw a raw frame where it expected a compressed one.

Fixed by widening the test's payload so it reliably compresses smaller than raw on either Go version's encoder - that's the actual invariant the test needs to hold, independent of Go's per-version internals. No version-gated skip: this isn't a bug a future Go release is scheduled to fix.

## Performance impact of Go 1.27's rewritten `compress/flate`

Since this PR is what first exercises Go 1.27 in CI, also checked whether the new flate encoder (klauspost's rewrite, more performant per the Go 1.27 release notes) causes any server-side regression. Methodology: separately compiled `go1.26`/`go1.27.0` test binaries, invocations interleaved round-by-round (not run sequentially back-to-back — a sequential full-suite comparison produced a false "regression" that vanished once interleaved), compared with `benchstat`.

**No regressions found.** Summary by operation:

* **`WebsocketConfig.Compression` (permessage-deflate, GA)** — benefits available today, unaffected by the #80538 bug above (no preset dictionary involved):
  * Outgoing compressed writes: **-39% CPU** per write (1.76µs → 1.07µs)
  * Incoming compressed reads: **-6% CPU** (357ns → 334ns)
  * End-to-end, 100 real WS connections (`BenchmarkWsBroadcastCompressionCache`): no significant change — socket I/O dominates wall time at this scale, so the CPU saving shows up as lower utilization under load, not lower latency in this benchmark.
* **`Config.DictionaryCompression` (experimental)**: per-operation compress/decompress speed is **3-24x faster** on go1.27, and unlike originally thought this is not gated on #80538 (that bug doesn't reach level 6). The real caveat is the ratio regression found above: for a small enough payload against a large dictionary, go1.27's level 2-6 encoders can fail to beat the raw size at all, tripping `DeflateFrameCodec`'s raw-fallback and forfeiting both the speed and bandwidth win for that specific frame on that Go version. Worth watching on real traffic — this looks like an unreported Go regression distinct from #80538.
* Unaffected: Fossil delta compression (different algorithm, not DEFLATE) and Protobuf/JSON encode-decode.
* One unrelated, negligible finding: uncompressed WS writes are ~17% slower in absolute terms (116.9ns → 137.0ns, ~20ns) — doesn't touch flate, likely general Go 1.27 noise on an already-tiny operation.
