### PR TITLE
Adopt protocol v0.22.1: explicit dictionary compression level

### DIFF
--- a/_examples/dictionary_compression/main.go
+++ b/_examples/dictionary_compression/main.go
@@ -31,6 +31,14 @@ import (
 	"github.com/centrifugal/protocol"
 )
 
+// dictionaryCompressionLevel is a DEFLATE level for protocol.NewDeflateFrameCodec
+// and protocol.DeflateDictionary. protocol picks no default for this: the right
+// level depends on the traffic and dictionary shapes a real deployment sees -
+// see protocol.NewDeflateFrameCodec's doc comment for the measurements behind
+// this particular choice, and re-derive it for your own workload rather than
+// copying this number.
+const dictionaryCompressionLevel = 7
+
 // --- the engine -------------------------------------------------------------
 
 // engine is a centrifuge.DictionaryCompression serving one dictionary to
@@ -51,8 +59,8 @@ func newEngine(dict []byte) *engine {
 	return &engine{
 		id:    id,
 		raw:   dict,
-		wire:  base64.StdEncoding.EncodeToString(protocol.DeflateDictionary(dict)),
-		codec: protocol.NewDeflateFrameCodec(id, dict),
+		wire:  base64.StdEncoding.EncodeToString(protocol.DeflateDictionary(dict, dictionaryCompressionLevel)),
+		codec: protocol.NewDeflateFrameCodec(id, dict, dictionaryCompressionLevel),
 		cache: map[string][]byte{},
 	}
 }

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -7,7 +7,7 @@ replace github.com/centrifugal/centrifuge => ../
 require (
 	github.com/centrifugal/centrifuge v0.38.0
 	github.com/centrifugal/centrifuge-go v0.12.1
-	github.com/centrifugal/protocol v0.22.0
+	github.com/centrifugal/protocol v0.22.1
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/cristalhq/jwt/v5 v5.4.0

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -20,8 +20,8 @@ github.com/bytedance/sonic v1.15.3 h1:P3akjLPBtV/i6bHC6LbcLjY3KuoOvfiqF8wFHeP5Ih
 github.com/bytedance/sonic v1.15.3/go.mod h1:8e51yTPdY8M6t+vvGL1c2Y1xL9i+frEeIAQAEl75NUc=
 github.com/bytedance/sonic/loader v0.5.2 h1:0QtP1gevc1OZ6/H8Lb9BRZiCXd1Ftjd3OKuj1T1lBIo=
 github.com/bytedance/sonic/loader v0.5.2/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
-github.com/centrifugal/protocol v0.22.0 h1:mOiSwhH0h2STMxZsRyfmOSpk6WFUuWbG3h75Jft/LFw=
-github.com/centrifugal/protocol v0.22.0/go.mod h1:gL7ftIACFuHhymAeIK9Vf+ombUpscN7J/dKfdNjhNiw=
+github.com/centrifugal/protocol v0.22.1 h1:m5Nuf396H3h3CbE3CkNTohbrhn55PFwKIZ/fH+LvgsI=
+github.com/centrifugal/protocol v0.22.1/go.mod h1:gL7ftIACFuHhymAeIK9Vf+ombUpscN7J/dKfdNjhNiw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=

--- a/dictionary_compression_test.go
+++ b/dictionary_compression_test.go
@@ -27,6 +27,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testDictionaryCompressionLevel is an arbitrary valid protocol.DeflateFrameCodec
+// level for tests that exercise something other than level choice itself - see
+// protocol.NewDeflateFrameCodec's doc comment for how a real caller should pick
+// one; this package implements no engine of its own, so it has no basis for
+// recommending a value beyond "one that works" for its own tests.
+const testDictionaryCompressionLevel = 7
+
 // testCompression is an engine supplied from outside the package, which is the
 // only way engines exist. It hands every supporting connection one fixed
 // dictionary, and records what it was told about the connection.
@@ -59,7 +66,7 @@ func (e *testCompression) NewDictionaryConnection(params DictionaryConnectionPar
 		dict = e.dictFor(params)
 	}
 	e.last = &testConnCompression{
-		codec:       protocol.NewDeflateFrameCodec(testDictionaryID(dict), dict),
+		codec:       protocol.NewDeflateFrameCodec(testDictionaryID(dict), dict, testDictionaryCompressionLevel),
 		proto:       params.ProtocolType.toProto(),
 		held:        params.HeldDictionaryID,
 		rawFallback: e.rawFallback,
@@ -90,7 +97,7 @@ func (c *testConnCompression) Dictionary() *protocol.Dictionary {
 		// The client already holds these bytes, so naming it is enough.
 		return d
 	}
-	packed := protocol.DeflateDictionary(c.codec.Dict())
+	packed := protocol.DeflateDictionary(c.codec.Dict(), testDictionaryCompressionLevel)
 	if c.proto == protocol.TypeJSON {
 		d.DataB64 = base64.StdEncoding.EncodeToString(packed)
 	} else {
@@ -174,7 +181,7 @@ func (w *wireClient) connectResult() *protocol.ConnectResult {
 	require.NoError(w.t, err)
 	if len(msg) > 0 && msg[0] == protocol.FrameCodecCompressed {
 		require.NotNil(w.t, w.held, "a compressed connect reply means the server took the id this client advertised")
-		codec := protocol.NewDeflateFrameCodec(testDictionaryID(w.held), w.held)
+		codec := protocol.NewDeflateFrameCodec(testDictionaryID(w.held), w.held, testDictionaryCompressionLevel)
 		msg, err = codec.Decompress(nil, msg, 1<<20)
 		require.NoError(w.t, err)
 		w.codec = codec
@@ -185,7 +192,7 @@ func (w *wireClient) connectResult() *protocol.ConnectResult {
 	if d := r.Connect.Dict; d != nil && d.DataB64 != "" {
 		raw, derr := protocol.InflateDictionary(mustBase64(w.t, d.DataB64), 1<<20)
 		require.NoError(w.t, derr)
-		w.codec = protocol.NewDeflateFrameCodec(d.Id, raw)
+		w.codec = protocol.NewDeflateFrameCodec(d.Id, raw, testDictionaryCompressionLevel)
 	}
 	return r.Connect
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	cel.dev/cel-go v0.32.0
 	github.com/FZambia/eagle v0.2.0
-	github.com/centrifugal/protocol v0.22.0
+	github.com/centrifugal/protocol v0.22.1
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/google/uuid v1.6.0
 	github.com/maypok86/otter/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYW
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/centrifugal/protocol v0.22.0 h1:mOiSwhH0h2STMxZsRyfmOSpk6WFUuWbG3h75Jft/LFw=
-github.com/centrifugal/protocol v0.22.0/go.mod h1:gL7ftIACFuHhymAeIK9Vf+ombUpscN7J/dKfdNjhNiw=
+github.com/centrifugal/protocol v0.22.1 h1:m5Nuf396H3h3CbE3CkNTohbrhn55PFwKIZ/fH+LvgsI=
+github.com/centrifugal/protocol v0.22.1/go.mod h1:gL7ftIACFuHhymAeIK9Vf+ombUpscN7J/dKfdNjhNiw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/handler_websocket_test.go
+++ b/handler_websocket_test.go
@@ -2624,7 +2624,7 @@ func TestWsCloseDictionaryCompressionIsIdempotent(t *testing.T) {
 	t.Parallel()
 	newCodec := func() *testConnCompression {
 		d := testDictionary()
-		return &testConnCompression{codec: protocol.NewDeflateFrameCodec(testDictionaryID(d), d)}
+		return &testConnCompression{codec: protocol.NewDeflateFrameCodec(testDictionaryID(d), d, testDictionaryCompressionLevel)}
 	}
 
 	t.Run("still pending", func(t *testing.T) {


### PR DESCRIPTION
Bumps to protocol v0.22.1, which now requires the DEFLATE compression level to be passed explicitly to `NewDeflateFrameCodec`/`DeflateDictionary` instead of assuming one internally (see centrifugal/protocol#49). Updated this repo's test and example call sites accordingly.