### PR TITLE
stress_runtime: cover map subscriptions and shared poll

### DIFF
--- a/_examples/stress_runtime/README.md
+++ b/_examples/stress_runtime/README.md
@@ -116,6 +116,24 @@ was expected vs. observed and where. Failures are listed first in the report.
 | `sub_refresh_expiry` | a 2s-TTL subscription survives several TTL windows via server-side sub refresh |
 | `recovery_storm` | subscribers kicked off repeatedly during continuous publishing end with **zero gaps and zero duplicates** |
 
+### Keyed subscriptions (map state and shared poll)
+
+Both kinds hand a connection a set of keys rather than a stream of
+publications, and both have a handshake no other scenario exercises: a map
+subscription pages through channel state before going live, a shared poll
+subscription tracks keys that a server-side refresh loop polls through
+`OnSharedPoll`. The shared poll scenarios answer from a harness-owned store, so
+moving a key's version there and then seeing the update arrive is an end-to-end
+check of the refresh loop, not of a mock.
+
+| Scenario | Invariant |
+|---|---|
+| `map_state_live` | state paging delivers every key exactly once across pages, the server switches the reported phase to LIVE on the last page, and updates and removals then arrive on the same subscription |
+| `map_ttl_removal` | keys that expire by `KeyTTL` are delivered as removals — the cleanup path nothing else drives |
+| `map_churn` | connections churning through the whole state handshake while keys change underneath leave the hub with no subscribers |
+| `shared_poll_track` | every tracked key is refreshed at its current version, a removal is delivered, and an untracked key goes quiet while its neighbours keep updating |
+| `shared_poll_churn` | subscribe/track/untrack/drop cycles against a 50ms refresh loop produce no errors and drain the hub |
+
 ### Node APIs and payload edges
 
 | Scenario | Invariant |
@@ -162,6 +180,7 @@ gap that survives to the client is a real defect, not flakiness.
 | `redis_history_pagination` | a stream written on node A pages forward and reads back in reverse from node B |
 | `redis_recovery_storm` | subscribers on both nodes kicked repeatedly during continuous publishing end with zero gaps and zero duplicates |
 | `redis_chaos` | mixed operations from many clients on both nodes for the whole load window, no errors |
+| `redis_map_cross_node` | a map key written through node A is in the state a subscriber reads on node B, and later updates and removals cross nodes live |
 
 ### Final
 
@@ -200,7 +219,8 @@ frames that grew, biggest first — that list *is* the leak.
   in `main.go`; a name starting with `redis_` is dropped automatically under
   `-no-redis`.
 - Channel behaviour is selected by name prefix (`recov:`, `delta:`, `pos:`,
-  `cache:`, `pres:`, `plain:`, `tags:`, `stags:`, `subexp:`, `deny:`, `nopub:`)
+  `cache:`, `pres:`, `plain:`, `tags:`, `stags:`, `subexp:`, `deny:`, `nopub:`,
+  `map:`, `mapttl:`, `poll:`)
   via `subOptions`, and per-connection behaviour by user-id prefix (`refresh:`,
   `expire:`, `ping:`, `ssub:<channel>[,<channel>…]`), so one set of handlers
   serves every scenario.

--- a/_examples/stress_runtime/keyed.go
+++ b/_examples/stress_runtime/keyed.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/centrifugal/centrifuge"
+)
+
+// pollStore is the backend the shared poll handler reads. Scenarios move a key's
+// version here and then assert the update reached every connection tracking it,
+// which is the only way to check the refresh loop end to end: the server asks
+// this store what a key looks like now, and the answer must reach the client.
+var pollStore = &keyStore{items: map[string]map[string]keyValue{}}
+
+type keyValue struct {
+	version uint64
+	data    string
+	removed bool
+}
+
+type keyStore struct {
+	mu    sync.RWMutex
+	items map[string]map[string]keyValue
+}
+
+// set bumps a key to the given version with fresh data.
+func (s *keyStore) set(channel, key string, version uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ch, ok := s.items[channel]
+	if !ok {
+		ch = map[string]keyValue{}
+		s.items[channel] = ch
+	}
+	ch[key] = keyValue{version: version, data: fmt.Sprintf(`{"key":%q,"v":%d}`, key, version)}
+}
+
+// remove marks a key removed, which the refresh loop must deliver as a removal.
+func (s *keyStore) remove(channel, key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ch, ok := s.items[channel]
+	if !ok {
+		ch = map[string]keyValue{}
+		s.items[channel] = ch
+	}
+	cur := ch[key]
+	ch[key] = keyValue{version: cur.version + 1, removed: true}
+}
+
+// poll answers a refresh cycle: every key the server asks about is reported at
+// its current version, or as removed when the store never had it.
+func (s *keyStore) poll(e centrifuge.SharedPollEvent) centrifuge.SharedPollResult {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ch := s.items[e.Channel]
+	items := make([]centrifuge.SharedPollRefreshItem, 0, len(e.Items))
+	for _, it := range e.Items {
+		val, ok := ch[it.Key]
+		if !ok || val.removed {
+			items = append(items, centrifuge.SharedPollRefreshItem{Key: it.Key, Removed: true, Version: val.version})
+			continue
+		}
+		items = append(items, centrifuge.SharedPollRefreshItem{
+			Key:     it.Key,
+			Data:    []byte(val.data),
+			Version: val.version,
+		})
+	}
+	return centrifuge.SharedPollResult{Items: items}
+}

--- a/_examples/stress_runtime/main.go
+++ b/_examples/stress_runtime/main.go
@@ -148,6 +148,13 @@ func allScenarios() []scenario {
 		{name: "sub_refresh_expiry", run: subRefreshExpiry},
 		{name: "recovery_storm", run: recoveryStorm},
 
+		// Keyed subscriptions: map state/stream/live and shared poll tracking.
+		{name: "map_state_live", run: mapStateLive},
+		{name: "map_ttl_removal", run: mapTTLRemoval},
+		{name: "map_churn", run: mapChurn},
+		{name: "shared_poll_track", run: sharedPollTrack},
+		{name: "shared_poll_churn", run: sharedPollChurn},
+
 		// Node APIs and payload edges.
 		{name: "survey_notify", run: surveyNotify},
 		{name: "async_send_echo", run: asyncSendEcho},
@@ -179,6 +186,7 @@ func allScenarios() []scenario {
 		{name: "redis_cache_recovery", run: redisCacheRecovery},
 		{name: "redis_history_pagination", run: redisHistoryPagination},
 		{name: "redis_recovery_storm", run: redisRecoveryStorm},
+		{name: "redis_map_cross_node", run: redisMapCrossNode},
 	}
 }
 

