### PR TITLE
Fix stale comment in Hub.NumSubscriptions, dedupe keyedHub set-building

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -310,7 +310,7 @@ func (h *Hub) NumUsers() int {
 func (h *Hub) NumSubscriptions() int {
 	var total int
 	for i := 0; i < numHubShards; i++ {
-		// users do not overlap among shards.
+		// channels do not overlap among shards.
 		total += h.subShards[i].NumSubscriptions()
 	}
 	return total

--- a/keyed_hub.go
+++ b/keyed_hub.go
@@ -155,6 +155,18 @@ func (h *keyedHub) broadcastRemoval(channel string, key string) {
 	}
 }
 
+// stringSet builds a lookup set from items, or returns nil if items is empty.
+func stringSet(items []string) map[string]struct{} {
+	if len(items) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		set[item] = struct{}{}
+	}
+	return set
+}
+
 // broadcastRemovalToUsers sends removal publications only to connections
 // belonging to the specified users (or excluding specified users).
 func (h *keyedHub) broadcastRemovalToUsers(channel string, key string, users []string, excludeUsers []string) {
@@ -163,21 +175,8 @@ func (h *keyedHub) broadcastRemovalToUsers(channel string, key string, users []s
 		return
 	}
 
-	var userSet map[string]struct{}
-	var excludeSet map[string]struct{}
-
-	if len(users) > 0 {
-		userSet = make(map[string]struct{}, len(users))
-		for _, u := range users {
-			userSet[u] = struct{}{}
-		}
-	}
-	if len(excludeUsers) > 0 {
-		excludeSet = make(map[string]struct{}, len(excludeUsers))
-		for _, u := range excludeUsers {
-			excludeSet[u] = struct{}{}
-		}
-	}
+	userSet := stringSet(users)
+	excludeSet := stringSet(excludeUsers)
 
 	pub := &protocol.Publication{Key: key, Removed: true}
 	for _, c := range targets {
@@ -198,21 +197,8 @@ func (h *keyedHub) broadcastRemovalToUsers(channel string, key string, users []s
 
 // removeSubscribersForUsers removes subscribers matching user/exclude filters.
 func (h *keyedHub) removeSubscribersForUsers(key string, users []string, excludeUsers []string) {
-	var userSet map[string]struct{}
-	var excludeSet map[string]struct{}
-
-	if len(users) > 0 {
-		userSet = make(map[string]struct{}, len(users))
-		for _, u := range users {
-			userSet[u] = struct{}{}
-		}
-	}
-	if len(excludeUsers) > 0 {
-		excludeSet = make(map[string]struct{}, len(excludeUsers))
-		for _, u := range excludeUsers {
-			excludeSet[u] = struct{}{}
-		}
-	}
+	userSet := stringSet(users)
+	excludeSet := stringSet(excludeUsers)
 
 	h.mu.Lock()
 	subs, ok := h.items[key]


### PR DESCRIPTION
## What changed

- `hub.go`: `Hub.NumSubscriptions()` had a comment copy-pasted from the neighboring `NumUsers()` — "users do not overlap among shards" — even though subscriptions are sharded by channel, not user (see `NumChannels()` right below it, which correctly says "channels do not overlap among shards"). Fixed the wording to match.
- `keyed_hub.go`: `broadcastRemovalToUsers` and `removeSubscribersForUsers` each built an identical `userSet`/`excludeSet` pair from `[]string` inline (same ~12 lines duplicated twice). Factored into a small unexported `stringSet` helper used by both call sites.

## Why

Found while surveying the codebase for small, safe cleanups. Both are local clarity fixes with no behavior change: the comment was actively misleading about shard invariants, and the duplicated set-building logic was an easy target for the two copies drifting apart.

## Verification

- `go build ./...` and `go vet ./...` — clean.
- `go test . -run 'TestKeyedHub_|TestHub'` — all pass (these directly cover the touched functions).
- Full `go test ./...` (all packages, no Redis/integration tests since those are gated behind the `integration` build tag and weren't touched) — all pass.

No new test was added since this is a pure refactor/comment fix with no behavior change — existing `TestKeyedHub_BroadcastRemovalToUsers` and `TestKeyedHub_RemoveSubscribersForUsers_Exclude` already exercise the `stringSet` logic through both call sites.