### PR TITLE
Send expiration in map subscribe replies, keep client-side refresh across pages

### DIFF
--- a/client.go
+++ b/client.go
@@ -4170,6 +4170,25 @@ func (c *Client) commitSubscription(channel string, ctx ChannelContext, kind res
 	return subscribingCh, true
 }
 
+// subscriptionExpiration returns the expiration fields of a subscribe result for
+// a subscription expiring at expireAt (Unix seconds, zero means no expiration),
+// shared by all subscription types. expired is true when the subscription has
+// already expired. The client is only told about expiration when it refreshes the
+// subscription itself.
+func subscriptionExpiration(expireAt int64, clientSideRefresh bool) (expires bool, ttl uint32, expired bool) {
+	if expireAt <= 0 {
+		return false, 0, false
+	}
+	remaining := expireAt - time.Now().Unix()
+	if remaining <= 0 {
+		return false, 0, true
+	}
+	if !clientSideRefresh {
+		return false, 0, false
+	}
+	return true, uint32(remaining), false
+}
+
 // subscribeCmd handles subscribe command - clients send this when subscribe
 // on channel, if channel is private then we must validate provided sign here before
 // actually subscribe client on channel. Optionally we can send missed messages to
@@ -4194,17 +4213,13 @@ func (c *Client) subscribeCmd(req *protocol.SubscribeRequest, reply SubscribeRep
 
 	res := &protocol.SubscribeResult{}
 
-	if reply.Options.ExpireAt > 0 {
-		ttl := reply.Options.ExpireAt - time.Now().Unix()
-		if ttl <= 0 {
-			c.node.logger.log(newLogEntry(LogLevelInfo, "subscription expiration must be greater than now", map[string]any{"client": c.uid, "user": c.UserID()}))
-			return errorDisconnectContext(ErrorExpired, nil)
-		}
-		if reply.ClientSideRefresh {
-			res.Expires = true
-			res.Ttl = uint32(ttl)
-		}
+	expires, ttl, expired := subscriptionExpiration(reply.Options.ExpireAt, reply.ClientSideRefresh)
+	if expired {
+		c.node.logger.log(newLogEntry(LogLevelInfo, "subscription expiration must be greater than now", map[string]any{"client": c.uid, "user": c.UserID()}))
+		return errorDisconnectContext(ErrorExpired, nil)
 	}
+	res.Expires = expires
+	res.Ttl = ttl
 
 	if reply.Options.Data != nil {
 		res.Data = reply.Options.Data

--- a/client_map.go
+++ b/client_map.go
@@ -151,6 +151,7 @@ func escapeStateForDelta(pubs []*protocol.Publication, deltaEnabled bool, isJSON
 // mapSubscribeState tracks state for map subscriptions that are still loading.
 type mapSubscribeState struct {
 	options             SubscribeOptions // From OnSubscribe callback
+	clientSideRefresh   bool             // From OnSubscribe callback: the client refreshes the subscription
 	epoch               string           // Epoch from first response (for validation)
 	offset              uint64           // Offset from first state page (frozen for consistency)
 	startedAt           int64            // UnixNano when catch-up started (for timeout)
@@ -207,7 +208,7 @@ func (c *Client) handleMapSubscribeCommand(
 			c.cleanupMapSubscribing(req.Channel)
 			return DisconnectSlow
 		}
-		reply := SubscribeReply{Options: state.options}
+		reply := SubscribeReply{Options: state.options, ClientSideRefresh: state.clientSideRefresh}
 		if handleErr := c.handleMapSubscribe(req, reply, cmd, started, rw); handleErr != nil {
 			c.writeDisconnectOrErrorFlush(req.Channel, protocol.FrameTypeSubscribe, cmd, handleErr, started, rw)
 		}
@@ -223,7 +224,7 @@ func (c *Client) handleMapSubscribeCommand(
 			c.cleanupMapSubscribing(req.Channel)
 			return DisconnectSlow
 		}
-		reply := SubscribeReply{Options: state.options}
+		reply := SubscribeReply{Options: state.options, ClientSideRefresh: state.clientSideRefresh}
 		if handleErr := c.handleMapSubscribe(req, reply, cmd, started, rw); handleErr != nil {
 			c.writeDisconnectOrErrorFlush(req.Channel, protocol.FrameTypeSubscribe, cmd, handleErr, started, rw)
 		}
@@ -253,6 +254,12 @@ func (c *Client) handleMapSubscribeCommand(
 
 		if reply.Options.Type != event.Type {
 			c.writeDisconnectOrErrorFlush(req.Channel, protocol.FrameTypeSubscribe, cmd, ErrorBadRequest, started, rw)
+			return
+		}
+
+		if _, _, expired := subscriptionExpiration(reply.Options.ExpireAt, reply.ClientSideRefresh); expired {
+			c.node.logger.log(newLogEntry(LogLevelInfo, "subscription expiration must be greater than now", map[string]any{"channel": req.Channel, "client": c.uid, "user": c.UserID()}))
+			c.writeDisconnectOrErrorFlush(req.Channel, protocol.FrameTypeSubscribe, cmd, ErrorExpired, started, rw)
 			return
 		}
 
@@ -354,13 +361,14 @@ func (c *Client) handleMapStatePhase(
 			}
 		}
 		c.mapSubscribing[channel] = &mapSubscribeState{
-			options:          reply.Options,
-			startedAt:        time.Now().UnixNano(),
-			isPresence:       reply.Options.Type.IsMapPresence(),
-			subscribingCh:    make(chan struct{}),
-			subGen:           c.subGenCounter.Add(1),
-			tagsFilter:       tf,
-			serverTagsFilter: stf,
+			options:           reply.Options,
+			clientSideRefresh: reply.ClientSideRefresh,
+			startedAt:         time.Now().UnixNano(),
+			isPresence:        reply.Options.Type.IsMapPresence(),
+			subscribingCh:     make(chan struct{}),
+			subGen:            c.subGenCounter.Add(1),
+			tagsFilter:        tf,
+			serverTagsFilter:  stf,
 		}
 		c.mu.Unlock()
 	} else {
@@ -615,14 +623,15 @@ func (c *Client) handleMapTransitionToLive(
 		}
 		subGen = c.subGenCounter.Add(1)
 		ourState = &mapSubscribeState{
-			options:          opts,
-			startedAt:        time.Now().UnixNano(),
-			isPresence:       isPresence,
-			subscribingCh:    make(chan struct{}),
-			subGen:           subGen,
-			epoch:            req.Epoch,
-			tagsFilter:       params.tagsFilterFromState,
-			serverTagsFilter: params.serverTagsFilterFromState,
+			options:           opts,
+			clientSideRefresh: reply.ClientSideRefresh,
+			startedAt:         time.Now().UnixNano(),
+			isPresence:        isPresence,
+			subscribingCh:     make(chan struct{}),
+			subGen:            subGen,
+			epoch:             req.Epoch,
+			tagsFilter:        params.tagsFilterFromState,
+			serverTagsFilter:  params.serverTagsFilterFromState,
 		}
 		c.mapSubscribing[channel] = ourState
 	}
@@ -877,6 +886,9 @@ func (c *Client) handleMapTransitionToLive(
 	if d := opts.ClientPublishDebounceInterval; d > 0 {
 		res.PublishDebounce = uint32(d.Milliseconds())
 	}
+	// Tell the client when the subscription expires, so that it refreshes the
+	// token in time. Already expired subscriptions are rejected on the first request.
+	res.Expires, res.Ttl, _ = subscriptionExpiration(opts.ExpireAt, reply.ClientSideRefresh)
 	if positioning {
 		res.Recoverable = true
 	}
@@ -1018,12 +1030,13 @@ func (c *Client) handleMapStreamPhase(
 		// captured from this state while it was still loading — the unsubscribe
 		// would then fail its identity check and leak the subscription.
 		state = &mapSubscribeState{
-			options:       reply.Options,
-			startedAt:     time.Now().UnixNano(),
-			isPresence:    reply.Options.Type.IsMapPresence(),
-			subscribingCh: make(chan struct{}),
-			subGen:        c.subGenCounter.Add(1),
-			epoch:         req.Epoch,
+			options:           reply.Options,
+			clientSideRefresh: reply.ClientSideRefresh,
+			startedAt:         time.Now().UnixNano(),
+			isPresence:        reply.Options.Type.IsMapPresence(),
+			subscribingCh:     make(chan struct{}),
+			subGen:            c.subGenCounter.Add(1),
+			epoch:             req.Epoch,
 		}
 		tf, err := c.validateAndCreateTagsFilter(req, reply.Options.AllowTagsFilter, channel)
 		if err != nil {

--- a/client_map_test.go
+++ b/client_map_test.go
@@ -5793,3 +5793,150 @@ func TestMapSubscribe_DisconnectRace_NoGhostSubscription(t *testing.T) {
 	}, 15*time.Second, 50*time.Millisecond,
 		"expected zero hub subscribers, got %d", node.hub.NumSubscribers(channel))
 }
+
+// Map subscriptions expire like other subscription types: the client must be told
+// the TTL when it refreshes the subscription itself, the client-side refresh mode
+// must survive a paginated subscribe, and an already expired subscription must be
+// rejected.
+
+func setMapSubscribeExpiration(node *Node, expireAt int64, clientSideRefresh bool) {
+	node.OnConnect(func(client *Client) {
+		client.OnSubscribe(func(e SubscribeEvent, cb SubscribeCallback) {
+			cb(SubscribeReply{
+				Options: SubscribeOptions{
+					Type:     SubscriptionTypeMap,
+					ExpireAt: expireAt,
+				},
+				ClientSideRefresh: clientSideRefresh,
+			}, nil)
+		})
+		client.OnSubRefresh(func(e SubRefreshEvent, cb SubRefreshCallback) {
+			cb(SubRefreshReply{ExpireAt: time.Now().Unix() + 3600}, nil)
+		})
+	})
+}
+
+func TestMapSubscribe_ExpirationClientSideRefresh(t *testing.T) {
+	t.Parallel()
+	node, _ := newTestNodeWithMapBroker(t)
+	setMapSubscribeExpiration(node, time.Now().Unix()+60, true)
+	client := newTestConnectedClientV2(t, node, "user1")
+
+	result := subscribeMapClient(t, client, &protocol.SubscribeRequest{
+		Channel: "test_map_expiration",
+		Type:    int32(SubscriptionTypeMap),
+		Phase:   MapPhaseState,
+		Limit:   100,
+	})
+	require.Equal(t, MapPhaseLive, result.Phase)
+	require.True(t, result.Expires)
+	require.Greater(t, result.Ttl, uint32(0))
+	require.LessOrEqual(t, result.Ttl, uint32(60))
+}
+
+func TestMapSubscribe_ExpirationServerSideRefresh(t *testing.T) {
+	t.Parallel()
+	node, _ := newTestNodeWithMapBroker(t)
+	setMapSubscribeExpiration(node, time.Now().Unix()+60, false)
+	client := newTestConnectedClientV2(t, node, "user1")
+
+	result := subscribeMapClient(t, client, &protocol.SubscribeRequest{
+		Channel: "test_map_expiration_server_side",
+		Type:    int32(SubscriptionTypeMap),
+		Phase:   MapPhaseState,
+		Limit:   100,
+	})
+	require.Equal(t, MapPhaseLive, result.Phase)
+	require.False(t, result.Expires)
+	require.Zero(t, result.Ttl)
+}
+
+func TestMapSubscribe_ExpirationAlreadyExpired(t *testing.T) {
+	t.Parallel()
+	node, _ := newTestNodeWithMapBroker(t)
+	setMapSubscribeExpiration(node, time.Now().Unix()-10, true)
+	client := newTestConnectedClientV2(t, node, "user1")
+
+	protoErr := subscribeMapClientExpectError(t, client, &protocol.SubscribeRequest{
+		Channel: "test_map_expired",
+		Type:    int32(SubscriptionTypeMap),
+		Phase:   MapPhaseState,
+		Limit:   100,
+	})
+	require.Equal(t, ErrorExpired.Code, protoErr.Code)
+}
+
+// A paginated subscribe authorizes on the first page only: the later pages must
+// keep the client-side refresh mode, or the client's refresh command is rejected.
+func TestMapSubscribe_ExpirationPaginatedClientSideRefresh(t *testing.T) {
+	t.Parallel()
+	node, broker := newTestNodeWithMapBroker(t)
+	setMapSubscribeExpiration(node, time.Now().Unix()+60, true)
+	client := newTestConnectedClientV2(t, node, "user1")
+
+	channel := "test_map_expiration_paginated"
+	for i := 0; i < 10; i++ {
+		_, err := broker.Publish(context.Background(), channel, string(rune('a'+i)), MapPublishOptions{
+			Data: []byte(`{"v":"data"}`),
+		})
+		require.NoError(t, err)
+	}
+
+	first := subscribeMapClient(t, client, &protocol.SubscribeRequest{
+		Channel: channel,
+		Type:    int32(SubscriptionTypeMap),
+		Phase:   MapPhaseState,
+		Limit:   5,
+	})
+	require.NotEmpty(t, first.Cursor)
+
+	last := subscribeMapClient(t, client, &protocol.SubscribeRequest{
+		Channel: channel,
+		Type:    int32(SubscriptionTypeMap),
+		Phase:   MapPhaseState,
+		Limit:   5,
+		Cursor:  first.Cursor,
+	})
+	require.Equal(t, MapPhaseLive, last.Phase)
+	require.True(t, last.Expires)
+	require.Greater(t, last.Ttl, uint32(0))
+
+	rwWrapper := testReplyWriterWrapper()
+	err := client.handleSubRefresh(&protocol.SubRefreshRequest{
+		Channel: channel,
+		Token:   "token",
+	}, &protocol.Command{Id: 2}, time.Now(), rwWrapper.rw)
+	require.NoError(t, err)
+	require.Len(t, rwWrapper.replies, 1)
+	require.Nil(t, rwWrapper.replies[0].Error)
+	require.True(t, rwWrapper.replies[0].SubRefresh.Expires)
+}
+
+// Recovering a map subscription from a stream position goes live without the
+// state phase: it must also carry the expiration.
+func TestMapSubscribe_ExpirationStreamRecovery(t *testing.T) {
+	t.Parallel()
+	node, broker := newTestNodeWithMapBroker(t)
+	setTestMapChannelOptionsConverging(node)
+	setMapSubscribeExpiration(node, time.Now().Unix()+60, true)
+	client := newTestConnectedClientV2(t, node, "user1")
+
+	channel := "test_map_expiration_recovery"
+	res, err := broker.Publish(context.Background(), channel, "key1", MapPublishOptions{
+		Data: []byte(`{"v":"data"}`),
+	})
+	require.NoError(t, err)
+
+	result := subscribeMapClient(t, client, &protocol.SubscribeRequest{
+		Channel: channel,
+		Type:    int32(SubscriptionTypeMap),
+		Phase:   MapPhaseStream,
+		Recover: true,
+		Offset:  res.Position.Offset,
+		Epoch:   res.Position.Epoch,
+		Limit:   100,
+	})
+	require.Equal(t, MapPhaseLive, result.Phase)
+	require.True(t, result.Expires)
+	require.Greater(t, result.Ttl, uint32(0))
+}

--- a/client_shared_poll.go
+++ b/client_shared_poll.go
@@ -60,16 +60,15 @@ func (c *Client) handleSharedPollSubscribe(req *protocol.SubscribeRequest, cmd *
 		res := &protocol.SubscribeResult{}
 		res.Type = int32(SubscriptionTypeSharedPoll)
 
-		if reply.Options.ExpireAt > 0 {
-			ttl := reply.Options.ExpireAt - time.Now().Unix()
-			if ttl <= 0 {
-				c.onSubscribeErrorGen(channel, subGen)
-				c.writeDisconnectOrErrorFlush(channel, protocol.FrameTypeSubscribe, cmd, ErrorExpired, started, rw)
-				return
-			}
-			res.Expires = true
-			res.Ttl = uint32(ttl)
+		// Shared poll subscriptions are always refreshed client-side.
+		expires, ttl, expired := subscriptionExpiration(reply.Options.ExpireAt, true)
+		if expired {
+			c.onSubscribeErrorGen(channel, subGen)
+			c.writeDisconnectOrErrorFlush(channel, protocol.FrameTypeSubscribe, cmd, ErrorExpired, started, rw)
+			return
 		}
+		res.Expires = expires
+		res.Ttl = ttl
 
 		// Delta negotiation.
 		var deltaType DeltaType


### PR DESCRIPTION
## What
Map subscriptions didn't handle expiration the way stream and shared poll subscriptions do, which broke token refresh for map subscriptions:

- **No TTL in the subscribe reply.** The map live reply never set `expires`/`ttl`, although the channel context stored `expireAt` and the server enforced it. A client couldn't schedule a subscription token refresh, so the subscription was unsubscribed with `2501` at expiry. centrifuge-js then lost it completely when resubscribing with the expired token (fixed on the SDK side in centrifugal/centrifuge-js#399).
- **Client-side refresh lost on paginated subscribes.** Only the first page of a map subscribe goes through `OnSubscribe`. Continuation pages rebuilt the reply from the stored options and dropped `ClientSideRefresh`. A map subscription that needed more than one page went live without `flagClientSideRefresh`, so the client's `sub_refresh` was rejected with `DisconnectBadRequest` ("server-side sub refresh expected").
- **No check for an already expired subscription.** A map subscribe with `ExpireAt` in the past was accepted. Stream and shared poll subscribes reject it with `ErrorExpired`.

## Change
- **`subscriptionExpiration(expireAt, clientSideRefresh)`:** one helper returning the `expires`/`ttl` result fields and whether the subscription has already expired. Stream subscribe (`subscribeCmd`), shared poll subscribe and map subscribe now all use it, replacing two duplicated blocks.
- **Map live reply:** sets `expires`/`ttl` from it, on every path to live: state page, stream page and stream recovery.
- **`mapSubscribeState`:** keeps `clientSideRefresh` from the `OnSubscribe` reply. Continuation pages pass it on, so the committed channel gets `flagClientSideRefresh` however many pages the subscribe took.
- **First map subscribe request:** rejects an already expired subscription with `ErrorExpired`.

Stream and shared poll behaviour is unchanged.

## Tests
New tests in `client_map_test.go`:
- **client-side refresh:** the live reply carries `expires` and a TTL
- **server-side refresh:** no `expires`/`ttl`
- **already expired:** `ErrorExpired`
- **paginated subscribe (two state pages):** the live reply carries the TTL, and the client's `sub_refresh` succeeds
- **stream recovery straight to live:** the reply carries the TTL

Without the fix, the client-side refresh, already expired, paginated and stream recovery tests fail. The server-side refresh test pins behaviour that was already correct.

## Verification
- **Tests:** `go test -count=1 ./...` passes (root package and all internal packages).
- **Static checks:** `go vet .` is clean, `golangci-lint run ./...` reports 0 issues, and `gofmt` is clean.