--- a/_examples/stress_runtime/rawproto.go
+++ b/_examples/stress_runtime/rawproto.go
@@ -5,8 +5,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -37,8 +39,11 @@ type connectResult struct {
 }
 
 type pubPush struct {
-	Data   json.RawMessage `json:"data"`
-	Offset uint64          `json:"offset"`
+	Data    json.RawMessage `json:"data"`
+	Offset  uint64          `json:"offset"`
+	Key     string          `json:"key"`
+	Removed bool            `json:"removed"`
+	Version uint64          `json:"version"`
 }
 
 type pushBody struct {
@@ -76,6 +81,7 @@ type command struct {
 	Unsubscribe *unsubscribeCmd `json:"unsubscribe,omitempty"`
 	Publish     *publishCmd     `json:"publish,omitempty"`
 	RPC         *rpcCmd         `json:"rpc,omitempty"`
+	SubRefresh  *subRefreshCmd  `json:"sub_refresh,omitempty"`
 }
 
 type connectCmd struct {
@@ -88,6 +94,42 @@ type subscribeCmd struct {
 	Recover bool   `json:"recover,omitempty"`
 	Offset  uint64 `json:"offset,omitempty"`
 	Epoch   string `json:"epoch,omitempty"`
+	// Keyed subscriptions: type selects map (1) or shared poll (2), phase picks
+	// the map handshake stage, and cursor/limit page through it.
+	Type   int32  `json:"type,omitempty"`
+	Phase  int32  `json:"phase,omitempty"`
+	Cursor string `json:"cursor,omitempty"`
+	Limit  int32  `json:"limit,omitempty"`
+	Asc    bool   `json:"asc,omitempty"`
+}
+
+// subRefreshCmd doubles as the track/untrack command for shared poll: type 1
+// tracks the items, type 2 untracks the listed keys.
+type subRefreshCmd struct {
+	Channel string       `json:"channel"`
+	Type    int32        `json:"type,omitempty"`
+	Track   []trackBatch `json:"track,omitempty"`
+	Untrack []string     `json:"untrack,omitempty"`
+}
+
+type trackBatch struct {
+	Items []keyedItem `json:"items"`
+}
+
+type keyedItem struct {
+	Key     string `json:"key"`
+	Version uint64 `json:"version,omitempty"`
+}
+
+// subscribeResult is the part of a subscribe reply the keyed scenarios read.
+type subscribeResult struct {
+	Type         int32     `json:"type"`
+	Phase        int32     `json:"phase"`
+	Cursor       string    `json:"cursor"`
+	Epoch        string    `json:"epoch"`
+	Offset       uint64    `json:"offset"`
+	State        []pubPush `json:"state"`
+	Publications []pubPush `json:"publications"`
 }
 
 type unsubscribeCmd struct {
@@ -126,6 +168,10 @@ func splitReplies(frame []byte) [][]byte {
 type rawWS struct {
 	ws      *websocket.Conn
 	pending [][]byte
+	// failed records that a read already errored. gorilla panics on a second
+	// read after a failure, and a read deadline that expires is such a failure,
+	// so every helper here must stop reading once one has.
+	failed error
 }
 
 func dialRaw(wsURL string) (*rawWS, error) {
@@ -155,6 +201,9 @@ func (r *rawWS) sendBytes(b []byte) error {
 // readReply returns the next protocol reply, transparently answering server
 // pings so the connection is not dropped while a scenario waits.
 func (r *rawWS) readReply(timeout time.Duration) (*reply, error) {
+	if r.failed != nil {
+		return nil, r.failed
+	}
 	deadline := time.Now().Add(timeout)
 	for {
 		for len(r.pending) > 0 {
@@ -177,6 +226,7 @@ func (r *rawWS) readReply(timeout time.Duration) (*reply, error) {
 		_ = r.ws.SetReadDeadline(time.Now().Add(remaining))
 		_, frame, err := r.ws.ReadMessage()
 		if err != nil {
+			r.failed = err
 			return nil, err
 		}
 		r.pending = splitReplies(frame)
@@ -184,6 +234,166 @@ func (r *rawWS) readReply(timeout time.Duration) (*reply, error) {
 }
 
 var errReadTimeout = fmt.Errorf("raw read timeout")
+
+// waitReplyID waits for the reply to one command, returning every push that
+// arrived while waiting. Keyed subscriptions interleave pushes with replies, so
+// a scenario that dropped them would lose the very updates it is asserting on.
+func (r *rawWS) waitReplyID(id uint32, timeout time.Duration) (*reply, []*pushBody, error) {
+	deadline := time.Now().Add(timeout)
+	var pushes []*pushBody
+	for {
+		rep, err := r.readReply(time.Until(deadline))
+		if err != nil {
+			return nil, pushes, err
+		}
+		if rep.Push != nil {
+			pushes = append(pushes, rep.Push)
+			continue
+		}
+		if rep.ID == id {
+			return rep, pushes, nil
+		}
+	}
+}
+
+// drainUntil reads pushes until enough returns true or the window elapses.
+//
+// It stops on the caller's condition rather than on a read deadline: letting a
+// deadline expire fails the connection for good (gorilla panics on the next
+// read), so a scenario that still has commands to send must never wait past
+// what it needs.
+func (r *rawWS) drainUntil(window time.Duration, enough func(*pushBody) bool) ([]*pushBody, error) {
+	deadline := time.Now().Add(window)
+	var pushes []*pushBody
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return pushes, nil
+		}
+		rep, err := r.readReply(remaining)
+		if err != nil {
+			var netErr net.Error
+			if errors.Is(err, errReadTimeout) || (errors.As(err, &netErr) && netErr.Timeout()) {
+				return pushes, nil
+			}
+			return pushes, err
+		}
+		if rep.Push == nil {
+			continue
+		}
+		pushes = append(pushes, rep.Push)
+		if enough != nil && enough(rep.Push) {
+			return pushes, nil
+		}
+	}
+}
+
+// drainPushes collects every push in the window. It leaves the connection
+// unusable for further reads, so callers must not send commands afterwards.
+func (r *rawWS) drainPushes(window time.Duration) ([]*pushBody, error) {
+	return r.drainUntil(window, nil)
+}
+
+// mapSubscribe sends one map subscribe command and decodes its result.
+func (r *rawWS) mapSubscribe(id uint32, channel string, phase int32, cursor string, limit int32) (*subscribeResult, []*pushBody, error) {
+	cmd := command{ID: id, Subscribe: &subscribeCmd{
+		Channel: channel,
+		Type:    subTypeMap,
+		Phase:   phase,
+		Cursor:  cursor,
+		Limit:   limit,
+	}}
+	if err := r.sendJSON(cmd); err != nil {
+		return nil, nil, err
+	}
+	rep, pushes, err := r.waitReplyID(id, 10*time.Second)
+	if err != nil {
+		return nil, pushes, err
+	}
+	if rep.Error != nil {
+		return nil, pushes, fmt.Errorf("map subscribe %s: error %d %s", channel, rep.Error.Code, rep.Error.Message)
+	}
+	if rep.Subscribe == nil {
+		return nil, pushes, fmt.Errorf("map subscribe %s: empty result", channel)
+	}
+	var res subscribeResult
+	if err := json.Unmarshal(*rep.Subscribe, &res); err != nil {
+		return nil, pushes, fmt.Errorf("decode map subscribe result: %w", err)
+	}
+	return &res, pushes, nil
+}
+
+// pollSubscribe subscribes to a shared poll channel.
+func (r *rawWS) pollSubscribe(id uint32, channel string) (*subscribeResult, error) {
+	cmd := command{ID: id, Subscribe: &subscribeCmd{Channel: channel, Type: subTypeSharedPoll}}
+	if err := r.sendJSON(cmd); err != nil {
+		return nil, err
+	}
+	rep, _, err := r.waitReplyID(id, 10*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	if rep.Error != nil {
+		return nil, fmt.Errorf("poll subscribe %s: error %d %s", channel, rep.Error.Code, rep.Error.Message)
+	}
+	var res subscribeResult
+	if rep.Subscribe != nil {
+		_ = json.Unmarshal(*rep.Subscribe, &res)
+	}
+	return &res, nil
+}
+
+// track and untrack drive the shared poll key set for this connection.
+func (r *rawWS) track(id uint32, channel string, keys []string) error {
+	items := make([]keyedItem, 0, len(keys))
+	for _, k := range keys {
+		items = append(items, keyedItem{Key: k})
+	}
+	cmd := command{ID: id, SubRefresh: &subRefreshCmd{
+		Channel: channel, Type: trackTypeTrack, Track: []trackBatch{{Items: items}},
+	}}
+	if err := r.sendJSON(cmd); err != nil {
+		return err
+	}
+	rep, _, err := r.waitReplyID(id, 10*time.Second)
+	if err != nil {
+		return err
+	}
+	if rep.Error != nil {
+		return fmt.Errorf("track %s: error %d %s", channel, rep.Error.Code, rep.Error.Message)
+	}
+	return nil
+}
+
+func (r *rawWS) untrack(id uint32, channel string, keys []string) error {
+	cmd := command{ID: id, SubRefresh: &subRefreshCmd{
+		Channel: channel, Type: trackTypeUntrack, Untrack: keys,
+	}}
+	if err := r.sendJSON(cmd); err != nil {
+		return err
+	}
+	rep, _, err := r.waitReplyID(id, 10*time.Second)
+	if err != nil {
+		return err
+	}
+	if rep.Error != nil {
+		return fmt.Errorf("untrack %s: error %d %s", channel, rep.Error.Code, rep.Error.Message)
+	}
+	return nil
+}
+
+// Protocol constants the keyed scenarios send on the wire.
+const (
+	subTypeMap        int32 = 1
+	subTypeSharedPoll int32 = 4
+
+	trackTypeTrack   int32 = 1
+	trackTypeUntrack int32 = 2
+
+	mapPhaseLive   int32 = 0
+	mapPhaseStream int32 = 1
+	mapPhaseState  int32 = 2
+)
 
 // connect performs the handshake and returns the connect result.
 func (r *rawWS) connect(token string) (*reply, error) {

--- a/_examples/stress_runtime/scenarios_keyed.go
+++ b/_examples/stress_runtime/scenarios_keyed.go
@@ -1,0 +1,502 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/centrifugal/centrifuge"
+)
+
+// Map subscriptions and shared poll are the two keyed subscription kinds. Both
+// hand a connection a set of keys rather than a stream of publications, and both
+// have a handshake the plain channel scenarios never exercise: a map
+// subscription pages through channel state before it goes live, a shared poll
+// subscription tracks keys that a server-side loop refreshes. The scenarios here
+// assert those handshakes deliver every key exactly once, that updates and
+// removals reach the connection afterwards, and that neither leaks when
+// connections churn through them.
+
+// mapStateLive pages a map subscription through its state phase and then checks
+// that live updates and removals keep arriving on the same subscription.
+func mapStateLive(ctx context.Context, e *env) (string, error) {
+	ch := newChannel(chMap, "state")
+	const keys = 25
+	for i := 0; i < keys; i++ {
+		if _, err := e.node.MapPublish(ctx, ch, fmt.Sprintf("k%02d", i), centrifuge.MapPublishOptions{
+			Data: []byte(fmt.Sprintf(`{"i":%d}`, i)),
+		}); err != nil {
+			return fail("seed key %d: %v", i, err)
+		}
+	}
+
+	r, err := dialRaw(e.wsURL)
+	if err != nil {
+		return fail("dial: %v", err)
+	}
+	defer r.close()
+	if _, err := r.connect(newUser("map")); err != nil {
+		return fail("connect: %v", err)
+	}
+
+	// Page through state. The server switches the reported phase to LIVE on the
+	// last page, which is the signal the handshake is complete.
+	seen := map[string]int{}
+	cursor := ""
+	pages := 0
+	var id uint32 = 10
+	for {
+		id++
+		pages++
+		if pages > keys+5 {
+			return fail("state paging did not finish after %d pages", pages)
+		}
+		res, _, err := r.mapSubscribe(id, ch, mapPhaseState, cursor, 10)
+		if err != nil {
+			return fail("page %d: %v", pages, err)
+		}
+		for _, p := range res.State {
+			seen[p.Key]++
+		}
+		if res.Phase == mapPhaseLive {
+			break
+		}
+		if res.Cursor == "" {
+			return fail("page %d reported phase %d with no cursor to continue", pages, res.Phase)
+		}
+		cursor = res.Cursor
+	}
+	if len(seen) != keys {
+		return fail("state delivered %d distinct keys, want %d", len(seen), keys)
+	}
+	for k, n := range seen {
+		if n != 1 {
+			return fail("key %s delivered %d times during state paging", k, n)
+		}
+	}
+
+	// Live phase: an update and a removal must both arrive on the subscription.
+	if _, err := e.node.MapPublish(ctx, ch, "k00", centrifuge.MapPublishOptions{Data: []byte(`{"i":999}`)}); err != nil {
+		return fail("live publish: %v", err)
+	}
+	if _, err := e.node.MapRemove(ctx, ch, "k01", centrifuge.MapRemoveOptions{}); err != nil {
+		return fail("live remove: %v", err)
+	}
+	var gotUpdate, gotRemoval bool
+	pushes, err := r.drainUntil(10*time.Second, func(p *pushBody) bool {
+		if p.Pub == nil || p.Channel != ch {
+			return false
+		}
+		if p.Pub.Key == "k00" && !p.Pub.Removed {
+			gotUpdate = true
+		}
+		if p.Pub.Key == "k01" && p.Pub.Removed {
+			gotRemoval = true
+		}
+		return gotUpdate && gotRemoval
+	})
+	if err != nil {
+		return fail("drain live pushes: %v", err)
+	}
+	if !gotUpdate {
+		return fail("live update for k00 never arrived (%d pushes seen)", len(pushes))
+	}
+	if !gotRemoval {
+		return fail("live removal for k01 never arrived (%d pushes seen)", len(pushes))
+	}
+	return okf("%d keys paged over %d state pages, then live update and removal delivered", keys, pages)
+}
+
+// mapTTLRemoval checks that keys expiring by TTL become removals on a live
+// subscription - the cleanup path, which nothing else in the suite drives.
+func mapTTLRemoval(ctx context.Context, e *env) (string, error) {
+	ch := newChannel(chMapTTL, "ttl")
+	const keys = 6
+	for i := 0; i < keys; i++ {
+		if _, err := e.node.MapPublish(ctx, ch, fmt.Sprintf("t%d", i), centrifuge.MapPublishOptions{
+			Data: []byte(fmt.Sprintf(`{"i":%d}`, i)),
+		}); err != nil {
+			return fail("seed key %d: %v", i, err)
+		}
+	}
+	r, err := dialRaw(e.wsURL)
+	if err != nil {
+		return fail("dial: %v", err)
+	}
+	defer r.close()
+	if _, err := r.connect(newUser("mapttl")); err != nil {
+		return fail("connect: %v", err)
+	}
+	res, _, err := r.mapSubscribe(10, ch, mapPhaseState, "", 100)
+	if err != nil {
+		return fail("subscribe: %v", err)
+	}
+	if len(res.State) != keys {
+		return fail("state carried %d keys, want %d", len(res.State), keys)
+	}
+
+	// KeyTTL on "mapttl:" channels is 3s; give the cleanup worker room past it.
+	removed := map[string]bool{}
+	if _, err := r.drainUntil(25*time.Second, func(p *pushBody) bool {
+		if p.Pub != nil && p.Channel == ch && p.Pub.Removed {
+			removed[p.Pub.Key] = true
+		}
+		return len(removed) == keys
+	}); err != nil {
+		return fail("drain: %v", err)
+	}
+	if len(removed) != keys {
+		return fail("%d/%d keys reported as removed after TTL", len(removed), keys)
+	}
+	return okf("all %d keys expired by TTL and were delivered as removals", keys)
+}
+
+// mapChurn runs connections through the whole map handshake while keys change
+// underneath them, then checks the hub let go of everything.
+func mapChurn(ctx context.Context, e *env) (string, error) {
+	channels := []string{newChannel(chMap, "churn-a"), newChannel(chMap, "churn-b")}
+	for _, ch := range channels {
+		for i := 0; i < 20; i++ {
+			if _, err := e.node.MapPublish(ctx, ch, fmt.Sprintf("k%02d", i), centrifuge.MapPublishOptions{
+				Data: []byte(`{"seed":true}`),
+			}); err != nil {
+				return fail("seed: %v", err)
+			}
+		}
+	}
+
+	deadline := time.Now().Add(loadDur)
+	var wg sync.WaitGroup
+	var cycles, failures atomic.Int64
+	var firstErr atomic.Value
+
+	// Key churn.
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			n := 0
+			for time.Now().Before(deadline) {
+				ch := channels[n%len(channels)]
+				key := fmt.Sprintf("k%02d", n%25)
+				var err error
+				if n%5 == 0 {
+					_, err = e.node.MapRemove(ctx, ch, key, centrifuge.MapRemoveOptions{})
+				} else {
+					_, err = e.node.MapPublish(ctx, ch, key, centrifuge.MapPublishOptions{
+						Data: []byte(fmt.Sprintf(`{"n":%d}`, n)),
+					})
+				}
+				if err != nil {
+					failures.Add(1)
+					firstErr.CompareAndSwap(nil, fmt.Sprintf("key churn: %v", err))
+					return
+				}
+				n++
+			}
+		}(i)
+	}
+
+	// Subscribe / page / drop churn.
+	for i := 0; i < 6; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			n := 0
+			for time.Now().Before(deadline) {
+				ch := channels[(id+n)%len(channels)]
+				r, err := dialRaw(e.wsURL)
+				if err != nil {
+					failures.Add(1)
+					firstErr.CompareAndSwap(nil, fmt.Sprintf("dial: %v", err))
+					return
+				}
+				if _, err := r.connect(newUser("mapchurn")); err != nil {
+					r.close()
+					failures.Add(1)
+					firstErr.CompareAndSwap(nil, fmt.Sprintf("connect: %v", err))
+					return
+				}
+				cursor := ""
+				var id32 uint32 = 10
+				for page := 0; page < 6; page++ {
+					id32++
+					res, _, err := r.mapSubscribe(id32, ch, mapPhaseState, cursor, 5)
+					if err != nil {
+						r.close()
+						failures.Add(1)
+						firstErr.CompareAndSwap(nil, fmt.Sprintf("map subscribe: %v", err))
+						return
+					}
+					if res.Phase == mapPhaseLive {
+						break
+					}
+					cursor = res.Cursor
+					if cursor == "" {
+						break
+					}
+				}
+				r.close()
+				cycles.Add(1)
+				n++
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if v := firstErr.Load(); v != nil {
+		return fail("%d failures, first: %s", failures.Load(), v.(string))
+	}
+	for _, ch := range channels {
+		if !waitFor(10*time.Second, func() bool { return e.node.Hub().NumSubscribers(ch) == 0 }) {
+			return fail("channel %s still has %d subscribers after churn", ch, e.node.Hub().NumSubscribers(ch))
+		}
+	}
+	return okf("%d map subscribe cycles over %s, hub drained", cycles.Load(), loadDur)
+}
+
+// sharedPollTrack drives the shared poll refresh loop: tracked keys must be
+// refreshed, an untracked key must go quiet, and removals must be delivered.
+func sharedPollTrack(ctx context.Context, e *env) (string, error) {
+	ch := newChannel(chPoll, "track")
+	keys := []string{"a", "b", "c"}
+	for i, k := range keys {
+		pollStore.set(ch, k, uint64(i+1))
+	}
+
+	r, err := dialRaw(e.wsURL)
+	if err != nil {
+		return fail("dial: %v", err)
+	}
+	defer r.close()
+	if _, err := r.connect(newUser("poll")); err != nil {
+		return fail("connect: %v", err)
+	}
+	if _, err := r.pollSubscribe(10, ch); err != nil {
+		return fail("subscribe: %v", err)
+	}
+	if err := r.track(11, ch, keys); err != nil {
+		return fail("track: %v", err)
+	}
+
+	// Every tracked key must be delivered at its current version.
+	got := map[string]uint64{}
+	if _, err := r.drainUntil(10*time.Second, func(p *pushBody) bool {
+		if p.Pub != nil && p.Channel == ch && !p.Pub.Removed {
+			got[p.Pub.Key] = p.Pub.Version
+		}
+		return len(got) == len(keys)
+	}); err != nil {
+		return fail("drain: %v", err)
+	}
+	if len(got) != len(keys) {
+		return fail("refresh delivered %d/%d tracked keys", len(got), len(keys))
+	}
+
+	// Untrack "a", then move every key: only the still-tracked ones may arrive.
+	if err := r.untrack(12, ch, []string{"a"}); err != nil {
+		return fail("untrack: %v", err)
+	}
+	for _, k := range keys {
+		pollStore.set(ch, k, 100)
+	}
+	pollStore.remove(ch, "c")
+
+	updated := map[string]bool{}
+	removals := map[string]bool{}
+	if _, err := r.drainUntil(10*time.Second, func(p *pushBody) bool {
+		if p.Pub == nil || p.Channel != ch {
+			return false
+		}
+		if p.Pub.Removed {
+			removals[p.Pub.Key] = true
+		} else if p.Pub.Version >= 100 {
+			updated[p.Pub.Key] = true
+		}
+		return updated["b"] && removals["c"]
+	}); err != nil {
+		return fail("drain after untrack: %v", err)
+	}
+	if !updated["b"] {
+		return fail("tracked key b never refreshed after its version moved")
+	}
+	if !removals["c"] {
+		return fail("removal of tracked key c never delivered")
+	}
+	if updated["a"] {
+		return fail("untracked key a kept being refreshed")
+	}
+	return okf("%d keys refreshed, untracked key went quiet, removal delivered", len(keys))
+}
+
+// sharedPollChurn churns connections through subscribe/track/untrack/drop while
+// the refresh loop runs, then checks the manager let go of every channel.
+func sharedPollChurn(ctx context.Context, e *env) (string, error) {
+	channels := []string{newChannel(chPoll, "churn-a"), newChannel(chPoll, "churn-b")}
+	for _, ch := range channels {
+		for i := 0; i < 30; i++ {
+			pollStore.set(ch, fmt.Sprintf("k%02d", i), uint64(i))
+		}
+	}
+
+	deadline := time.Now().Add(loadDur)
+	var wg sync.WaitGroup
+	var cycles, failures atomic.Int64
+	var firstErr atomic.Value
+
+	// Key churn under the refresh loop.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		n := uint64(0)
+		for time.Now().Before(deadline) {
+			for _, ch := range channels {
+				pollStore.set(ch, fmt.Sprintf("k%02d", n%30), 1000+n)
+			}
+			n++
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+
+	for i := 0; i < 6; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			n := 0
+			for time.Now().Before(deadline) {
+				ch := channels[(id+n)%len(channels)]
+				r, err := dialRaw(e.wsURL)
+				if err != nil {
+					failures.Add(1)
+					firstErr.CompareAndSwap(nil, fmt.Sprintf("dial: %v", err))
+					return
+				}
+				if _, err := r.connect(newUser("pollchurn")); err != nil {
+					r.close()
+					failures.Add(1)
+					firstErr.CompareAndSwap(nil, fmt.Sprintf("connect: %v", err))
+					return
+				}
+				if _, err := r.pollSubscribe(10, ch); err != nil {
+					r.close()
+					failures.Add(1)
+					firstErr.CompareAndSwap(nil, fmt.Sprintf("subscribe: %v", err))
+					return
+				}
+				keys := []string{
+					fmt.Sprintf("k%02d", n%30),
+					fmt.Sprintf("k%02d", (n+7)%30),
+					fmt.Sprintf("k%02d", (n+13)%30),
+				}
+				if err := r.track(11, ch, keys); err != nil {
+					r.close()
+					failures.Add(1)
+					firstErr.CompareAndSwap(nil, fmt.Sprintf("track: %v", err))
+					return
+				}
+				switch n % 3 {
+				case 0:
+					// Untrack, then drop.
+					if err := r.untrack(12, ch, keys); err != nil {
+						r.close()
+						failures.Add(1)
+						firstErr.CompareAndSwap(nil, fmt.Sprintf("untrack: %v", err))
+						return
+					}
+				case 1:
+					// Drop while a refresh cycle is in flight.
+					_, _ = r.drainUntil(30*time.Millisecond, nil)
+				case 2:
+					// Re-track the same keys before dropping.
+					if err := r.track(13, ch, keys); err != nil {
+						r.close()
+						failures.Add(1)
+						firstErr.CompareAndSwap(nil, fmt.Sprintf("re-track: %v", err))
+						return
+					}
+				}
+				r.close()
+				cycles.Add(1)
+				n++
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if v := firstErr.Load(); v != nil {
+		return fail("%d failures, first: %s", failures.Load(), v.(string))
+	}
+	for _, ch := range channels {
+		if !waitFor(15*time.Second, func() bool { return e.node.Hub().NumSubscribers(ch) == 0 }) {
+			return fail("channel %s still has %d subscribers after churn", ch, e.node.Hub().NumSubscribers(ch))
+		}
+	}
+	return okf("%d shared poll cycles over %s, hub drained", cycles.Load(), loadDur)
+}
+
+// redisMapCrossNode checks a map subscription is a cluster feature: a key
+// written through one node reaches a connection subscribed on the other, and the
+// state a fresh subscriber reads there is the same.
+func redisMapCrossNode(ctx context.Context, e *env) (string, error) {
+	if !e.redisEnabled() {
+		return okf("skipped (no redis)")
+	}
+	ch := newChannel(chMap, "xnode")
+	const keys = 8
+	for i := 0; i < keys; i++ {
+		if _, err := e.redisA.MapPublish(ctx, ch, fmt.Sprintf("k%d", i), centrifuge.MapPublishOptions{
+			Data: []byte(fmt.Sprintf(`{"i":%d}`, i)),
+		}); err != nil {
+			return fail("publish on node A: %v", err)
+		}
+	}
+
+	// Subscribe on node B and read the state written through node A.
+	r, err := dialRaw(e.redisBWS)
+	if err != nil {
+		return fail("dial node B: %v", err)
+	}
+	defer r.close()
+	if _, err := r.connect(newUser("mapx")); err != nil {
+		return fail("connect node B: %v", err)
+	}
+	res, _, err := r.mapSubscribe(10, ch, mapPhaseState, "", 100)
+	if err != nil {
+		return fail("subscribe node B: %v", err)
+	}
+	if len(res.State) != keys {
+		return fail("node B state has %d keys, node A wrote %d", len(res.State), keys)
+	}
+
+	// A live update through node A must reach the node B connection over Redis.
+	if _, err := e.redisA.MapPublish(ctx, ch, "k0", centrifuge.MapPublishOptions{Data: []byte(`{"i":777}`)}); err != nil {
+		return fail("cross-node publish: %v", err)
+	}
+	if _, err := e.redisA.MapRemove(ctx, ch, "k1", centrifuge.MapRemoveOptions{}); err != nil {
+		return fail("cross-node remove: %v", err)
+	}
+	var gotUpdate, gotRemoval bool
+	if _, err := r.drainUntil(15*time.Second, func(p *pushBody) bool {
+		if p.Pub == nil || p.Channel != ch {
+			return false
+		}
+		if p.Pub.Key == "k0" && !p.Pub.Removed {
+			gotUpdate = true
+		}
+		if p.Pub.Key == "k1" && p.Pub.Removed {
+			gotRemoval = true
+		}
+		return gotUpdate && gotRemoval
+	}); err != nil {
+		return fail("drain: %v", err)
+	}
+	if !gotUpdate {
+		return fail("update written on node A never reached node B")
+	}
+	if !gotRemoval {
+		return fail("removal written on node A never reached node B")
+	}
+	return okf("%d keys read on node B, cross-node update and removal delivered", keys)
+}

--- a/_examples/stress_runtime/server.go
+++ b/_examples/stress_runtime/server.go
@@ -29,7 +29,15 @@ const (
 	chDeny   = "deny:"   // subscribe is rejected with ErrorPermissionDenied
 	chNoPub  = "nopub:"  // client publish is rejected with ErrorPermissionDenied
 	chSubExp = "subexp:" // subscription with a short TTL (exercises sub refresh)
+	chMap    = "map:"    // map subscription: keyed state with stream + live phases
+	chMapTTL = "mapttl:" // map subscription whose keys expire quickly (cleanup worker)
+	chPoll   = "poll:"   // shared poll subscription: per-connection tracked keys
 )
+
+// isMapChannel reports whether a channel name selects a map subscription.
+func isMapChannel(ch string) bool {
+	return strings.HasPrefix(ch, chMap) || strings.HasPrefix(ch, chMapTTL)
+}
 
 // User (token) prefixes select per-connection behaviour in OnConnecting.
 const (
@@ -67,6 +75,12 @@ func subOptions(channel string) centrifuge.SubscribeOptions {
 	if strings.HasPrefix(channel, chDelta) {
 		o.AllowedDeltaTypes = []centrifuge.DeltaType{centrifuge.DeltaTypeFossil}
 	}
+	if isMapChannel(channel) {
+		return centrifuge.SubscribeOptions{Type: centrifuge.SubscriptionTypeMap}
+	}
+	if strings.HasPrefix(channel, chPoll) {
+		return centrifuge.SubscribeOptions{Type: centrifuge.SubscriptionTypeSharedPoll}
+	}
 	// Presence + join/leave everywhere they don't conflict — cheap and lets any
 	// channel be inspected. Kept off delta channels to avoid mixing concerns, and
 	// off "plain:" channels used by scenarios that subscribe to thousands of them.
@@ -90,14 +104,61 @@ func historyPublishOptions(channel string) centrifuge.PublishOptions {
 	return opts
 }
 
+// mapChannelOptions gives "map:" channels a generous key TTL and "mapttl:"
+// channels a short one, so a scenario can watch keys expire and the cleanup
+// worker generate the removals for them.
+func mapChannelOptions(channel string) centrifuge.MapChannelOptions {
+	o := centrifuge.MapChannelOptions{
+		Mode:            centrifuge.MapModeEphemeral,
+		KeyTTL:          2 * time.Minute,
+		MinPageSize:     1,
+		DefaultPageSize: 10,
+		MaxPageSize:     100,
+	}
+	if strings.HasPrefix(channel, chMapTTL) {
+		o.KeyTTL = 3 * time.Second
+	}
+	return o
+}
+
+// sharedPollOptions drives the refresh loop fast enough for a scenario to see
+// several cycles without waiting on wall clock.
+func sharedPollOptions() centrifuge.SharedPollChannelOptions {
+	return centrifuge.SharedPollChannelOptions{
+		RefreshInterval:      50 * time.Millisecond,
+		RefreshBatchSize:     64,
+		MaxKeysPerConnection: 128,
+	}
+}
+
+// withKeyedFeatures adds the map and shared-poll configuration every node in the
+// suite shares.
+func withKeyedFeatures(cfg centrifuge.Config) centrifuge.Config {
+	cfg.Map = centrifuge.MapConfig{
+		GetMapChannelOptions: func(channel string) centrifuge.MapChannelOptions {
+			return mapChannelOptions(channel)
+		},
+	}
+	cfg.SharedPoll = centrifuge.SharedPollConfig{
+		GetSharedPollChannelOptions: func(channel string) (centrifuge.SharedPollChannelOptions, bool) {
+			if !strings.HasPrefix(channel, chPoll) {
+				return centrifuge.SharedPollChannelOptions{}, false
+			}
+			return sharedPollOptions(), true
+		},
+	}
+	return cfg
+}
+
 // nodeConfig is the tuning that differs between the nodes the suite runs.
 type nodeConfig struct {
 	name string
 	cfg  centrifuge.Config
 	ws   centrifuge.WebsocketConfig
-	// storage builds the broker and presence manager. Nil means in-memory. The
-	// returned closer releases whatever the storage holds (Redis clients).
-	storage func(*centrifuge.Node) (centrifuge.Broker, centrifuge.PresenceManager, func(), error)
+	// storage builds the broker, presence manager and map broker. Nil means
+	// in-memory. The returned closer releases whatever the storage holds (Redis
+	// clients).
+	storage func(*centrifuge.Node) (centrifuge.Broker, centrifuge.PresenceManager, centrifuge.MapBroker, func(), error)
 }
 
 // mainNodeConfig is generous on purpose: bursty concurrent scenarios must not
@@ -106,11 +167,11 @@ type nodeConfig struct {
 func mainNodeConfig() nodeConfig {
 	return nodeConfig{
 		name: "main",
-		cfg: centrifuge.Config{
+		cfg: withKeyedFeatures(centrifuge.Config{
 			LogLevel:           centrifuge.LogLevelError,
 			ClientQueueMaxSize: 128 * 1024 * 1024,
 			ClientChannelLimit: 100000,
-		},
+		}),
 		ws: centrifuge.WebsocketConfig{
 			UseWriteBufferPool: true,
 			// Large enough for the megabyte-scale client publishes in large_payloads.
@@ -151,7 +212,7 @@ func strictNodeConfig() nodeConfig {
 func redisNodeConfig(name, address, prefix string) nodeConfig {
 	return nodeConfig{
 		name: name,
-		cfg: centrifuge.Config{
+		cfg: withKeyedFeatures(centrifuge.Config{
 			Name:               name,
 			LogLevel:           centrifuge.LogLevelError,
 			ClientQueueMaxSize: 128 * 1024 * 1024,
@@ -159,15 +220,15 @@ func redisNodeConfig(name, address, prefix string) nodeConfig {
 			// Keep every key this run creates short-lived: the suite uses a fresh
 			// prefix per run and never deletes anything, so Redis must expire it.
 			HistoryMetaTTL: 2 * time.Minute,
-		},
+		}),
 		ws: centrifuge.WebsocketConfig{
 			UseWriteBufferPool: true,
 			MessageSizeLimit:   4 * 1024 * 1024,
 		},
-		storage: func(node *centrifuge.Node) (centrifuge.Broker, centrifuge.PresenceManager, func(), error) {
+		storage: func(node *centrifuge.Node) (centrifuge.Broker, centrifuge.PresenceManager, centrifuge.MapBroker, func(), error) {
 			shard, err := centrifuge.NewRedisShard(node, centrifuge.RedisShardConfig{Address: address})
 			if err != nil {
-				return nil, nil, nil, fmt.Errorf("redis shard: %w", err)
+				return nil, nil, nil, nil, fmt.Errorf("redis shard: %w", err)
 			}
 			shards := []*centrifuge.RedisShard{shard}
 			broker, err := centrifuge.NewRedisBroker(node, centrifuge.RedisBrokerConfig{
@@ -176,7 +237,7 @@ func redisNodeConfig(name, address, prefix string) nodeConfig {
 			})
 			if err != nil {
 				shard.Close()
-				return nil, nil, nil, fmt.Errorf("redis broker: %w", err)
+				return nil, nil, nil, nil, fmt.Errorf("redis broker: %w", err)
 			}
 			pm, err := centrifuge.NewRedisPresenceManager(node, centrifuge.RedisPresenceManagerConfig{
 				Prefix:      prefix,
@@ -186,16 +247,27 @@ func redisNodeConfig(name, address, prefix string) nodeConfig {
 			if err != nil {
 				_ = broker.Close(context.Background())
 				shard.Close()
-				return nil, nil, nil, fmt.Errorf("redis presence manager: %w", err)
+				return nil, nil, nil, nil, fmt.Errorf("redis presence manager: %w", err)
+			}
+			mapBroker, err := centrifuge.NewRedisMapBroker(node, centrifuge.RedisMapBrokerConfig{
+				Prefix: prefix,
+				Shards: shards,
+			})
+			if err != nil {
+				_ = broker.Close(context.Background())
+				_ = pm.Close(context.Background())
+				shard.Close()
+				return nil, nil, nil, nil, fmt.Errorf("redis map broker: %w", err)
 			}
 			closer := func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()
 				_ = broker.Close(ctx)
 				_ = pm.Close(ctx)
+				_ = mapBroker.Close(ctx)
 				shard.Close()
 			}
-			return broker, pm, closer, nil
+			return broker, pm, mapBroker, closer, nil
 		},
 	}
 }
@@ -211,12 +283,23 @@ func buildNode(nc nodeConfig) (*centrifuge.Node, func(), error) {
 	if storage == nil {
 		storage = memoryStorage
 	}
-	broker, pm, closeStorage, err := storage(node)
+	broker, pm, mapBroker, closeStorage, err := storage(node)
 	if err != nil {
 		return nil, nil, err
 	}
 	node.SetBroker(broker)
 	node.SetPresenceManager(pm)
+	if mapBroker != nil {
+		node.SetMapBroker(mapBroker)
+	}
+
+	// Shared poll answers from the harness-owned store, so a scenario can move a
+	// key's version and then assert the update reached the connections tracking
+	// it. Must be installed before Run - Run refuses a shared poll config without
+	// a handler.
+	node.OnSharedPoll(func(_ context.Context, e centrifuge.SharedPollEvent) (centrifuge.SharedPollResult, error) {
+		return pollStore.poll(e), nil
+	})
 
 	// Survey/notification handlers must be installed before Run.
 	node.OnSurvey(func(e centrifuge.SurveyEvent, cb centrifuge.SurveyCallback) {
@@ -241,16 +324,20 @@ func buildNode(nc nodeConfig) (*centrifuge.Node, func(), error) {
 	return node, closer, nil
 }
 
-func memoryStorage(node *centrifuge.Node) (centrifuge.Broker, centrifuge.PresenceManager, func(), error) {
+func memoryStorage(node *centrifuge.Node) (centrifuge.Broker, centrifuge.PresenceManager, centrifuge.MapBroker, func(), error) {
 	broker, err := centrifuge.NewMemoryBroker(node, centrifuge.MemoryBrokerConfig{})
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	pm, err := centrifuge.NewMemoryPresenceManager(node, centrifuge.MemoryPresenceManagerConfig{})
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
-	return broker, pm, func() {}, nil
+	mapBroker, err := centrifuge.NewMemoryMapBroker(node, centrifuge.MemoryMapBrokerConfig{})
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	return broker, pm, mapBroker, func() {}, nil
 }
 
 func installHandlers(node *centrifuge.Node) {
@@ -363,6 +450,9 @@ func installHandlers(node *centrifuge.Node) {
 		})
 		client.OnSubRefresh(func(e centrifuge.SubRefreshEvent, cb centrifuge.SubRefreshCallback) {
 			cb(centrifuge.SubRefreshReply{ExpireAt: time.Now().Add(2 * time.Second).Unix()}, nil)
+		})
+		client.OnTrack(func(e centrifuge.TrackEvent, cb centrifuge.TrackCallback) {
+			cb(centrifuge.TrackReply{}, nil)
 		})
 		client.OnDisconnect(func(e centrifuge.DisconnectEvent) {
 			if debugDisc && e.Code != centrifuge.DisconnectConnectionClosed.Code {


### PR DESCRIPTION
## What

`_examples/stress_runtime` had 56 scenarios and none for the two keyed subscription kinds. Map subscriptions and shared poll are the newest and most concurrent parts of the library, and the only major features the harness could not reach — the raw client had no way to send a typed subscribe or a track command, and no node in the suite had a map broker or a shared poll handler.

Six new scenarios, one new file of scenario code, and the harness plumbing to reach them.

| Scenario | Invariant |
|---|---|
| `map_state_live` | state paging delivers every key exactly once across pages, the server flips the reported phase to LIVE on the last page, and updates and removals then arrive on the same subscription |
| `map_ttl_removal` | keys expiring by `KeyTTL` are delivered as removals — the cleanup path nothing else drives |
| `map_churn` | connections churning through the whole state handshake while keys change underneath leave the hub with no subscribers |
| `shared_poll_track` | every tracked key is refreshed at its current version, a removal is delivered, and an untracked key goes quiet while its neighbours keep updating |
| `shared_poll_churn` | subscribe/track/untrack/drop cycles against a 50ms refresh loop produce no errors and drain the hub |
| `redis_map_cross_node` | a key written through node A is in the state a subscriber reads on node B, and later updates and removals cross nodes live |

## How

**Shared poll answers from a harness-owned store** (`keyed.go`). The scenario moves a key's version there and then asserts the update reached the connection tracking it, so the refresh loop is checked end to end rather than against a mock that always returns the same thing.

**Every node gains a map broker** — memory on the main node, Redis on the two Redis nodes. That is what makes `redis_map_cross_node` a cluster test rather than a local one: the key is written through node A's map broker and read by a connection on node B.

**Channel prefixes select the behaviour**, as the rest of the suite does: `map:` for a map subscription, `mapttl:` for one whose keys expire in 3s, `poll:` for shared poll.

**The raw protocol client grew the keyed commands**: subscribe carries `type`, `phase`, `cursor` and `limit`; `sub_refresh` doubles as track (type 1) and untrack (type 2); pushes now decode `key`, `removed` and `version`.

One non-obvious detail worth calling out: the raw client's reads now stop on a caller's condition rather than on a read deadline. Letting a deadline expire fails a gorilla connection permanently — the next read panics with `repeated read on failed websocket connection` — so a scenario that still has commands to send must never wait past what it needs. `drainUntil(window, enough)` returns the moment the caller has what it wanted; a read error is recorded so a later read reports it instead of panicking.

## Verification

- Full suite with Redis: **62 passed, 0 failed** (56 pre-existing + 6 new) — the harness changes touch every node's config, so the whole suite is the regression check here.
- Full suite with Redis under `-race`: **62 passed, 0 failed**.
- The new scenarios were run repeatedly on their own while being written; `map_churn` sustains ~24k map subscribe cycles and `shared_poll_churn` ~7.5k track/untrack cycles over a 20s load window.
- `go vet`, `gofmt` clean.

No library code changed — this is harness and scenario code only.
