### PR TITLE
Test the recovery merge gap check and PubSubSync pass-through paths

### DIFF
--- a/internal/recovery/helpers_test.go
+++ b/internal/recovery/helpers_test.go
@@ -91,3 +91,79 @@ func TestMergePublications_AllBufferedFiltered_WithBrokerPubs(t *testing.T) {
 	require.Equal(t, uint64(5), pubs[0].Offset)
 	require.Equal(t, uint64(7), maxSeenOffset)
 }
+
+func pubOffsets(pubs []*protocol.Publication) []uint64 {
+	offsets := make([]uint64, 0, len(pubs))
+	for _, p := range pubs {
+		offsets = append(offsets, p.Offset)
+	}
+	return offsets
+}
+
+// TestMergePublications_OverlapDeduplicated covers the common case where a
+// publication arrives both from history and from PUB/SUB while subscribing.
+func TestMergePublications_OverlapDeduplicated(t *testing.T) {
+	recoveredPubs := []*protocol.Publication{
+		{Offset: 1},
+		{Offset: 2},
+		{Offset: 3},
+	}
+	bufferedPubs := []*protocol.Publication{
+		{Offset: 3},
+		{Offset: 4},
+	}
+	pubs, maxSeenOffset, ok := MergePublications(recoveredPubs, bufferedPubs)
+	require.True(t, ok)
+	require.Equal(t, []uint64{1, 2, 3, 4}, pubOffsets(pubs))
+	require.Equal(t, uint64(4), maxSeenOffset)
+}
+
+// TestMergePublications_GapWithoutFiltered asserts that a missing offset
+// between recovered and buffered publications is reported as a failed merge,
+// so the client is not sent a stream with a hole in it.
+func TestMergePublications_GapWithoutFiltered(t *testing.T) {
+	recoveredPubs := []*protocol.Publication{
+		{Offset: 1},
+		{Offset: 2},
+	}
+	bufferedPubs := []*protocol.Publication{
+		{Offset: 4},
+	}
+	pubs, maxSeenOffset, ok := MergePublications(recoveredPubs, bufferedPubs)
+	require.False(t, ok)
+	require.Nil(t, pubs)
+	require.Zero(t, maxSeenOffset)
+}
+
+// TestMergePublications_GapCoveredByFiltered asserts that offsets missing from
+// the result are fine when every one of them belongs to a filtered publication.
+func TestMergePublications_GapCoveredByFiltered(t *testing.T) {
+	recoveredPubs := []*protocol.Publication{
+		{Offset: 1},
+		{Offset: 2, Time: -1},
+	}
+	bufferedPubs := []*protocol.Publication{
+		{Offset: 3, Time: -1},
+		{Offset: 4},
+	}
+	pubs, maxSeenOffset, ok := MergePublications(recoveredPubs, bufferedPubs)
+	require.True(t, ok)
+	require.Equal(t, []uint64{1, 4}, pubOffsets(pubs))
+	require.Equal(t, uint64(4), maxSeenOffset)
+}
+
+// TestMergePublications_GapPartiallyCoveredByFiltered asserts that having some
+// filtered publications does not hide an offset that is genuinely missing.
+func TestMergePublications_GapPartiallyCoveredByFiltered(t *testing.T) {
+	recoveredPubs := []*protocol.Publication{
+		{Offset: 1},
+	}
+	bufferedPubs := []*protocol.Publication{
+		{Offset: 2, Time: -1},
+		{Offset: 4},
+	}
+	pubs, maxSeenOffset, ok := MergePublications(recoveredPubs, bufferedPubs)
+	require.False(t, ok)
+	require.Nil(t, pubs)
+	require.Zero(t, maxSeenOffset)
+}

--- a/internal/recovery/sync_test.go
+++ b/internal/recovery/sync_test.go
@@ -94,6 +94,30 @@ func TestPubSubSyncNonSynchronized(t *testing.T) {
 	require.Empty(t, psSync.subSync)
 }
 
+func TestPubSubSyncNotBuffering(t *testing.T) {
+	psSync := NewPubSubSync()
+
+	synced := 0
+	psSync.SyncPublication("ch", &protocol.Publication{Offset: 1}, func() { synced++ })
+	require.Equal(t, 1, synced, "publication must pass through when channel is not buffering")
+
+	require.Nil(t, psSync.LockBufferAndReadBuffered("ch"))
+	psSync.StopBuffering("ch") // No-op for a channel which is not buffering.
+	require.Empty(t, psSync.subSync)
+
+	psSync.StartBuffering("ch")
+	psSync.SyncPublication("ch", &protocol.Publication{Offset: 2}, func() { synced++ })
+	require.Equal(t, 1, synced, "publication must be buffered while subscribing")
+	pubs := psSync.LockBufferAndReadBuffered("ch")
+	require.Len(t, pubs, 1)
+	require.Equal(t, uint64(2), pubs[0].Offset)
+	psSync.StopBuffering("ch")
+
+	psSync.SyncPublication("ch", &protocol.Publication{Offset: 3}, func() { synced++ })
+	require.Equal(t, 2, synced, "publication must pass through after buffering stopped")
+	require.Empty(t, psSync.subSync)
+}
+
 func BenchmarkPubSubSync(b *testing.B) {
 	psSync := NewPubSubSync()
 	var channels []string


### PR DESCRIPTION
## What

Test-only change in `internal/recovery`:

- `helpers_test.go`: new cases for `MergePublications`
  - a publication present in both history and the PUB/SUB buffer is returned once, in order;
  - a gap between recovered and buffered publications with no filtered publications makes the merge fail (`ok=false`, nil result);
  - a gap made up only of filtered publications (`Time == -1`) is accepted, and the filtered entries are removed from the result;
  - a gap only partly made up of filtered publications still makes the merge fail.
- `sync_test.go`: `PubSubSync` on a channel that is not buffering. The publication is passed straight through, `LockBufferAndReadBuffered` returns nil and `StopBuffering` does nothing. The test also checks that a publication is buffered between `StartBuffering` and `StopBuffering` and passed through again afterwards.

## Why

The gap check in `MergePublications` is what turns a hole in the recovered stream into a `DisconnectInsufficientState` in `client.go` and `client_map.go`, so the client is not given a stream with a missing publication. Neither this package's tests nor the root package's recovery and filter tests reached that branch. Package coverage was 83.5% and is now 100%.

## Verification

- `go test -race -count=3 ./internal/recovery/` passes.
- `go vet`, `gofmt` and `golangci-lint run ./internal/recovery/...` report no issues.
- To check that the new assertions catch real mistakes, I ran the tests against two broken copies of `helpers.go`, swapped in with `go test -overlay` so the source was not edited:
  - skipping the per-offset check against filtered offsets makes `TestMergePublications_GapPartiallyCoveredByFiltered` fail;
  - disabling the gap check entirely makes both `TestMergePublications_GapWithoutFiltered` and `TestMergePublications_GapPartiallyCoveredByFiltered` fail.